### PR TITLE
GBSA refactoring and API fixes

### DIFF
--- a/TESTSUITE/cpp_api_example.cpp
+++ b/TESTSUITE/cpp_api_example.cpp
@@ -1,0 +1,45 @@
+#include <cmath>
+#include <cassert>
+#include <cstdio>
+
+#include "xtb.h"
+
+using namespace std;
+
+int
+main (int argc, char **argv)
+{
+   const double thr = 1.0e-10;
+   const int    natoms = 7;
+   const int    attyp[natoms] = {6,6,6,1,1,1,1};
+   const double charge = 0.0;
+   const double coord[3*natoms] =
+      {0.00000000000000, 0.00000000000000,-1.79755622305860,
+       0.00000000000000, 0.00000000000000, 0.95338756106749,
+       0.00000000000000, 0.00000000000000, 3.22281255790261,
+      -0.96412815539807,-1.66991895015711,-2.53624948351102,
+      -0.96412815539807, 1.66991895015711,-2.53624948351102,
+       1.92825631079613, 0.00000000000000,-2.53624948351102,
+       0.00000000000000, 0.00000000000000, 5.23010455462158};
+
+   const xtb::SCC_options opt {2, 0, 1.0, 300.0, true, false, 30, "none"};
+
+   double energy {0.0};
+   double dipole[3] {0.0};
+   double q[natoms] {0.0};
+   double qp[6*natoms] {0.0};
+   double wbo[natoms*natoms] {0.0};
+
+   int stat = xtb::GFN2_calculation(&natoms, attyp, &charge, coord, &opt, "-",
+                                    &energy, nullptr, dipole, q, nullptr, qp, wbo);
+
+   assert(stat == 0);
+   assert(fabs(energy + 8.3824793818504) < thr);
+   assert(fabs(q[5] - 0.05184019996829) < thr);
+   assert(fabs(dipole[2] + 0.29832384492435) < thr);
+   assert(fabs(qp[14] - 0.56386138525354) < thr);
+   assert(fabs(wbo[9] - 2.89823984265213) < thr);
+
+   return 0;
+}
+

--- a/TESTSUITE/dftd4.f90
+++ b/TESTSUITE/dftd4.f90
@@ -423,6 +423,7 @@ subroutine test_dftd4_api
    use tbdef_options
    use tbdef_param
    use dftd4
+   use tb_calculators
    implicit none
    type(tb_molecule)  :: mol
 
@@ -487,6 +488,7 @@ subroutine test_dftd4_pbc_api
    use tbdef_param
    use dftd4
    use pbc_tools
+   use tb_calculators
    implicit none
 
    real(wp),parameter :: thr = 1.0e-10_wp

--- a/TESTSUITE/eeq_model.f90
+++ b/TESTSUITE/eeq_model.f90
@@ -322,7 +322,7 @@ subroutine test_eeq_model_gbsa
    dqdr = 0.0_wp
 
    lgbsa = .true.
-   call init_gbsa(iunit,mol%n,mol%at,'ch2cl2',0,temp,2,230)
+   call init_gbsa(iunit,'ch2cl2',0,temp,2,230)
    call new_gbsa(gbsa,mol%n,mol%at)
    call update_nnlist_gbsa(gbsa,mol%xyz,.false.)
    call compute_brad_sasa(gbsa,mol%xyz)
@@ -451,7 +451,7 @@ subroutine test_eeq_model_salt
    lsalt = .true.
    ionst = 0.001_wp
    ion_rad = 1.0_wp
-   call init_gbsa(iunit,mol%n,mol%at,'ch2cl2',0,temp,2,230)
+   call init_gbsa(iunit,'ch2cl2',0,temp,2,230)
    call new_gbsa(gbsa,mol%n,mol%at)
    call update_nnlist_gbsa(gbsa,mol%xyz,.false.)
    call compute_brad_sasa(gbsa,mol%xyz)

--- a/TESTSUITE/gfn0.f90
+++ b/TESTSUITE/gfn0.f90
@@ -136,6 +136,8 @@ subroutine test_gfn0_api
 
    use pbc_tools
 
+   use tb_calculators
+
    implicit none
 
    real(wp),parameter :: thr = 1.0e-7_wp

--- a/TESTSUITE/gfn1.f90
+++ b/TESTSUITE/gfn1.f90
@@ -125,6 +125,8 @@ subroutine test_gfn1_api
    use tbdef_param
    use tbdef_pcem
 
+   use tb_calculators
+
    implicit none
 
    real(wp),parameter :: thr = 1.0e-10_wp
@@ -187,6 +189,8 @@ subroutine test_gfn1gbsa_api
    use tbdef_molecule
    use tbdef_param
    use tbdef_pcem
+
+   use tb_calculators
 
    implicit none
 
@@ -253,6 +257,8 @@ subroutine test_gfn1_pcem_api
    use tbdef_pcem
 
    use aoparam
+
+   use tb_calculators
 
    implicit none
 

--- a/TESTSUITE/gfn2.f90
+++ b/TESTSUITE/gfn2.f90
@@ -132,6 +132,8 @@ subroutine test_gfn2_api
    use tbdef_param
    use tbdef_pcem
 
+   use tb_calculators
+
    implicit none
 
    real(wp),parameter :: thr = 1.0e-10_wp
@@ -197,6 +199,8 @@ subroutine test_gfn2gbsa_api
    use tbdef_wavefunction
    use tbdef_param
    use tbdef_pcem
+
+   use tb_calculators
 
    implicit none
 
@@ -268,6 +272,8 @@ subroutine test_gfn2salt_api
    use tbdef_pcem
 
    use gbobc
+
+   use tb_calculators
 
    implicit none
 
@@ -341,6 +347,8 @@ subroutine test_gfn2_pcem_api
    use tbdef_pcem
 
    use aoparam
+
+   use tb_calculators
 
    implicit none
 

--- a/TESTSUITE/peeq.f90
+++ b/TESTSUITE/peeq.f90
@@ -175,6 +175,8 @@ subroutine test_peeq_api
 
    use pbc_tools
 
+   use tb_calculators
+
    implicit none
 
    real(wp),parameter :: thr = 1.0e-10_wp

--- a/include/xtb.h
+++ b/include/xtb.h
@@ -80,6 +80,18 @@ GFN0_calculation(const int* natoms, const int* attyp, const double* charge,
       const double* coord, const PEEQ_options* opt, const char* output,
       double* energy, double* grad);
 
+extern int
+GBSA_model_preload(const double* epsv, const double* smass, const double* rhos,
+      const double* c1, const double* rprobe, const double* gshift,
+      const double* soset, const double* dum, const double* gamscale,
+      const double* sx, const double tmp);
+
+extern int
+GBSA_calculation(const int* natoms, const int* attyp, const double* coord,
+      const char* solvent, const int* reference, const double* temperature,
+      const int* method, const int* grid_size, const char* file,
+      double* brad, double* sasa);
+
 #ifdef __cplusplus
 }
 }

--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,35 @@
+# This file is part of xtb.
+#
+# Copyright (C) 2019 Sebastian Ehlert
+#
+# xtb is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
 # extended tight binding program package
 project('xtb',
-  'fortran', 'c', 'cpp',
-  version: '6.2',
-  license: 'GPL',
-  meson_version: '>=0.49')
+        'fortran', 'c', 'cpp',
+        version: '6.2.1',
+        license: 'LGPL3',
+        meson_version: '>=0.49')
+
+conf = configuration_data()
+conf.set('version', meson.project_version())
+conf.set('commit', run_command(find_program('git'),'show','-s','--format=%h').stdout().strip())
+conf.set('date', run_command(find_program('date'),'-I').stdout().strip())
+conf.set('author', run_command(find_program('whoami')).stdout().strip())
+conf.set('origin', run_command(find_program('hostname')).stdout().strip())
+configure_file(input : 'xtb/version.f90', output : 'xtb_version.fh',
+  configuration : conf)
 
 fc = meson.get_compiler('fortran')
 cc = meson.get_compiler('c')
@@ -267,7 +293,7 @@ xtb_srcs += 'symmetry/symmetry_i.c'
 
 # API
 xtb_srcs += 'xtb/calculator.f90'
-xtb_srcs += 'xtb/api.f90'
+xtb_srcs += 'xtb/c_api.f90'
 
 xtb_test = ['TESTSUITE/tests_peeq.f90']
 xtb_test += 'TESTSUITE/assertion.f90'
@@ -289,30 +315,62 @@ xtb_srcs += mctc_srcs
 ## TARGETS
 ## ========================================== ##
 # create a static library from all sources
-xtb_lib_static = static_library(meson.project_name(), xtb_srcs,
-                 include_directories: incdir, pic: true)
+xtb_lib_static = static_library(meson.project_name(),
+                                xtb_srcs,
+                                include_directories: incdir,
+                                pic: true)
 
-xtb_exe = executable(meson.project_name(), xtb_main,
-                 dependencies: dependencies_exe,
-                 include_directories: incdir,
-                 link_with: xtb_lib_static,
-                 link_args: '-static' )
+xtb_exe = executable(meson.project_name(),
+                     xtb_main,
+                     dependencies: dependencies_exe,
+                     include_directories: incdir,
+                     link_with: xtb_lib_static,
+                     link_args: '-static',
+                     install: true)
 
 xtb_lib_shared = shared_library(meson.project_name(),
-                 version: meson.project_version(),
-                 dependencies: dependencies_sha,
-                 include_directories: incdir,
-                 link_whole: xtb_lib_static,
-                 link_args: '-fopenmp')
+                                version: meson.project_version(),
+                                dependencies: dependencies_sha,
+                                include_directories: incdir,
+                                link_whole: xtb_lib_static,
+                                link_args: '-fopenmp',
+                                install: true)
+
+## ========================================== ##
+## INSTALL
+## ========================================== ##
+install_headers('include/xtb.h')
+install_man(['man/man1/xtb.1', 'man/man7/xcontrol.7'])
+
+xtb_parameter_files = ['.param_gfn0.xtb',
+                       '.param_gfn2.xtb',
+                       '.param_gfn.xtb',
+                       '.param_ipea.xtb']
+
+gbsa_parameter_files = ['.param_gbsa_acetone',
+                        '.param_gbsa_acetonitrile',
+                        '.param_gbsa_benzene',
+                        '.param_gbsa_ch2cl2',
+                        '.param_gbsa_chcl3',
+                        '.param_gbsa_cs2',
+                        '.param_gbsa_dmso',
+                        '.param_gbsa_ether',
+                        '.param_gbsa_h2o',
+                        '.param_gbsa_methanol',
+                        '.param_gbsa_thf',
+                        '.param_gbsa_toluene']
+
+install_data(xtb_parameter_files, gbsa_parameter_files)
 
 ## ========================================== ##
 ## TESTSUITE
 ## ========================================== ##
