### PR TITLE
refactored property printout routines

### DIFF
--- a/TESTSUITE/thermo.f90
+++ b/TESTSUITE/thermo.f90
@@ -171,6 +171,7 @@ subroutine test_print_thermo
    use splitparam
 
    use axis_trafo
+   use property_output
 
    implicit none
 

--- a/xtb/dtrafo.f90
+++ b/xtb/dtrafo.f90
@@ -15,6 +15,10 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
+module dtrafo
+
+contains
+
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !c transforms cao(6d) integrals to sao(5d) basis
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -347,4 +351,4 @@ subroutine cao2saop(nbf,nao,s,basis)
 
   deallocate(sneu)
 end subroutine cao2saop
-
+end module dtrafo

--- a/xtb/hlex.f90
+++ b/xtb/hlex.f90
@@ -19,6 +19,7 @@ subroutine hlex(nat,at,nbf,nao,ihomo,xyz,focc,s,cmo,eiga,basis)
    use iso_fortran_env, wp => real64
    use mctc_econv, only : autoev,evtoau
    use tbdef_basisset
+   use dtrafo
    implicit none
    type(tb_basisset), intent(in) :: basis
    integer, intent(in)  :: nao,ihomo,nat,at(nat),nbf

--- a/xtb/local.f90
+++ b/xtb/local.f90
@@ -22,6 +22,7 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis)
    use tbdef_basisset
    use setparam
    use scc_core, only : wiberg_nosort
+   use dtrafo
    implicit none
    type(tb_basisset), intent(in) :: basis
    integer, intent(in) :: nao,ihomo,nat,at(nat),nbf

--- a/xtb/main_json.f90
+++ b/xtb/main_json.f90
@@ -55,11 +55,12 @@
 !    "version": 6.1
 ! }
 subroutine main_json &
-      (ijson,n,at,xyz,z,nshell,nbf,nao,wfx,xbas,xpar,sccres,freqres)
+      (ijson,mol,wfx,xbas,xpar,sccres,freqres)
    use iso_fortran_env, wp => real64
 
 !! ========================================================================
 !  load class definitions
+   use tbdef_molecule
    use tbdef_wavefunction
    use tbdef_basisset
    use tbdef_data
@@ -75,13 +76,7 @@ subroutine main_json &
 !! ========================================================================
    integer, intent(in) :: ijson ! file handle (usually json-file)
 !  molecule data
-   integer, intent(in) :: n        ! number of atoms
-   integer, intent(in) :: at(n)    ! atom types
-   real(wp),intent(in) :: xyz(3,n) ! cartesian coordinates
-   real(wp),intent(in) :: z(n)     ! nuclear charges
-   integer, intent(in) :: nshell   ! number of shells in basis
-   integer, intent(in) :: nbf      ! number of basis functions
-   integer, intent(in) :: nao      ! number of spherical atomic orbitals
+   type(tb_molecule), intent(in) :: mol
    type(tb_wavefunction),intent(in) :: wfx
    type(tb_basisset),    intent(in) :: xbas
    type(scc_parameter),  intent(in) :: xpar

--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -64,6 +64,7 @@ program XTBprog
    use set_module
    use geometry_reader
    use write_geometry
+   use property_output
 
 !! ========================================================================
 !  get interfaces for methods used in this part
@@ -787,19 +788,16 @@ program XTBprog
       write(*,*)'Periodic properties'
    else
       call main_property(iprop, &
-           mol%n,mol%at,mol%xyz,mol%z,calc%basis%nshell,calc%basis%nbf, &
-           calc%basis%nao,wfn,calc%basis,calc%param,res,acc)
+           mol,wfn,calc%basis,calc%param,res,acc)
       call main_cube(verbose, &
-           mol%n,mol%at,mol%xyz,mol%z,calc%basis%nshell,calc%basis%nbf, &
-           calc%basis%nao,wfn,calc%basis,calc%param,res)
+           mol,wfn,calc%basis,calc%param,res)
    endif
 
 
    if (pr_json) then
       call open_file(ich,'xtbout.json','w')
       call main_json(ich, &
-         mol%n,mol%at,mol%xyz,mol%z,calc%basis%nshell,calc%basis%nbf, &
-         calc%basis%nao,wfn,calc%basis,calc%param,res,fres)
+         mol,wfn,calc%basis,calc%param,res,fres)
       call close_file(ich)
    endif
 
@@ -811,7 +809,7 @@ program XTBprog
 
    if ((runtyp.eq.p_run_hess).or.(runtyp.eq.p_run_ohess)) then
       call generic_header(iprop,'Frequency Printout',49,10)
-      call main_freq(iprop,mol%n,mol%at,mol%xyz,mol%z,wfn,fres)
+      call main_freq(iprop,mol,wfn,fres)
    endif
 
    if (allocated(property_file)) then


### PR DESCRIPTION
- pass geometry as molecule class
- remove array dimensions since they are passed by basis set object
- make dtrafo a module to check dummy arguments
- fix missing arguments in sao2cao trafo :beetle: