### PR TITLE
introduce a mutex for shell-escapes

### DIFF
--- a/xtb/qcextern.f90
+++ b/xtb/qcextern.f90
@@ -146,6 +146,7 @@ subroutine run_mopac_egrad(nat,at,xyz,energy,gradient)
    integer :: num
    real(wp) :: dum(10),edum
 
+   !$omp critical(mopac_lock)
    call open_file(imopac,ext_mopac%input_file,'w')
    write(imopac,'(a,/,/)') ext_mopac%input_string
    do i = 1, nat
@@ -198,6 +199,7 @@ subroutine run_mopac_egrad(nat,at,xyz,energy,gradient)
       endif
    enddo read_mopac_output
    call close_file(imopac)
+   !$omp end critical (mopac_lock)
    gradient = gradient * kcaltoau / aatoau
 end subroutine run_mopac_egrad
 
@@ -337,6 +339,7 @@ subroutine run_orca_egrad(nat,at,xyz,energy,gradient)
    character(len=2),external :: asym
 !$ integer,external :: omp_get_num_threads
 
+   !$omp critical (orca_lock)
    if (ext_orca%exist) then
       ! we dump the name of the external xyz file to input_string... not cool
       call open_file(iorca,ext_orca%input_string,'w')
@@ -415,6 +418,7 @@ subroutine run_orca_egrad(nat,at,xyz,energy,gradient)
       read(iorca,*)gradient(3,j)
    enddo
    call close_file(iorca)
+   !$omp end critical (orca_lock)
 
 end subroutine run_orca_egrad
 

--- a/xtb/qmexternal.f90
+++ b/xtb/qmexternal.f90
@@ -31,6 +31,7 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lgbsa)
 
    ! TM (RI)
    if(extcode.eq.1)then
+      !$omp critical (turbo_lock)
       call wrtm(n,at,xyz)
       if(extmode.eq.1)then
          call execute_command_line('ridft  >  job.last 2>> /dev/null')
@@ -38,11 +39,13 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lgbsa)
       endif
       call extcodeok(extcode) 
       call rdtm(n,grd,eel,g)
+      !$omp end critical (turbo_lock)
       return
    endif
 
    ! TM+d3+gcp
    if(extcode.eq.2)then
+      !$omp critical (turbo_lock)
       call wrtm(n,at,xyz)
       if(extmode.le.2)then
          call execute_command_line('ridft  >  job.last 2>> /dev/null')
@@ -52,11 +55,13 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lgbsa)
       endif
       call extcodeok(extcode) 
       call rdtm(n,.true.,eel,g)
+      !$omp end critical (turbo_lock)
       return
    endif
 
    ! TM (NORI)
    if(extcode.eq.3)then
+      !$omp critical (turbo_lock)
       call wrtm(n,at,xyz)
       if(extmode.eq.1)then
          call execute_command_line('dscf  > job.last 2>> /dev/null')
@@ -64,8 +69,10 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lgbsa)
       endif
       call extcodeok(extcode) 
       call rdtm(n,grd,eel,g)
+      !$omp end critical (turbo_lock)
       return
    endif
+
 
    call raise('E','This external code is not implemented',1)
 


### PR DESCRIPTION
- [ ] use `exec` in shell escape to get rid of the additional `sh`