-xtb_test = executable('xtb_test', xtb_test,
-                 dependencies: dependencies_exe,
-                 include_directories: incdir,
-                 link_with: xtb_lib_static,
-                 link_args: '-static' )
+xtb_test = executable('xtb_test',
+                      xtb_test,
+                      dependencies: dependencies_exe,
+                      include_directories: incdir,
+                      link_with: xtb_lib_static,
+                      link_args: '-static' )
 
 # some very basic checks to see if the executable reacts at all
 test('Argparser: print version',xtb_exe, args: '--version')

--- a/meson.build
+++ b/meson.build
@@ -336,6 +336,8 @@ xtb_lib_shared = shared_library(meson.project_name(),
                                 link_args: '-fopenmp',
                                 install: true)
 
+xtb_dep = [declare_dependency(link_with: xtb_lib_shared), dependencies_sha]
+
 ## ========================================== ##
 ## INSTALL
 ## ========================================== ##
@@ -424,6 +426,9 @@ test('GFN2-xTB: API',xtb_test,args: ['gfn2','api'])
 test('GFN2-xTB: API (GBSA)',xtb_test,args: ['gfn2','gbsa'])
 test('GFN2-xTB: API (GBSA+salt)',xtb_test,args: ['gfn2','salt'])
 test('GFN2-xTB: API (PCEM)',xtb_test,args: ['gfn2','pcem'])
+test('GFN2-xTB: C++', executable('xtb_cpp_test', 'TESTSUITE/cpp_api_example.cpp',
+                                 include_directories: incdir,
+                                 dependencies: xtb_dep))
 
 test('GFN1-xTB: SCC',xtb_test,args: ['gfn1','scc'])
 test('GFN1-xTB: API',xtb_test,args: ['gfn1','api'])
@@ -432,6 +437,5 @@ test('GFN1-xTB: API (PCEM)',xtb_test,args: ['gfn1','pcem'])
 
 test('GFN0-xTB: SP', xtb_test,args: ['gfn0','sp'])
 test('GFN0-xTB: API',xtb_test,args: ['gfn0','api'])
-
-test('PEEQ: SP', xtb_test,args: ['peeq','sp'])
-test('PEEQ: API',xtb_test,args: ['peeq','api'])
+test('GFN0-xTB: SP  (PBC)', xtb_test,args: ['peeq','sp'])
+test('GFN0-xTB: API (PBC)', xtb_test,args: ['peeq','api'])

--- a/xtb/c_api.f90
+++ b/xtb/c_api.f90
@@ -15,16 +15,42 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
+module c_api
+   use iso_c_binding
+   use iso_fortran_env, only: wp => real64, istdout => output_unit
+
+   implicit none
+
+   !> some overloading for convience
+   interface c_return
+      module procedure :: c_return_double_0d
+      module procedure :: c_return_double_1d
+      module procedure :: c_return_double_2d
+   end interface c_return
+
+   interface c_return_alloc
+      module procedure :: c_return_double_0d_alloc
+      module procedure :: c_return_double_1d_alloc
+      module procedure :: c_return_double_2d_alloc
+   end interface c_return_alloc
+
+   interface c_get
+      module procedure :: c_get_double_0d
+      module procedure :: c_get_double_1d
+      module procedure :: c_get_double_2d
+   end interface c_get
+
+contains
+
 function peeq_api &
       &   (natoms,attyp,charge,coord,lattice,pbc,opt_in,file_in,etot,grad,glat) &
       &    result(status) bind(C,name="GFN0_PBC_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_param
    use tbdef_options
+
+   use tb_calculators
 
    implicit none
 
@@ -63,16 +89,15 @@ function peeq_api &
    ! ====================================================================
    call mctc_init('peeq',10,.true.)
    call env%setup
-   
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
 
-   if (outfile.ne.'-') then
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
+
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -80,11 +105,6 @@ function peeq_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -132,9 +152,7 @@ function peeq_api &
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
-      if (iunit.ne.istdout) call close_file(iunit)
+      call finalize
 
       status = 1
       return
@@ -143,16 +161,20 @@ function peeq_api &
    ! ====================================================================
    !  STEP 6: finally return values to C
    ! ====================================================================
-   etot = energy
-   grad = gradient
-   glat = lattice_gradient
+   call c_return(etot, energy)
+   call c_return(grad, gradient)
+   call c_return(glat, lattice_gradient)
 
-   call mol%deallocate
-   deallocate(gradient)
-   if (iunit.ne.istdout) call close_file(iunit)
+   call finalize
 
    status = 0
 
+contains
+   subroutine finalize
+      call mol%deallocate
+      deallocate(gradient)
+      if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
 end function peeq_api
 
 function gfn2_api &
@@ -160,14 +182,13 @@ function gfn2_api &
       &    etot,grad,dipole,q,dipm,qp,wbo) &
       &    result(status) bind(C,name="GFN2_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_wavefunction
    use tbdef_param
    use tbdef_options
    use tbdef_pcem
+
+   use tb_calculators
 
    implicit none
 
@@ -210,15 +231,14 @@ function gfn2_api &
    call mctc_init('peeq',10,.true.)
    call env%setup
 
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
 
-   if (outfile.ne.'-') then
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -226,11 +246,6 @@ function gfn2_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -272,8 +287,7 @@ function gfn2_api &
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
+      call finalize
 
       status = 1
       return
@@ -282,32 +296,37 @@ function gfn2_api &
    ! ====================================================================
    !  STEP 6: finally return values to C
    ! ====================================================================
-   etot = energy
-   grad = gradient
-   q = wfn%q
-   dipm = wfn%dipm
-   qp = wfn%qp
-   wbo = wfn%wbo
-   dipole = sum(wfn%dipm,dim=2) + matmul(mol%xyz,wfn%q)
+   call c_return(etot, energy)
+   call c_return(grad, gradient)
+   call c_return(q, wfn%q)
+   call c_return(dipm, wfn%dipm)
+   call c_return(qp, wfn%qp)
+   call c_return(wbo, wfn%wbo)
+   call c_return(dipole, sum(wfn%dipm,dim=2) + matmul(mol%xyz,wfn%q))
 
-   call mol%deallocate
-   deallocate(gradient)
+   call finalize
 
    status = 0
 
+contains
+   subroutine finalize
+      call mol%deallocate
+      call wfn%deallocate
+      deallocate(gradient)
+      if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
 end function gfn2_api
 
 function gfn1_api &
       &   (natoms,attyp,charge,coord,opt_in,file_in,etot,grad) &
       &    result(status) bind(C,name="GFN1_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_param
    use tbdef_options
    use tbdef_pcem
+
+   use tb_calculators
 
    implicit none
 
@@ -344,15 +363,14 @@ function gfn1_api &
    call mctc_init('peeq',10,.true.)
    call env%setup
 
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
 
-   if (outfile.ne.'-') then
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -360,11 +378,6 @@ function gfn1_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -406,8 +419,7 @@ function gfn1_api &
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
+      call finalize
 
       status = 1
       return
@@ -416,26 +428,30 @@ function gfn1_api &
    ! ====================================================================
    !  STEP 6: finally return values to C
    ! ====================================================================
-   etot = energy
-   grad = gradient
+   call c_return(etot, energy)
+   call c_return(grad, gradient)
 
-   call mol%deallocate
-   deallocate(gradient)
+   call finalize
 
    status = 0
 
+contains
+   subroutine finalize
+      call mol%deallocate
+      deallocate(gradient)
+      if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
 end function gfn1_api
 
 function gfn0_api &
       &   (natoms,attyp,charge,coord,opt_in,file_in,etot,grad) &
       &    result(status) bind(C,name="GFN0_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_param
    use tbdef_options
+
+   use tb_calculators
 
    implicit none
 
@@ -471,15 +487,14 @@ function gfn0_api &
    call mctc_init('peeq',10,.true.)
    call env%setup
 
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
 
-   if (outfile.ne.'-') then
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -487,11 +502,6 @@ function gfn0_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -533,8 +543,7 @@ function gfn0_api &
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
+      call finalize
 
       status = 1
       return
@@ -543,14 +552,19 @@ function gfn0_api &
    ! ====================================================================
    !  STEP 6: finally return values to C
    ! ====================================================================
-   etot = energy
-   grad = gradient
+   call c_return(etot, energy)
+   call c_return(grad, gradient)
 
-   call mol%deallocate
-   deallocate(gradient)
+   call finalize
 
    status = 0
 
+contains
+   subroutine finalize
+      call mol%deallocate
+      deallocate(gradient)
+      if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
 end function gfn0_api
 
 function gfn2_pcem_api &
@@ -558,15 +572,15 @@ function gfn2_pcem_api &
       &    npc,pc_q,pc_at,pc_gam,pc_coord,etot,grad,pc_grad) &
       &    result(status) bind(C,name="GFN2_QMMM_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_param
    use tbdef_options
    use tbdef_pcem
+   use tbdef_wavefunction
 
    use aoparam
+
+   use tb_calculators
 
    implicit none
 
@@ -592,6 +606,7 @@ function gfn2_pcem_api &
    type(tb_molecule)    :: mol
    type(gfn_parameter)  :: gfn
    type(scc_options)    :: opt
+   type(tb_wavefunction):: wfn
    type(tb_environment) :: env
    type(tb_pcem)        :: pcem
 
@@ -610,15 +625,14 @@ function gfn2_pcem_api &
    call mctc_init('peeq',10,.true.)
    call env%setup
 
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
 
-   if (outfile.ne.'-') then
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -626,11 +640,6 @@ function gfn2_pcem_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -674,15 +683,14 @@ function gfn2_pcem_api &
    call mctc_mute
 
    call gfn2_calculation &
-      (iunit,env,opt,mol,gfn,pcem,hl_gap,energy,gradient)
+      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
+      call finalize
 
       status = 1
       return
@@ -691,15 +699,21 @@ function gfn2_pcem_api &
    ! ====================================================================
    !  STEP 6: finally return values to C
    ! ====================================================================
-   etot = energy
-   grad = gradient
-   pc_grad = pcem%grd
+   call c_return(etot, energy)
+   call c_return(grad, gradient)
+   call c_return(pc_grad, pcem%grd)
 
-   call mol%deallocate
-   deallocate(gradient)
+   call finalize
 
    status = 0
 
+contains
+   subroutine finalize
+      call mol%deallocate
+      call pcem%deallocate
+      deallocate(gradient)
+      if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
 end function gfn2_pcem_api
 
 function gfn1_pcem_api &
@@ -707,15 +721,14 @@ function gfn1_pcem_api &
       &    npc,pc_q,pc_at,pc_gam,pc_coord,etot,grad,pc_grad) &
       &    result(status) bind(C,name="GFN1_QMMM_calculation")
 
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
    use tbdef_molecule
    use tbdef_param
    use tbdef_options
    use tbdef_pcem
 
    use aoparam
+
+   use tb_calculators
 
    implicit none
 
@@ -759,15 +772,14 @@ function gfn1_pcem_api &
    call mctc_init('peeq',10,.true.)
    call env%setup
 
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
+   ! ====================================================================
+   !  STEP 2: convert the options from C struct to actual Fortran type
+   ! ====================================================================
+   opt = opt_in
+   
+   call c_string_convert(outfile, file_in)
 
-   if (outfile.ne.'-') then
+   if (outfile.ne.'-'.and.opt%prlevel > 0) then
       call open_file(iunit,outfile,'w')
       if (iunit.eq.-1) then
          iunit = istdout
@@ -775,11 +787,6 @@ function gfn1_pcem_api &
    else
       iunit = istdout
    endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
 
    if (opt%prlevel > 2) then
       ! print the xtb banner with version number and compilation date
@@ -830,8 +837,7 @@ function gfn1_pcem_api &
    if (.not.sane) then !! it's stark raving mad and on fire !!
 
       ! at least try to destroy the molecule structure data
-      call mol%deallocate
-      deallocate(gradient)
+      call finalize
 
       status = 1
       return
@@ -844,377 +850,115 @@ function gfn1_pcem_api &
    grad = gradient
    pc_grad = pcem%grd
 
-   call mol%deallocate
-   deallocate(gradient)
+   call finalize
 
    status = 0
 
-end function gfn1_pcem_api
-
-function eeq_api &
-      &   (natoms,attyp,charge,coord,lattice,pbc,opt_in,file_in, &
-      &    qout,dipole,etot,grad,glat) &
-      &    result(status) bind(C,name="EEQ_charges")
-
-   use iso_fortran_env, wp => real64, istdout => output_unit
-   use iso_c_binding
-
-   use mctc_econv
-
-   use tbdef_molecule
-   use tbdef_param
-   use tbdef_options
-
-   use ncoord
-   use eeq_model
-   use pbc_tools
-
-   implicit none
-
-   integer(c_int), intent(in) :: natoms
-   integer(c_int), intent(in) :: attyp(natoms)
-   real(c_double), intent(in) :: charge
-   real(c_double), intent(in) :: coord(3,natoms)
-   real(c_double), intent(in) :: lattice(3,3)
-   logical(c_bool),intent(in) :: pbc(3)
-   type(c_eeq_options), intent(in) :: opt_in
-   character(kind=c_char),intent(in) :: file_in(*)
-
-   integer(c_int) :: status
-
-   real(c_double),intent(out) :: etot
-   real(c_double),intent(out) :: grad(3,natoms)
-   real(c_double),intent(out) :: glat(3,3)
-   real(c_double),intent(out) :: qout(natoms)
-   real(c_double),intent(out) :: dipole(3)
-
-   type(tb_molecule)    :: mol
-   type(chrg_parameter) :: chrgeq
-   type(eeq_options)    :: opt
-   type(tb_environment) :: env
-
-   character(len=:),allocatable :: outfile
-
-   integer, parameter :: wsc_rep(3) = [1,1,1] ! FIXME
-
-   integer  :: iunit
-   logical  :: sane
-   integer  :: i
-   real(wp) :: energy
-   real(wp) :: hl_gap
-   real(wp) :: sigma(3,3),inv_lat(3,3)
-   real(wp) :: lattice_gradient(3,3)
-   real(wp),allocatable :: gradient(:,:)
-   real(wp),allocatable :: cn(:)
-   real(wp),allocatable :: dcndr(:,:,:)
-   real(wp),allocatable :: dcndL(:,:,:)
-   real(wp),allocatable :: q(:)
-   real(wp),allocatable :: dqdr(:,:,:)
-   real(wp),allocatable :: dqdL(:,:,:)
-
-   ! ====================================================================
-   !  STEP 1: setup the environment variables
-   ! ====================================================================
-   call mctc_init('peeq',10,.true.)
-   call env%setup
-
-   i = 0
-   outfile = ''
-   do
-      i = i+1
-      if (file_in(i).eq.c_null_char) exit
-      outfile = outfile//file_in(i)
-   enddo
-
-   if (outfile.ne.'-') then
-      call open_file(iunit,outfile,'w')
-      if (iunit.eq.-1) then
-         iunit = istdout
-      endif
-   else
-      iunit = istdout
-   endif
-
-   ! ====================================================================
-   !  STEP 2: convert the options from C struct to actual Fortran type
-   ! ====================================================================
-   opt = opt_in
-
-   ! ====================================================================
-   !  STEP 3: aquire the molecular structure and fill with data from C
-   ! ====================================================================
-   call mol%allocate(natoms)
-   ! set periodicity of system
-   mol%lattice = lattice
-   mol%pbc = pbc
-   mol%npbc = 0
-   do i = 1,3
-      if (mol%pbc(i)) mol%npbc = mol%npbc + 1
-   enddo
-   ! get atomtypes, coordinates and total charge
-   mol%at = attyp
-   mol%xyz = coord
-   mol%chrg = charge
-   if (mol%npbc > 0) then
-      call generate_wsc(mol,mol%wsc,wsc_rep)
-   endif
-
-   ! update everything from xyz and lattice
-   call mol%update
-
-   ! ====================================================================
-   !  STEP 4: reserve some memory
-   ! ====================================================================
-   allocate(gradient(3,mol%n),q(mol%n),dqdr(3,mol%n,mol%n+1),dqdL(3,3,mol%n+1), &
-      &     cn(mol%n),dcndr(3,mol%n,mol%n),dcndL(3,3,mol%n))
-   energy = 0.0_wp
-   gradient = 0.0_wp
-   sigma = 0.0_wp
-
-   ! ====================================================================
-   !  STEP 5: call the actual Fortran API to perform the calculation
-   ! ====================================================================
-   ! shut down fatal errors from the MCTC library, so it will not kill the caller
-   call mctc_mute
-
-   if (mol%npbc > 0) then
-      call get_erf_cn(mol,cn,dcndr,dcndL,thr=900.0_wp)
-      call dncoord_logcn(mol%n,cn,dcndr,dcndL,cn_max=8.0_wp)
-   else
-      call get_erf_cn(mol,cn,dcndr,thr=900.0_wp)
-      call dncoord_logcn(mol%n,cn,dcndr,cn_max=8.0_wp)
-   endif
-
-   call new_charge_model_2019(chrgeq,mol%n,mol%at)
-
-   call eeq_chrgeq(mol,chrgeq,cn,dcndr,dcndL,q,dqdr,dqdL,energy,gradient,sigma, &
-      &            .false.,.true.,.true.)
-
-   if (mol%npbc > 0) then
-      inv_lat = mat_inv_3x3(mol%lattice)
-      call sigma_to_latgrad(sigma,inv_lat,lattice_gradient)
-   endif
-
-   ! check if the MCTC environment is still sane, if not tell the caller
-   call mctc_sanity(sane)
-   if (.not.sane) then !! it's stark raving mad and on fire !!
-
-      ! at least try to destroy the molecule structure data
+contains
+   subroutine finalize
       call mol%deallocate
+      call pcem%deallocate
       deallocate(gradient)
       if (iunit.ne.istdout) call close_file(iunit)
+   end subroutine finalize
+end function gfn1_pcem_api
 
-      status = 1
-      return
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran value has been calculated
+subroutine c_return_double_0d(c_array, f_array)
+   real(c_double), intent(out), target :: c_array
+   real(wp), intent(in) :: f_array
+   if (c_associated(c_loc(c_array))) then
+      c_array = f_array
    endif
+end subroutine c_return_double_0d
 
-   ! ====================================================================
-   !  STEP 6: finally return values to C
-   ! ====================================================================
-   etot = energy
-   grad = gradient
-   glat = lattice_gradient
-   qout = q
-   dipole = matmul(mol%xyz,q)
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran value has been calculated
+subroutine c_return_double_0d_alloc(c_array, f_array)
+   real(c_double), intent(out), target :: c_array
+   real(wp), allocatable, intent(in) :: f_array
+   if (c_associated(c_loc(c_array)) .and. allocated(f_array)) then
+      c_array = f_array
+   endif
+end subroutine c_return_double_0d_alloc
 
-   call mol%deallocate
-   deallocate(gradient)
-   if (iunit.ne.istdout) call close_file(iunit)
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran array has been populated
+subroutine c_return_double_1d(c_array, f_array)
+   real(c_double), intent(out), target :: c_array(:)
+   real(wp), intent(in) :: f_array(:)
+   if (c_associated(c_loc(c_array))) then
+      c_array = f_array
+   endif
+end subroutine c_return_double_1d
 
-   status = 0
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran array has been populated
+subroutine c_return_double_1d_alloc(c_array, f_array)
+   real(c_double), intent(out), target :: c_array(:)
+   real(wp), allocatable, intent(in) :: f_array(:)
+   if (c_associated(c_loc(c_array)) .and. allocated(f_array)) then
+      c_array = f_array
+   endif
+end subroutine c_return_double_1d_alloc
 
-end function eeq_api
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran array has been populated (2D version)
+subroutine c_return_double_2d(c_array, f_array)
+   real(c_double), intent(out), target :: c_array(:,:)
+   real(wp), intent(in) :: f_array(:,:)
+   if (c_associated(c_loc(c_array))) then
+      c_array = f_array
+   endif
+end subroutine c_return_double_2d
 
-!function eeeq_api &
-!      &   (natoms,attyp,charge,coord,lattice,pbc,opt_in,file_in, &
-!      &    chi,gam,kappa,alpha,beta,dpol, &
-!      &    qout,dout,dipole,etot,grad,glat) &
-!      &    result(status) bind(C,name="EEQ_multipoles")
-!
-!   use iso_fortran_env, wp => real64, istdout => output_unit
-!   use iso_c_binding
-!
-!   use mctc_econv
-!
-!   use tbdef_molecule
-!   use tbdef_param
-!   use tbdef_options
-!
-!   use ncoord
-!   use eeq_model
-!   use pbc_tools
-!
-!   implicit none
-!
-!   integer(c_int), intent(in) :: natoms
-!   integer(c_int), intent(in) :: attyp(natoms)
-!   real(c_double), intent(in) :: charge
-!   real(c_double), intent(in) :: coord(3,natoms)
-!   real(c_double), intent(in) :: lattice(3,3)
-!   logical(c_bool),intent(in) :: pbc(3)
-!   type(c_eeq_options), intent(in) :: opt_in
-!   character(kind=c_char),intent(in) :: file_in(*)
-!
-!   real(c_double), intent(in) :: chi(*)
-!   real(c_double), intent(in) :: gam(*)
-!   real(c_double), intent(in) :: kappa(*)
-!   real(c_double), intent(in) :: alpha(*)
-!   real(c_double), intent(in) :: beta(*)
-!   real(c_double), intent(in) :: dpol(*)
-!
-!   integer(c_int) :: status
-!
-!   real(c_double),intent(out) :: etot
-!   real(c_double),intent(out) :: grad(3,natoms)
-!   real(c_double),intent(out) :: glat(3,3)
-!   real(c_double),intent(out) :: qout(natoms)
-!   real(c_double),intent(out) :: dout(3,natoms)
-!   real(c_double),intent(out) :: dipole(3)
-!
-!   type(tb_molecule)    :: mol
-!   type(chrg_parameter) :: chrgeq
-!   type(eeq_options)    :: opt
-!   type(tb_environment) :: env
-!
-!   character(len=:),allocatable :: outfile
-!
-!   integer, parameter :: wsc_rep(3) = [1,1,1] ! FIXME
-!
-!   integer  :: iunit
-!   logical  :: sane
-!   integer  :: i
-!   real(wp) :: energy
-!   real(wp) :: hl_gap
-!   real(wp) :: sigma(3,3),inv_lat(3,3)
-!   real(wp) :: lattice_gradient(3,3)
-!   real(wp),allocatable :: gradient(:,:)
-!   real(wp),allocatable :: cn(:)
-!   real(wp),allocatable :: dcndr(:,:,:)
-!   real(wp),allocatable :: dcndL(:,:,:)
-!   real(wp),allocatable :: dipm(:,:)
-!   real(wp),allocatable :: q(:)
-!   real(wp),allocatable :: dqdr(:,:,:)
-!   real(wp),allocatable :: dqdL(:,:,:)
-!
-!   ! ====================================================================
-!   !  STEP 1: setup the environment variables
-!   ! ====================================================================
-!   call mctc_init('peeq',10,.true.)
-!   call env%setup
-!
-!   i = 0
-!   outfile = ''
-!   do
-!      i = i+1
-!      if (file_in(i).eq.c_null_char) exit
-!      outfile = outfile//file_in(i)
-!   enddo
-!
-!   if (outfile.ne.'-') then
-!      call open_file(iunit,outfile,'w')
-!      if (iunit.eq.-1) then
-!         iunit = istdout
-!      endif
-!   else
-!      iunit = istdout
-!   endif
-!
-!   ! ====================================================================
-!   !  STEP 2: convert the options from C struct to actual Fortran type
-!   ! ====================================================================
-!   opt = opt_in
-!
-!   ! ====================================================================
-!   !  STEP 3: aquire the molecular structure and fill with data from C
-!   ! ====================================================================
-!   call mol%allocate(natoms)
-!   ! set periodicity of system
-!   mol%lattice = lattice
-!   mol%pbc = pbc
-!   mol%npbc = 0
-!   do i = 1,3
-!      if (mol%pbc(i)) mol%npbc = mol%npbc + 1
-!   enddo
-!   ! get atomtypes, coordinates and total charge
-!   mol%at = attyp
-!   mol%xyz = coord
-!   mol%chrg = charge
-!   if (mol%npbc > 0) then
-!      call generate_wsc(mol,mol%wsc,wsc_rep)
-!   endif
-!
-!   ! update everything from xyz and lattice
-!   call mol%update
-!
-!   ! ====================================================================
-!   !  STEP 4: reserve some memory
-!   ! ====================================================================
-!   allocate(gradient(3,mol%n),q(mol%n),dqdr(3,mol%n,mol%n+1),dqdL(3,3,mol%n+1), &
-!      &     dipm(3,mol%n),cn(mol%n),dcndr(3,mol%n,mol%n),dcndL(3,3,mol%n))
-!   energy = 0.0_wp
-!   gradient = 0.0_wp
-!   sigma = 0.0_wp
-!
-!   ! ====================================================================
-!   !  STEP 5: call the actual Fortran API to perform the calculation
-!   ! ====================================================================
-!   ! shut down fatal errors from the MCTC library, so it will not kill the caller
-!   call mctc_mute
-!
-!   if (mol%npbc > 0) then
-!      call get_erf_cn(mol,cn,dcndr,dcndL,thr=900.0_wp)
-!      call dncoord_logcn(mol%n,cn,dcndr,dcndL,cn_max=8.0_wp)
-!   else
-!      call get_erf_cn(mol,cn,dcndr,thr=900.0_wp)
-!      call dncoord_logcn(mol%n,cn,dcndr,cn_max=8.0_wp)
-!   endif
-!
-!   call chrgeq%allocate(mol%n,extended=.true.)
-!   do i = 1, mol%n
-!      chrgeq%en   (i) = chi  (mol%at(i))
-!      chrgeq%gam  (i) = gam  (mol%at(i))
-!      chrgeq%kappa(i) = kappa(mol%at(i))
-!      chrgeq%alpha(i) = alpha(mol%at(i))
-!      chrgeq%beta (i) = beta (mol%at(i))
-!      chrgeq%dpol (i) = dpol (mol%at(i))
-!   enddo
-!
-!   call eeq_multieq(mol,chrgeq,cn,q,dipm,energy)
-!   !call eeq_chrgeq(mol,chrgeq,cn,dcndr,dcndL,q,dqdr,dqdL,energy,gradient,sigma, &
-!   !   &            .false.,.true.,.true.)
-!
-!   if (mol%npbc > 0) then
-!      inv_lat = mat_inv_3x3(mol%lattice)
-!      call sigma_to_latgrad(sigma,inv_lat,lattice_gradient)
-!   endif
-!
-!   ! check if the MCTC environment is still sane, if not tell the caller
-!   call mctc_sanity(sane)
-!   if (.not.sane) then !! it's stark raving mad and on fire !!
-!
-!      ! at least try to destroy the molecule structure data
-!      call mol%deallocate
-!      deallocate(gradient)
-!      if (iunit.ne.istdout) call close_file(iunit)
-!
-!      status = 1
-!      return
-!   endif
-!
-!   ! ====================================================================
-!   !  STEP 6: finally return values to C
-!   ! ====================================================================
-!   etot = energy
-!   grad = gradient
-!   glat = lattice_gradient
-!   qout = q
-!   dout = dipm
-!   dipole = matmul(mol%xyz,q) + sum(dipm,dim=2)
-!
-!   call mol%deallocate
-!   deallocate(gradient,q,dqdr,dqdL,dipm,cn,dcndr,dcndL)
-!   if (iunit.ne.istdout) call close_file(iunit)
-!
-!   status = 0
-!
-!end function eeeq_api
+!> optional return to a c_ptr in case it is not a null pointer and the
+!  Fortran array has been populated (2D version)
+subroutine c_return_double_2d_alloc(c_array, f_array)
+   real(c_double), intent(out), target :: c_array(:,:)
+   real(wp), allocatable, intent(in) :: f_array(:,:)
+   if (c_associated(c_loc(c_array)) .and. allocated(f_array)) then
+      c_array = f_array
+   endif
+end subroutine c_return_double_2d_alloc
+
+!> convert vector of chars to deferred size character
+subroutine c_string_convert(f_string, c_string)
+   character(c_char), dimension(*), intent(in) :: c_string
+   character(len=:), allocatable, intent(out) :: f_string
+   integer :: i
+   i = 0
+   f_string = ''
+   do
+      i = i+1
+      if (c_string(i).eq.c_null_char) exit
+      f_string = f_string//c_string(i)
+   enddo
+end subroutine c_string_convert
+
+subroutine c_get_double_0d(f_array, c_array)
+   real(c_double), intent(in), target :: c_array
+   real(wp), allocatable, intent(out) :: f_array
+   if (c_associated(c_loc(c_array))) then
+      f_array = c_array
+   endif
+end subroutine c_get_double_0d
+
+subroutine c_get_double_1d(f_array, c_array)
+   real(c_double), intent(in), target :: c_array(:)
+   real(wp), allocatable, intent(out) :: f_array(:)
+   if (c_associated(c_loc(c_array))) then
+      f_array = c_array
+   endif
+end subroutine c_get_double_1d
+
+subroutine c_get_double_2d(f_array, c_array)
+   real(c_double), intent(in), target :: c_array(:,:)
+   real(wp), allocatable, intent(out) :: f_array(:,:)
+   if (c_associated(c_loc(c_array))) then
+      f_array = c_array
+   endif
+end subroutine c_get_double_2d
+
+end module c_api

--- a/xtb/calculator.f90
+++ b/xtb/calculator.f90
@@ -14,6 +14,9 @@
 !
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+module tb_calculators
+   implicit none
+contains
 
 ! ========================================================================
 !> periodic GFN0-xTB (PEEQ) calculation
@@ -985,3 +988,4 @@ dispersion_gradient: if (opt%lgradient) then
 endif dispersion_gradient
 
 end subroutine d4_pbc_calculation
+end module tb_calculators

--- a/xtb/calculator.f90
+++ b/xtb/calculator.f90
@@ -286,7 +286,7 @@ subroutine gfn2_calculation &
 
    if (len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none") then
       lgbsa = .true.
-      call init_gbsa(iunit,mol%n,mol%at,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
+      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
    endif
 
    ! ====================================================================
@@ -450,7 +450,7 @@ subroutine gfn1_calculation &
 
    if (len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none") then
       lgbsa = .true.
-      call init_gbsa(iunit,mol%n,mol%at,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
+      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
    endif
 
    ! ====================================================================

--- a/xtb/gbobc.f90
+++ b/xtb/gbobc.f90
@@ -254,7 +254,7 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
          select case(lowercase(trim(sname)))
          case default
             call raise('E','solvent : '//trim(sname)//&
-               ' not parametrized for GFN2-xTB Hamiltonian')
+               ' not parametrized for GFN2-xTB Hamiltonian',1)
          case('acetone');      gfn_solvent = gfn2_acetone
          case('acetonitrile'); gfn_solvent = gfn2_acetonitrile
 !        case('benzene');      gfn_solvent = gfn2_benzene
@@ -278,7 +278,7 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
          select case(lowercase(trim(sname)))
          case default
             call raise('E','solvent : '//trim(sname)//&
-               ' not parametrized for GFN-xTB Hamiltonian')
+               ' not parametrized for GFN-xTB Hamiltonian',1)
          case('acetone');      gfn_solvent = gfn1_acetone
          case('acetonitrile'); gfn_solvent = gfn1_acetonitrile
          case('benzene');      gfn_solvent = gfn1_benzene
@@ -489,7 +489,7 @@ subroutine new_gbsa(this,n,at)
    case(4802);   call ld4802(xang,yang,zang,wang,this%nang)
    case(5294);   call ld5294(xang,yang,zang,wang,this%nang)
    case(5810);   call ld5810(xang,yang,zang,wang,this%nang)
-   case default; call raise('E',"(gengrid) unknown grid size!")
+   case default; call raise('E',"(gengrid) unknown grid size!",1)
    end select
    this%grida(1,:) = xang
    this%grida(2,:) = yang

--- a/xtb/gbobc.f90
+++ b/xtb/gbobc.f90
@@ -48,10 +48,6 @@ module gbobc
 !  SASA = 2*(w+maxrasasa) + srcut_add
    real(wp),parameter :: srcut_add=2._wp
 ! ------------------------------------------------------------------------
-!  GBOBC PARAMETER
-!  offset parameter (fitted)
-!  real(wp) :: soset=0.09_wp*aatoau
-   real(wp) :: soset
 !  van der Waals to Lee-Richard's surface correction
    real(wp), parameter :: alp=1._wp
    real(wp), parameter :: bet=0.8_wp
@@ -64,89 +60,106 @@ module gbobc
    real(wp), parameter :: ah1=3._wp/(4._wp*w)
    real(wp), parameter :: ah3=-1._wp/(4._wp*w3)
 ! ------------------------------------------------------------------------
-!  Angular grid. 38 points lead rot.inv.errors for c60 of 2 kcal
-   integer :: nangsa=230
-!  real(wp) :: grida(4,nangsa)
-!  include 'grida230.inc'
-!  integer, parameter :: nangsa=86
-!  include 'grida86.inc'
-!  integer, parameter :: nangsa=110
-!  include 'grida110.inc'
-! ------------------------------------------------------------------------
 !  real space cut-offs
    real(wp), parameter :: tolsesp=1.d-6
 ! ------------------------------------------------------------------------
-!  Dielectric data
-   real(wp) :: epsv
-   real(wp) :: epsu
-   real(wp) :: keps
-! ------------------------------------------------------------------------
 !  Surface tension (mN/m=dyn/cm)
    real(wp), parameter :: mNmkcal=4.0305201015221386d-4
-   real(wp) :: gammas
-   real(wp) :: gamscale(94)
 ! ------------------------------------------------------------------------
 !  Solvent density (g/cm^3) and molar mass (g/mol)
    real(wp), parameter :: molcm3au=8.92388d-2
-   real(wp) :: smass
-   real(wp) :: rhos
-! ------------------------------------------------------------------------
-!  Born radii
-   real(wp) :: c1
 ! ------------------------------------------------------------------------
 !  Salt screening
-   logical :: lsalt=.false.
-   real(wp)  :: ionst=0._wp
-   real(wp)  :: kappa_const=0.7897d-3
-   real(wp)  :: ion_rad=0._wp
-   real(wp)  :: kappa=0._wp
-! ------------------------------------------------------------------------
-!  Atomic surfaces
-   real(wp) :: rprobe
-   real(wp) :: sasamol
+   logical  :: lsalt=.false.
+   real(wp) :: ionst=0._wp
+   real(wp) :: ion_rad=0._wp
+   real(wp), parameter :: kappa_const=0.7897d-3
 ! ------------------------------------------------------------------------
 !  Hydrogen bond contribution
    logical :: lhb=.true.
-
 ! ------------------------------------------------------------------------
-!  Parameters:
-! ------------------------------------------------------------------------
-!  van der Waals radii
-   real(wp) :: rvdw(94)
-!  dielectric descreening parameters
-   real(wp) :: sx(94)
-!  solvent accesible surface radii
-   real(wp) :: rasasa(94)
-!  HB correction present if zero no HB correction
-   integer :: at_hb(94)
-!  solvent HB donor or acceptor strength
-   real(wp) :: hb_mag(94)
 !  Gshift (gsolv=reference vs. gsolv)
    real(wp) :: gshift
 
-   type,private :: gbsa_parameter
+   real(wp), parameter :: d3_cutoff_radii(1:94) = [&
+      & 1.09155_wp, 0.86735_wp, 1.74780_wp, 1.54910_wp, &
+      & 1.60800_wp, 1.45515_wp, 1.31125_wp, 1.24085_wp, &
+      & 1.14980_wp, 1.06870_wp, 1.85410_wp, 1.74195_wp, &
+      & 2.00530_wp, 1.89585_wp, 1.75085_wp, 1.65535_wp, &
+      & 1.55230_wp, 1.45740_wp, 2.12055_wp, 2.05175_wp, &
+      & 1.94515_wp, 1.88210_wp, 1.86055_wp, 1.72070_wp, &
+      & 1.77310_wp, 1.72105_wp, 1.71635_wp, 1.67310_wp, &
+      & 1.65040_wp, 1.61545_wp, 1.97895_wp, 1.93095_wp, &
+      & 1.83125_wp, 1.76340_wp, 1.68310_wp, 1.60480_wp, &
+      & 2.30880_wp, 2.23820_wp, 2.10980_wp, 2.02985_wp, &
+      & 1.92980_wp, 1.87715_wp, 1.78450_wp, 1.73115_wp, &
+      & 1.69875_wp, 1.67625_wp, 1.66540_wp, 1.73100_wp, &
+      & 2.13115_wp, 2.09370_wp, 2.00750_wp, 1.94505_wp, &
+      & 1.86900_wp, 1.79445_wp, 2.52835_wp, 2.59070_wp, &
+      & 2.31305_wp, 2.31005_wp, 2.28510_wp, 2.26355_wp, &
+      & 2.24480_wp, 2.22575_wp, 2.21170_wp, 2.06215_wp, &
+      & 2.12135_wp, 2.07705_wp, 2.13970_wp, 2.12250_wp, &
+      & 2.11040_wp, 2.09930_wp, 2.00650_wp, 2.12250_wp, &
+      & 2.04900_wp, 1.99275_wp, 1.94775_wp, 1.87450_wp, &
+      & 1.72280_wp, 1.67625_wp, 1.62820_wp, 1.67995_wp, &
+      & 2.15635_wp, 2.13820_wp, 2.05875_wp, 2.00270_wp, &
+      & 1.93220_wp, 1.86080_wp, 2.53980_wp, 2.46470_wp, &
+      & 2.35215_wp, 2.21260_wp, 2.22970_wp, 2.19785_wp, &
+      & 2.17695_wp, 2.21705_wp]
+
+   type, private :: gbsa_parameter
 !     Dielectric data
-      real(wp) :: epsv
+      real(wp) :: epsv = 0.0_wp
 !     Solvent density (g/cm^3) and molar mass (g/mol)
-      real(wp) :: smass
-      real(wp) :: rhos
+      real(wp) :: smass = 0.0_wp
+      real(wp) :: rhos = 0.0_wp
 !     Born radii
-      real(wp) :: c1
+      real(wp) :: c1 = 0.0_wp
 !     Atomic surfaces
-      real(wp) :: rprobe
+      real(wp) :: rprobe = 0.0_wp
 !     Gshift (gsolv=reference vs. gsolv)
-      real(wp) :: gshift
+      real(wp) :: gshift = 0.0_wp
 !     offset parameter (fitted)
-!     real(wp) :: soset=0.09_wp*aatoau
-      real(wp) :: soset
-      real(wp) :: dum
+      real(wp) :: soset = 0.0_wp
+      real(wp) :: dum = 0.0_wp
 !     Surface tension (mN/m=dyn/cm)
-      real(wp) :: gamscale(94)
+      real(wp) :: gamscale(94) = 0.0_wp
 !     dielectric descreening parameters
-      real(wp) :: sx(94)
-      real(wp) :: tmp(94)
+      real(wp) :: sx(94) = 0.0_wp
+      real(wp) :: tmp(94) = 0.0_wp
    end type gbsa_parameter
 
+   type, extends(gbsa_parameter) :: gbsa_model
+      integer :: mode = -1
+      real(wp) :: temp = -1.0_wp
+      !> Dielectric data
+      real(wp) :: epsu = 1.0_wp
+      real(wp) :: keps = 0.0_wp
+      !> Surface tension (mN/m=dyn/cm)
+      real(wp) :: gammas = 1.0e-5_wp
+      !> Atomic surfaces
+      real(wp) :: sasamol = 0.0_wp
+      !> Hydrogen bond contribution
+      logical :: lhb = .false.
+      !> van der Waals radii
+      real(wp) :: rvdw(94) = 0.0_wp
+      !> solvent accesible surface radii
+      real(wp) :: rasasa(94) = 0.0_wp
+      !> HB correction present if zero no HB correction
+      integer :: at_hb(94) = 0
+      !> solvent HB donor or acceptor strength
+      real(wp) :: hb_mag(94) = 0.0_wp
+      !> Salt screening
+      logical :: lsalt = .false.
+      real(wp) :: ionst = 0._wp
+      real(wp) :: ion_rad = 0._wp
+      real(wp) :: kappa = 0._wp
+      !> SASA grid size
+      integer :: nangsa = 230
+   end type gbsa_model
+
+   type(gbsa_model), private :: gbm
+   type(gbsa_parameter), private :: custom_solvent
 
    include 'param_gbsa_acetone.inc'
    include 'param_gbsa_acetonitrile.inc'
@@ -165,8 +178,44 @@ module gbobc
 
 contains
 
+subroutine load_custom_parameters(epsv,smass,rhos,c1,rprobe,gshift,soset,dum, &
+      &                           gamscale,sx,tmp)
+   implicit none
+   !> Dielectric data
+   real(wp), intent(in), optional :: epsv
+   !> Solvent density (g/cm^3) and molar mass (g/mol)
+   real(wp), intent(in), optional :: smass
+   real(wp), intent(in), optional :: rhos
+   !> Born radii
+   real(wp), intent(in), optional :: c1
+   !> Atomic surfaces
+   real(wp), intent(in), optional :: rprobe
+   !> Gshift (gsolv=reference vs. gsolv)
+   real(wp), intent(in), optional :: gshift
+   !> offset parameter (fitted)
+   real(wp), intent(in), optional :: soset
+   real(wp), intent(in), optional :: dum
+   !> Surface tension (mN/m=dyn/cm)
+   real(wp), intent(in), optional :: gamscale(94)
+   !> dielectric descreening parameters
+   real(wp), intent(in), optional :: sx(94)
+   real(wp), intent(in), optional :: tmp(94)
+
+   if (present(epsv))    custom_solvent%epsv     = epsv
+   if (present(smass))   custom_solvent%smass    = smass
+   if (present(rhos))    custom_solvent%rhos     = rhos
+   if (present(c1))      custom_solvent%c1       = c1
+   if (present(rprobe))  custom_solvent%rprobe   = rprobe
+   if (present(gshift))  custom_solvent%gshift   = gshift
+   if (present(soset))   custom_solvent%soset    = soset
+   if (present(dum))     custom_solvent%dum      = dum
+   if (present(gamscale))custom_solvent%gamscale = gamscale
+   if (present(sx))      custom_solvent%sx       = sx
+   if (present(tmp))     custom_solvent%tmp      = tmp
+
+end subroutine load_custom_parameters
+
 subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
-!  use setparam
    use mctc_strings
    use readin
    implicit none
@@ -181,44 +230,11 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
 
    integer :: i,fix,inum,ich
    real(wp) :: rad
-   real(wp) :: gamma_in, rvdwscal, tmp(94), gstate, dum
+   real(wp) :: gamma_in, tmp(94), gstate, dum
    character(len=:),allocatable :: fname
    logical ex
    character(len=80) a80
    type(gbsa_parameter) :: gfn_solvent
-
-   !     D3 cut-off radii
-   rvdw(1:94)= (/ &
-   &1.09155,0.86735,1.7478 ,1.5491 ,1.608  ,1.45515,1.31125,1.24085, &
-   &1.1498 ,1.0687 ,1.8541 ,1.74195,2.0053 ,1.89585,1.75085,1.65535, &
-   &1.5523 ,1.4574 ,2.12055,2.05175,1.94515,1.8821 ,1.86055,1.7207, &
-   &1.7731 ,1.72105,1.71635,1.6731 ,1.6504 ,1.61545,1.97895,1.93095, &
-   &1.83125,1.7634 ,1.6831 ,1.6048 ,2.3088 ,2.2382 ,2.1098 ,2.02985, &
-   &1.9298 ,1.87715,1.7845 ,1.73115,1.69875,1.67625,1.6654 ,1.731, &
-   &2.13115,2.0937 ,2.0075 ,1.94505,1.869  ,1.79445,2.52835,2.5907, &
-   &2.31305,2.31005,2.2851 ,2.26355,2.2448 ,2.22575,2.2117 ,2.06215, &
-   &2.12135,2.07705,2.1397 ,2.1225 ,2.1104 ,2.0993 ,2.0065 ,2.1225, &
-   &2.049  ,1.99275,1.94775,1.8745 ,1.7228 ,1.67625,1.6282 ,1.67995, &
-   &2.15635,2.1382 ,2.05875,2.0027 ,1.9322 ,1.8608 ,2.5398 ,2.4647, &
-   &2.35215,2.2126 ,2.2297 ,2.19785,2.17695,2.21705/)
-
-   !     hydrogen bonding parameters
-   lhb=.false.
-
-   at_hb=0
-   at_hb(1)=1
-   at_hb(6)=1
-   at_hb(7)=1
-   at_hb(8)=1
-   at_hb(9)=1
-   at_hb(15)=1
-   at_hb(16)=1
-   at_hb(17)=1
-   at_hb(34)=1
-   at_hb(35)=1
-   at_hb(53)=1
-
-   rvdwscal=1.0_wp
 
    if (gfn_method.gt.1) then
       fname = '.param_gbsa2_'//trim(sname)
@@ -234,18 +250,7 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
    if(ex)then
       write(iunit,*) 'GBSA parameter file : ', trim(fname)
       open(newunit=ich,file=fname)
-      read(ich,*)epsv
-      read(ich,*)smass
-      read(ich,*)rhos
-      read(ich,*)c1
-      read(ich,*)rprobe
-      read(ich,*)gshift
-      read(ich,*)soset
-      read(ich,*)dum
-      do i=1,94
-         read(ich,*)gamscale(i),sx(i),tmp(i)
-         if(abs(tmp(i)).gt.1.d-3) lhb=.true.
-      enddo
+      call read_gbsa_parameters(ich, gfn_solvent)
       close(ich)
    else
       !call raise('W','Could not find GBSA parameters in XTBPATH,'//&
@@ -270,6 +275,7 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
          case('dmf');          gfn_solvent = gfn2_dmf
          case('nhexan','n-hexan','nhexane','n-hexane');
             gfn_solvent = gfn2_nhexan
+         case('custom'); gfn_solvent = custom_solvent
          end select
       !else if (gfn_method.eq.0) then
             !call raise('E','solvent : '//trim(sname)//&
@@ -293,100 +299,167 @@ subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
          case('toluene');      gfn_solvent = gfn1_toluene
 !        case('dmf');          gfn_solvent = gfn1_dmf
 !        case('nhexan');       gfn_solvent = gfn1_nhexan
+         case('custom'); gfn_solvent = custom_solvent
          end select
       endif
       write(iunit,'(1x,"Using internal parameter file:",1x,a)') fname
-      epsv   = gfn_solvent % epsv
-      smass  = gfn_solvent % smass
-      rhos   = gfn_solvent % rhos
-      c1     = gfn_solvent % c1
-      rprobe = gfn_solvent % rprobe
-      gshift = gfn_solvent % gshift
-      soset  = gfn_solvent % soset
-      dum    = gfn_solvent % dum
-      do i = 1, 94
-         gamscale(i) = gfn_solvent % gamscale(i)
-         sx(i)       = gfn_solvent % sx(i)
-         tmp(i)      = gfn_solvent % tmp(i)
-         if(abs(tmp(i)).gt.1.d-3) lhb=.true.
-      enddo
    endif
+
+   call new_gbsa_model(gbm,gfn_solvent,mode,temp,ngrida)
+
+   lhb = gbm%lhb
+   gshift = gbm%gshift
+
+   call gbsa_info(iunit,gbm)
+
+end subroutine init_gbsa
+
+subroutine gbsa_info(iunit,gbm)
+   implicit none
+   integer, intent(in) :: iunit
+   type(gbsa_model), intent(in) :: gbm
+
+   write(iunit,'(1x,a,1x)',advance='no') 'Gsolv ref. state (COSMO-RS):'
+   select case(gbm%mode)
+   case(1)
+      write(iunit,'(a)') 'gsolv=reference [X=1]'
+   case(0)
+      write(iunit,'(a)') 'gsolv [1 M gas/solution]'
+   case(2)
+      write(iunit,'(a)') 'gsolv [1 bar gas/ 1 M solution]'
+   case default
+      write(iunit,'(i0)') gbm%mode
+   end select
+   write(iunit,*) 'temperature (mdtemp)       : ',gbm%temp
+   write(iunit,*) 'dielectric constant        : ',gbm%epsv
+   write(iunit,*) 'rho                        : ',gbm%rhos / (molcm3au/gbm%smass)
+   write(iunit,*) 'mass                       : ',gbm%smass
+   write(iunit,*) 'surface tension            : ',(1.0d-5)*autokcal/mNmkcal
+   write(iunit,*) 'probe radius               : ',gbm%rprobe
+   write(iunit,*) 'Gshift (Eh)                : ',gbm%gshift
+   write(iunit,*) 'c1                         : ',gbm%c1
+   write(iunit,*) 'soset                      : ',gbm%soset / (0.1_wp*aatoau)
+   write(iunit,*) 'HB correction              : ',gbm%lhb
+   if(gbm%lsalt) then
+      write(iunit,*) 'Debye screening length     : ',1.0_wp/gbm%kappa/aatoau
+   endif
+end subroutine gbsa_info
+
+subroutine new_gbsa_model(gbm,solvent,mode,temp,ngrida)
+   use mctc_strings
+   use readin
+   implicit none
+   type(gbsa_model), intent(inout) :: gbm
+   type(gbsa_parameter), intent(inout) :: solvent
+   integer, intent(in) :: mode
+   real(wp),intent(in) :: temp
+   integer, intent(in) :: ngrida
+
+   integer :: i,fix,inum,ich
+   real(wp) :: rad
+   real(wp) :: gamma_in, rvdwscal, tmp(94), gstate, dum
+   character(len=:),allocatable :: fname
+   logical ex
+   character(len=80) a80
+   type(gbsa_parameter) :: gfn_solvent
+
+   gbm%lsalt = lsalt
+
+   gbm%temp = temp
+   gbm%mode = mode
+
+   ! D3 cut-off radii
+   gbm%rvdw(1:94) = d3_cutoff_radii
+
+   ! hydrogen bonding parameters
+   gbm%lhb = .false.
+
+   gbm%at_hb = 0
+   gbm%at_hb([1,6,7,8,9,15,16,17,34,35,53]) = 1
+
+   rvdwscal=1.0_wp
+
+   gbm%epsv   = solvent%epsv
+   gbm%smass  = solvent%smass
+   gbm%rhos   = solvent%rhos*molcm3au/gbm%smass
+   gbm%c1     = solvent%c1
+   gbm%rprobe = solvent%rprobe
+   gbm%gshift = solvent%gshift
+   gbm%soset  = solvent%soset*0.1_wp*aatoau
+   gbm%dum    = solvent%dum
+   do i = 1, 94
+      gbm%gamscale(i) = solvent%gamscale(i)
+      gbm%sx(i)       = solvent%sx(i)
+      tmp(i)      = solvent%tmp(i)
+      if(abs(tmp(i)).gt.1.d-3) gbm%lhb=.true.
+   enddo
 
    if(mode.eq.1) then ! gsolv=reference option in COSMOTHERM
       !               RT*(ln(ideal gas mol volume)+ln(rho/M))
-      gstate=(temp*8.31451/1000./4.184)* &
-      &      (log(24.79_wp*temp/298.15)+ &
-      &       log(1000.0_wp*rhos/smass))
-      gshift=(gshift+gstate)/autokcal
-      write(iunit,*) 'Gsolv state corr. (kcal):',gstate
-      a80='gsolv=reference [X=1]'
+      gstate=(gbm%temp*8.31451/1000./4.184)* &
+      &      (log(24.79_wp*gbm%temp/298.15)+ &
+      &       log(1000.0_wp*gbm%rhos/gbm%smass))
+      gbm%gshift=(gbm%gshift+gstate)*kcaltoau
    elseif(mode.eq.0)then !gsolv option in COSMOTHERM to which it was fitted
-      gshift=gshift/autokcal
-      a80='gsolv [1 M gas/solution]'
+      gbm%gshift=gbm%gshift*kcaltoau
    elseif(mode.eq.2)then ! 1 bar gas/ 1 M solution is not implemented in COSMOTHERM although its the canonical choice
-      gstate=(temp*8.31451/1000./4.184)*log(24.79_wp*temp/298.15)
-      gshift=(gshift+gstate)/autokcal
-      write(iunit,*) 'Gsolv state corr. (kcal):',gstate
-      a80='gsolv [1 bar gas/ 1 M solution]'
+      gstate=(gbm%temp*8.31451/1000./4.184)*log(24.79_wp*gbm%temp/298.15)
+      gbm%gshift=(gbm%gshift+gstate)*kcaltoau
    endif
 
 !  if(fit)then !penalty to avoid small sx which lead to numerical instabs
 !  dum=0
 !  do i=1,n
-!     dum=dum+2.*(sx(at(i))-0.8)**4
+!     dum=dum+2.*(gbm%sx(at(i))-0.8)**4
 !  enddo
-!  gshift=gshift+dum/autokcal
+!  gbm%gshift=gbm%gshift+dum/autokcal
 !  endif
 
 !  hydrogen bonding magnitude
-   hb_mag = -(tmp**2)/autokcal
+   gbm%hb_mag = -(tmp**2)*kcaltoau
 
 !  scaling of the van der Waals radius
-   rvdw = rvdw * rvdwscal
+   gbm%rvdw = gbm%rvdw * rvdwscal
 
 !  add the probe radius to the molecular surface
-   rasasa=rvdw+rprobe
+   gbm%rasasa=gbm%rvdw+gbm%rprobe
 
 !  surface tension scaling
    gamma_in=(1.0d-5)*autokcal/mNmkcal
 
 !  dielectric scaling
-   epsu=1.0_wp
-   keps=((1.0_wp/epsv)-(1.0_wp/epsu))
+   gbm%epsu=1.0_wp
+   gbm%keps=((1.0_wp/gbm%epsv)-(1.0_wp/gbm%epsu))
 
 !  set the salt term
-   if(lsalt) then
+   if(gbm%lsalt) then
 !     convert to au
-      ion_rad=ion_rad*aatoau
+      gbm%ion_rad=ion_rad*aatoau
 !     inverse Debye screening length
-      kappa=sqrt(epsv*temp*kappa_const/ionst)*aatoau
-      kappa=1.0_wp/kappa
+      gbm%kappa=sqrt(gbm%epsv*gbm%temp*kappa_const/ionst)*aatoau
+      gbm%kappa=1.0_wp/gbm%kappa
    endif
 
-!  print parameters
-   write(iunit,*) 'Gsolv ref. state (COSMO-RS): ',trim(a80)
-   write(iunit,*) 'temperature (mdtemp)       : ',temp
-   write(iunit,*) 'dielectric constant        : ',epsv
-   write(iunit,*) 'rho                        : ',rhos
-   write(iunit,*) 'mass                       : ',smass
-   write(iunit,*) 'surface tension            : ',gamma_in
-   write(iunit,*) 'probe radius               : ',rprobe
-   write(iunit,*) 'vdW radii scaling          : ',rvdwscal
-   write(iunit,*) 'Gshift (Eh)                : ',gshift
-   write(iunit,*) 'c1                         : ',c1
-   write(iunit,*) 'soset                      : ',soset
-   write(iunit,*) 'HB correction              : ',lhb
-   if(lsalt) then
-      write(iunit,*) 'Debye screening length     : ',1.0_wp/kappa/aatoau
-   endif
+   gbm%nangsa = ngrida
 
-   soset=0.1*soset*aatoau
+end subroutine new_gbsa_model
 
-   rhos=rhos*molcm3au/smass
-
-   nangsa = ngrida
-
-end subroutine init_gbsa
+subroutine read_gbsa_parameters(ifile, param)
+   integer, intent(in) :: ifile
+   type(gbsa_parameter) :: param
+   integer :: i
+   read(ifile,*) param%epsv
+   read(ifile,*) param%smass
+   read(ifile,*) param%rhos
+   read(ifile,*) param%c1
+   read(ifile,*) param%rprobe
+   read(ifile,*) param%gshift
+   read(ifile,*) param%soset
+   read(ifile,*) param%dum
+   do i = 1, 94
+      read(ifile,*) param%gamscale(i), param%sx(i), param%tmp(i)
+   enddo
+end subroutine read_gbsa_parameters
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
@@ -406,16 +479,16 @@ subroutine new_gbsa(this,n,at)
    real(wp), allocatable :: xang(:),yang(:),zang(:),wang(:)
 
    ! get some space
-   call allocate_gbsa(this,n,nangsa)
+   call allocate_gbsa(this,n,gbm%nangsa)
 
    ! initialize the vdw radii array
    this%at = at
    this%maxvdwr=0.0_wp
    minvdwr=1000.0_wp
    do i=1,this%nat
-      this%vdwr(i)=rvdw(this%at(i))*aatoau
-      this%rho(i)=this%vdwr(i)*sx(this%at(i))
-      this%svdw(i)=this%vdwr(i)-soset
+      this%vdwr(i)=gbm%rvdw(this%at(i))*aatoau
+      this%rho(i)=this%vdwr(i)*gbm%sx(this%at(i))
+      this%svdw(i)=this%vdwr(i)-gbm%soset
       this%maxvdwr=max(this%maxvdwr,this%vdwr(i))
       minvdwr=min(minvdwr,this%vdwr(i))
    enddo
@@ -434,7 +507,7 @@ subroutine new_gbsa(this,n,at)
    ! initialize solvent-accessible atomic surface area computation (SASA)
    maxrasasa=0.0_wp
    do i = 1, this%nat
-      this%vdwsa(i) = rasasa(this%at(i))*aatoau
+      this%vdwsa(i) = gbm%rasasa(this%at(i))*aatoau
       maxrasasa=max(maxrasasa,this%vdwsa(i))
       this%trj2(1,i) = (this%vdwsa(i)-w)**2
       this%trj2(2,i) = (this%vdwsa(i)+w)**2
@@ -449,10 +522,9 @@ subroutine new_gbsa(this,n,at)
    enddo
 
    this%srcut = 2.0_wp*(w + maxrasasa) + srcut_add*aatoau
-   gammas=(1.0d-5)
-   this%sasagam=fourpi*gammas
+   this%sasagam=fourpi*gbm%gammas
    do i = 1, this%nat
-      this%gamsasa(i)=gamscale(this%at(i))*fourpi*gammas
+      this%gamsasa(i)=gbm%gamscale(this%at(i))*fourpi*gbm%gammas
    enddo
 
    allocate(xang(this%nang),yang(this%nang),zang(this%nang),wang(this%nang))
@@ -515,7 +587,7 @@ pure subroutine compute_amat(this,Amat)
    real(wp) :: aa,r2,gg,iepsu,arg,bp
    real(wp) :: dd,expd,fgb,fgb2,dfgb
 
-   if(.not.lsalt) then
+   if(.not.gbm%lsalt) then
 
       ! compute energy and Amat direct and radii derivatives
       do kk = 1, this%ntpair
@@ -530,19 +602,19 @@ pure subroutine compute_amat(this,Amat)
          expd = exp(-dd)
          fgb2 = r2+aa*expd
          dfgb = 1.0_wp/sqrt(fgb2)
-         Amat(i,j) = keps*dfgb + Amat(i,j)
-         Amat(j,i) = keps*dfgb + Amat(j,i)
+         Amat(i,j) = gbm%keps*dfgb + Amat(i,j)
+         Amat(j,i) = gbm%keps*dfgb + Amat(j,i)
       enddo
 
       ! self-energy part
       do i = 1, this%nat
          bp = 1._wp/this%brad(i)
-         Amat(i,i) = Amat(i,i) + keps*bp
+         Amat(i,i) = Amat(i,i) + gbm%keps*bp
       enddo
 
    else
 
-      iepsu=1.0_wp/epsu
+      iepsu=1.0_wp/gbm%epsu
 
       ! compute energy and Amat direct and radii derivatives
       do kk = 1, this%ntpair
@@ -559,14 +631,14 @@ pure subroutine compute_amat(this,Amat)
          fgb=sqrt(r2+aa*expd)
          dfgb=1._wp/fgb
          gg=this%ionscr(i)+this%ionscr(j)
-         Amat(i,j)=(exp(-kappa*fgb)*gg-iepsu)*dfgb + Amat(i,j)
-         Amat(j,i)=(exp(-kappa*fgb)*gg-iepsu)*dfgb + Amat(j,i)
+         Amat(i,j)=(exp(-gbm%kappa*fgb)*gg-iepsu)*dfgb + Amat(i,j)
+         Amat(j,i)=(exp(-gbm%kappa*fgb)*gg-iepsu)*dfgb + Amat(j,i)
       enddo
 
       ! self-energy part
       do i = 1, this%nat
          gg=this%ionscr(i)*2.0_wp
-         Amat(i,i)= Amat(i,i) + (exp(-kappa*this%brad(i))*gg-iepsu)/this%brad(i)
+         Amat(i,i)= Amat(i,i) + (exp(-gbm%kappa*this%brad(i))*gg-iepsu)/this%brad(i)
       enddo
 
 
@@ -598,11 +670,11 @@ pure subroutine compute_fgb(this,fgb,fhb)
 !  initialize
    fgb=0.0_wp
 
-   hkeps=keps*autoeV
+   hkeps=gbm%keps*autoeV
 
-   if(lsalt) then
+   if(gbm%lsalt) then
 
-      iepsu=1.0_wp/epsu
+      iepsu=1.0_wp/gbm%epsu
 
 !     compute energy and fgb direct and radii derivatives
       do kk = 1, this%ntpair
@@ -617,14 +689,14 @@ pure subroutine compute_fgb(this,fgb,fhb)
          expd=exp(-dd)
          dfgb=sqrt(r2+aa*expd)
          gg=this%ionscr(i)+this%ionscr(j)
-         fgb(i,j)=autoeV*(exp(-kappa*dfgb)*gg-iepsu)/dfgb
+         fgb(i,j)=autoeV*(exp(-gbm%kappa*dfgb)*gg-iepsu)/dfgb
          fgb(j,i)=fgb(i,j)
       enddo
 
 !     self-energy part
       do i = 1, this%nat
          gg=this%ionscr(i)*2.0_wp
-         fgb(i,i)=autoeV*(exp(-kappa*this%brad(i))*gg-iepsu)/this%brad(i)
+         fgb(i,i)=autoeV*(exp(-gbm%kappa*this%brad(i))*gg-iepsu)/this%brad(i)
       enddo
 
    else
@@ -686,7 +758,7 @@ pure subroutine compute_gb_damat(this,q,gborn,ghb,dAmatdr,Afac,lpr)
 
    egb = 0._wp
 
-   if(.not.lsalt) then
+   if(.not.gbm%lsalt) then
       ! GB energy and gradient
 
       ! compute energy and fgb direct and radii derivatives
@@ -698,14 +770,14 @@ pure subroutine compute_gb_damat(this,q,gborn,ghb,dAmatdr,Afac,lpr)
          j = this%ppind(2,kk)
 
          ! dielectric scaling of the charges
-         qq = q(i)*q(j)*keps
+         qq = q(i)*q(j)*gbm%keps
          aa = this%brad(i)*this%brad(j)
          dd = a4*r2/aa
          expd = exp(-dd)
          fgb2 = r2+aa*expd
          dfgb2 = 1._wp/fgb2
          dfgb = sqrt(dfgb2)
-         dfgb3 = dfgb2*dfgb*keps
+         dfgb3 = dfgb2*dfgb*gbm%keps
 
          egb = egb + qq*dfgb
 
@@ -729,15 +801,15 @@ pure subroutine compute_gb_damat(this,q,gborn,ghb,dAmatdr,Afac,lpr)
       do i = 1, this%nat
          bp = 1._wp/this%brad(i)
          qq = q(i)*bp
-         egb = egb + 0.5_wp*q(i)*qq*keps
-         grddbi = -this%dbrdp(i)*keps*bp*bp*0.5_wp
+         egb = egb + 0.5_wp*q(i)*qq*gbm%keps
+         grddbi = -this%dbrdp(i)*gbm%keps*bp*bp*0.5_wp
          dAmatdr(:,:,i) = dAmatdr(:,:,i) + this%brdr(:,:,i)*grddbi*q(i)
       enddo
 
    else
       ! GB-SE energy and dAmatdr
 
-      epu=1._wp/epsu
+      epu=1._wp/gbm%epsu
 
       ! compute energy and fgb direct and radii derivatives
       do kk = 1, this%ntpair
@@ -755,7 +827,7 @@ pure subroutine compute_gb_damat(this,q,gborn,ghb,dAmatdr,Afac,lpr)
          fgb = sqrt(fgb2)
          dfgb2 = 1._wp/fgb2
          dfgb = sqrt(dfgb2)
-         aa = kappa*fgb
+         aa = gbm%kappa*fgb
          expa = exp(-aa)
          gg = (this%ionscr(i)+this%ionscr(j))*expa
 
@@ -782,11 +854,11 @@ pure subroutine compute_gb_damat(this,q,gborn,ghb,dAmatdr,Afac,lpr)
 
       ! self-energy part
       do i = 1, this%nat
-         gg = exp(-kappa*this%brad(i))
+         gg = exp(-gbm%kappa*this%brad(i))
          aa = 2._wp*this%ionscr(i)*gg-epu
          qq = q(i)/this%brad(i)
          egb = egb + 0.5_wp*qq*q(i)*aa
-         ap = aa-this%brad(i)*2._wp*(this%discr(i)+this%ionscr(i)*kappa)*gg
+         ap = aa-this%brad(i)*2._wp*(this%discr(i)+this%ionscr(i)*gbm%kappa)*gg
          grddbi = -this%dbrdp(i)*0.5_wp*qq*ap/this%brad(i)
          dAmatdr(:,:,i) = dAmatdr(:,:,i) + this%brdr(:,:,i)*grddbi
       enddo
@@ -842,7 +914,7 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
    egb = 0._wp
    grddb = 0._wp
 
-   if(.not.lsalt) then
+   if(.not.gbm%lsalt) then
       ! GB energy and gradient
 
       ! compute energy and fgb direct and radii derivatives
@@ -861,9 +933,9 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
          fgb2 = r2+aa*expd
          dfgb2 = 1._wp/fgb2
          dfgb = sqrt(dfgb2)
-         dfgb3 = dfgb2*dfgb*keps
+         dfgb3 = dfgb2*dfgb*gbm%keps
 
-         egb = egb + qq*keps*dfgb
+         egb = egb + qq*gbm%keps*dfgb
 
          ap = (1._wp-a4*expd)*dfgb3
          dr = ap*this%ddpair(2:4,kk)
@@ -884,8 +956,8 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
       do i = 1, this%nat
          bp = 1._wp/this%brad(i)
          qq = q(i)*bp
-         egb = egb + 0.5_wp*q(i)*qq*keps
-         grddbi = -this%dbrdp(i)*0.5_wp*keps*qq*bp
+         egb = egb + 0.5_wp*q(i)*qq*gbm%keps
+         grddbi = -this%dbrdp(i)*0.5_wp*gbm%keps*qq*bp
          grddb(i) = grddb(i) + grddbi*q(i)
          !gradient = gradient + this%brdr(:,:,i) * grddbi*q(i)
       enddo
@@ -893,7 +965,7 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
    else
       ! GB-SE energy and gradient
 
-      epu=1._wp/epsu
+      epu=1._wp/gbm%epsu
 
       ! compute energy and fgb direct and radii derivatives
       do kk = 1, this%ntpair
@@ -909,7 +981,7 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
          expd = exp(-dd)
          dfgb = r2+aa*expd
          fgb = sqrt(dfgb)
-         aa = kappa*fgb
+         aa = gbm%kappa*fgb
          expa = exp(-aa)
          gg = (this%ionscr(i)+this%ionscr(j))*expa
          qfg = qq/fgb
@@ -934,11 +1006,11 @@ subroutine compute_gb_egrad(this,q,gborn,ghb,gradient,lpr)
 
       ! self-energy part
       do i = 1, this%nat
-         gg = exp(-kappa*this%brad(i))
+         gg = exp(-gbm%kappa*this%brad(i))
          aa = 2._wp*this%ionscr(i)*gg-epu
          qq = q(i)/this%brad(i)
          egb = egb + 0.5_wp*qq*q(i)*aa
-         ap = aa-this%brad(i)*2._wp*(this%discr(i)+this%ionscr(i)*kappa)*gg
+         ap = aa-this%brad(i)*2._wp*(this%discr(i)+this%ionscr(i)*gbm%kappa)*gg
          grddbi = -this%dbrdp(i)*0.5_wp*qq*qq*ap
          grddb(i) = grddb(i) + grddbi
       enddo
@@ -994,13 +1066,13 @@ pure subroutine compute_fhb(this,xyz)
       ! atomic Z
       iz=this%at(i)
       ! number of HB
-      nhb=at_hb(iz)
+      nhb=gbm%at_hb(iz)
       if(nhb.le.0) cycle
       ! SASA-D for HB
       smaxd=1.0_wp/(this%vdwsa(i)*this%vdwsa(i)*this%gamsasa(i))
       sasad=this%sasa(i)*smaxd
-      this%hbw(i)=hb_mag(iz)*sasad
-      this%dhbdw(i)=hb_mag(iz)*smaxd
+      this%hbw(i)=gbm%hb_mag(iz)*sasad
+      this%dhbdw(i)=gbm%hb_mag(iz)*smaxd
    enddo
 
 end subroutine compute_fhb
@@ -1082,7 +1154,7 @@ subroutine compute_brad_sasa(this,xyz)
    call compute_numsa(this,xyz)
 
    ! compute the Debye-Hueckel ion exclusion term
-   if (lsalt) call compute_debye_hueckel(this)
+   if (gbm%lsalt) call compute_debye_hueckel(this)
 
    ! compute the HB term
    if (lhb) call compute_fhb(this,xyz)
@@ -1097,11 +1169,11 @@ pure subroutine compute_debye_hueckel(this)
    integer  :: i
    real(wp) :: aa,gg
 
-   aa=0.5_wp/epsv
+   aa=0.5_wp/gbm%epsv
    do i = 1, this%nat
-      gg=kappa*(this%brad(i)+ion_rad)
+      gg=gbm%kappa*(this%brad(i)+gbm%ion_rad)
       this%ionscr(i)=aa*exp(gg)/(1.0_wp+gg)
-      this%discr(i)=this%ionscr(i)*kappa*gg/(1.0_wp+gg)
+      this%discr(i)=this%ionscr(i)*gbm%kappa*gg/(1.0_wp+gg)
    enddo
 
 end subroutine compute_debye_hueckel
@@ -1139,11 +1211,11 @@ pure subroutine compute_bornr(this)
 
       br=1.0_wp/(s1-v1*th)
       ! Include GBMV2-like scaling
-      br=c1*br
+      br=gbm%c1*br
 
       dpsi=ch*(s1-v1*th)
       dpsi=s2*v1*arg2/(dpsi*dpsi)
-      dpsi=c1*dpsi
+      dpsi=gbm%c1*dpsi
 
       this%brad(iat) = br
       this%dbrdp(iat) = dpsi

--- a/xtb/gbobc.f90
+++ b/xtb/gbobc.f90
@@ -35,6 +35,7 @@ module gbobc
    public :: compute_gb_damat
    public :: compute_hb
    public :: update_nnlist_gbsa
+   public :: load_custom_parameters
 
    private
 ! ========================================================================
@@ -215,13 +216,11 @@ subroutine load_custom_parameters(epsv,smass,rhos,c1,rprobe,gshift,soset,dum, &
 
 end subroutine load_custom_parameters
 
-subroutine init_gbsa(iunit,n,at,sname,mode,temp,gfn_method,ngrida)
+subroutine init_gbsa(iunit,sname,mode,temp,gfn_method,ngrida)
    use mctc_strings
    use readin
    implicit none
    integer, intent(in) :: iunit
-   integer, intent(in) :: n
-   integer, intent(in) :: at(n)
    character(len=*),intent(in) :: sname
    integer, intent(in) :: mode
    real(wp),intent(in) :: temp

--- a/xtb/geometry_reader.f90
+++ b/xtb/geometry_reader.f90
@@ -140,7 +140,7 @@ subroutine read_sdf(iunit,mol)
       call getline(iunit,line,err)
       if (err.ne.0) call raise('E',"Could not read geometry from SDF file",1)
       if (debug) print'(">",a)',line
-      read(line,*,iostat=err) chdum, xyz(1), xyz(2), xyz(3)
+      read(line,*,iostat=err) xyz(1), xyz(2), xyz(3), chdum
       if (debug) print'("->",a)',chdum
       if (debug) print'("->",3g0)',xyz
 

--- a/xtb/header.f90
+++ b/xtb/header.f90
@@ -26,11 +26,19 @@ write(iunit,'(a)') &
    "     |                         S. Grimme                         |     ",&
    "     |          Mulliken Center for Theoretical Chemistry        |     ",&
    "     |                    University of Bonn                     |     ",&
-   "     |                  Version 6.2 (SAW190826)                  |     ",&
    !     |  Version number by <major>.<minor>.<rev> (<author><date>) |     !
    "      -----------------------------------------------------------      ",""
    !< < < < < < < < < < < < < < < < < < > > > > > > > > > > > > > > > > > >!
+   call xtb_version(iunit)
 end subroutine xtb_header
+
+subroutine xtb_version(iunit)
+integer,intent(in) :: iunit
+include 'xtb_version.fh'
+write(iunit,'(3x,"*",*(1x,a))') &
+   & "xtb version", version, "compiled by", author, "on", date
+write(iunit,'(a)')
+end subroutine xtb_version
 
 subroutine disclamer(iunit)
 integer,intent(in) :: iunit

--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -497,7 +497,7 @@ program XTBprog
 
 !  init GBSA part
    if(lgbsa) then
-      call init_gbsa(istdout,mol%n,mol%at,solvent,gsolvstate,temp_md,gfn_method,ngrida)
+      call init_gbsa(istdout,solvent,gsolvstate,temp_md,gfn_method,ngrida)
    endif
 !  initialize PC embedding (set default file names and stuff)
    call init_pcem

--- a/xtb/version.f90
+++ b/xtb/version.f90
@@ -1,0 +1,3 @@
+character(len=*),parameter :: version = "@version@ (@commit@)"
+character(len=*),parameter :: date = "@date@"
+character(len=*),parameter :: author = "'@author@@@origin@'"


### PR DESCRIPTION
Some maintenance and bugfixes (:beetle:) for the release aftermath. This changes the internals of the C-API (exposing a few bugs) and connects the GBSA model with the API.

- [x] add version number notice including git commit
- [x] GBSA refactoring
  - [x] new GSBA model class derived from GBSA parameters
  - [x] custom solvent parameters (needs preloading)
  - [x] preload custom solvent model from API
- [x] GBSA `raise` calls used wrong interface :beetle: 
- [x] C-API calls to calculators used wrong interface :beetle: 
  - [x] calculators are now wrapped in a module (forces correct interface)
  - [x] C-API is now wrapped in a module
- [x] optional arguments for the C-API using C `NULL`/C++ `nullptr`
- [x] removed undocumented interfaces from API
- [x] SDF input read in the wrong order :beetle:

This pull request is not breaking API compatibility.