### PR TITLE
Atomlist class

### DIFF
--- a/TESTSUITE/assertion.f90
+++ b/TESTSUITE/assertion.f90
@@ -1,9 +1,13 @@
 module assertion
 
    interface assert_eq
+      module procedure :: assert_eq_char
       module procedure :: assert_eq_int16
       module procedure :: assert_eq_int32
       module procedure :: assert_eq_int64
+      module procedure :: assert_eq_int16_array
+      module procedure :: assert_eq_int32_array
+      module procedure :: assert_eq_int64_array
    end interface assert_eq
 
    interface assert_close
@@ -27,6 +31,17 @@ subroutine assert(bool)
       afail = afail+1
    endif
 end subroutine assert
+
+subroutine assert_eq_char(val1,val2)
+   use iso_fortran_env, istderr => error_unit
+   character(len=*),intent(in) :: val1,val2
+
+   if (val1 /= val2) then
+      write(istderr,'("assertion:",1x,a," == ",a,1x,"FAILED")') &
+         val1,val2
+      afail = afail+1
+   endif
+end subroutine assert_eq_char
 
 subroutine assert_eq_int16(val1,val2)
    use iso_fortran_env, istderr => error_unit
@@ -60,6 +75,66 @@ subroutine assert_eq_int64(val1,val2)
       afail = afail+1
    endif
 end subroutine assert_eq_int64
+
+subroutine assert_eq_int16_array(val1,val2)
+   use iso_fortran_env, istderr => error_unit
+   integer(int16),intent(in) :: val1(:),val2(:)
+   integer :: i
+
+   if (size(val1) .ne. size(val2)) then
+      write(istderr,'("shape missmatch:",1x,i0," == ",i0,1x,"FAILED")') &
+         val1,val2
+      afail = afail+1
+   endif
+   if (any(val1 /= val2)) then
+      do i = 1, size(val1)
+         if (val1(i) /= val2(i)) &
+         write(istderr,'("assertion:",1x,g21.14," == ",g21.14,1x,"FAILED at ",i0)')&
+            val1(i),val2(i),i
+      enddo
+      afail = afail+1
+   endif
+end subroutine assert_eq_int16_array
+
+subroutine assert_eq_int32_array(val1,val2)
+   use iso_fortran_env, istderr => error_unit
+   integer(int32),intent(in) :: val1(:),val2(:)
+   integer :: i
+
+   if (size(val1) .ne. size(val2)) then
+      write(istderr,'("shape missmatch:",1x,i0," == ",i0,1x,"FAILED")') &
+         val1,val2
+      afail = afail+1
+   endif
+   if (any(val1 /= val2)) then
+      do i = 1, size(val1)
+         if (val1(i) /= val2(i)) &
+         write(istderr,'("assertion:",1x,g21.14," == ",g21.14,1x,"FAILED at ",i0)')&
+            val1(i),val2(i),i
+      enddo
+      afail = afail+1
+   endif
+end subroutine assert_eq_int32_array
+
+subroutine assert_eq_int64_array(val1,val2)
+   use iso_fortran_env, istderr => error_unit
+   integer(int64),intent(in) :: val1(:),val2(:)
+   integer :: i
+
+   if (size(val1) .ne. size(val2)) then
+      write(istderr,'("shape missmatch:",1x,i0," == ",i0,1x,"FAILED")') &
+         val1,val2
+      afail = afail+1
+   endif
+   if (any(val1 /= val2)) then
+      do i = 1, size(val1)
+         if (val1(i) /= val2(i)) &
+         write(istderr,'("assertion:",1x,g21.14," == ",g21.14,1x,"FAILED at ",i0)')&
+            val1(i),val2(i),i
+      enddo
+      afail = afail+1
+   endif
+end subroutine assert_eq_int64_array
 
 subroutine assert_close_real64(val1,val2,thr)
    use iso_fortran_env, istderr => error_unit

--- a/TESTSUITE/tbdef_atomlist.f90
+++ b/TESTSUITE/tbdef_atomlist.f90
@@ -6,6 +6,7 @@ subroutine test_atomlist
    type(tb_atomlist) :: atl
    character(len=:), allocatable :: string
    integer, allocatable :: list(:)
+   integer, parameter :: atoms(*) = [3,1,1,5,8,1,1,2,5]
    logical, parameter :: lpar(*) = [.true., .false., .true., .true., .true., &
       &                             .false., .false., .true., .false.]
    integer, parameter :: ipar(*) = [1, 3, 4, 5, 8]
@@ -47,6 +48,9 @@ subroutine test_atomlist
    call atl%switch_truth
    call atl%to_string(string)
    call assert_eq(string, '2,6-7,9')
+   call atl%gather(atoms, list)
+   call assert_eq(list, [1,1,1,5])
+   call assert_eq(size(list), len(atl))
    call atl%new
 
    atl = tb_atomlist(list=lpar, truth=.false., delimiter=' ', skip=':')

--- a/TESTSUITE/tbdef_atomlist.f90
+++ b/TESTSUITE/tbdef_atomlist.f90
@@ -1,0 +1,67 @@
+subroutine test_atomlist
+   use iso_fortran_env
+   use assertion
+   use tbdef_atomlist
+   implicit none
+   type(tb_atomlist) :: atl
+   character(len=:), allocatable :: string
+   integer, allocatable :: list(:)
+   logical, parameter :: lpar(*) = [.true., .false., .true., .true., .true., &
+      &                             .false., .false., .true., .false.]
+   integer, parameter :: ipar(*) = [1, 3, 4, 5, 8]
+   character(len=*), parameter :: cpar = '1,3-5,8'
+
+   write(error_unit,'(a)') " * Testing defaults"
+   call assert(atl%get_truth() .eqv. .true.)
+   call atl%switch_truth
+   call assert(atl%get_truth() .eqv. .false.)
+   call assert_eq(size(atl), 0)
+   write(error_unit,'("-> Done:",1x,i0,1x,"fails")') afail
+
+   write(error_unit,'(a)') " * Testing constructors"
+   atl = tb_atomlist(list=lpar, truth=.true.)
+   call assert_eq(size(atl), 9)
+   call assert_eq(len(atl), 5)
+
+   atl = tb_atomlist(list=lpar, truth=.false.)
+   call assert_eq(size(atl), 9)
+   call assert_eq(len(atl), 4)
+
+   atl = tb_atomlist(list=ipar, truth=.true.)
+   call assert_eq(size(atl), 8)
+   call assert_eq(len(atl), 5)
+   call atl%to_list(list)
+   call assert_eq(list, ipar)
+
+   atl = tb_atomlist(list=cpar, truth=.false.)
+   call assert_eq(size(atl), 8)
+   call assert_eq(len(atl), 5)
+   call atl%to_string(string)
+   call assert_eq(string, cpar)
+   write(error_unit,'("-> Done:",1x,i0,1x,"fails")') afail
+   call atl%new
+
+   write(error_unit,'(a)') " * Testing data manipulation"
+   call atl%new(lpar)
+   call atl%resize(9)
+   call atl%switch_truth
+   call atl%to_string(string)
+   call assert_eq(string, '2,6-7,9')
+   call atl%new
+
+   atl = tb_atomlist(list=lpar, truth=.false., delimiter=' ', skip=':')
+   call atl%to_string(string)
+   call assert_eq(string, '2 6:7 9')
+   call atl%switch_truth
+   write(string, *) atl
+   call assert_eq(string, '1 3:5 8')
+   call atl%to_list(list)
+   call atl%switch_truth
+   call atl%add(list)
+   call assert_eq(len(atl), size(atl))
+   call atl%to_string(string)
+   call assert_eq(string, '1:9')
+   write(error_unit,'("-> Done:",1x,i0,1x,"fails")') afail
+
+   call terminate(afail)
+end subroutine test_atomlist

--- a/TESTSUITE/tests_peeq.f90
+++ b/TESTSUITE/tests_peeq.f90
@@ -107,6 +107,10 @@ program peeq_tester
       case('0d'); call test_wigner_seitz_0d
       case('3d'); call test_wigner_seitz_3d
       end select
+   case('tbdef_atomlist')
+      select case(sec)
+      case('list'); call test_atomlist
+      end select
    case('symmetry')
       select case(sec)
       case('water');  call test_symmetry_water

--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,7 @@ xtb_srcs += 'xtb/tbdef_pcem.f90'
 xtb_srcs += 'xtb/tbdef_wsc.f90'
 xtb_srcs += 'xtb/tbdef_options.f90'
 xtb_srcs += 'xtb/tbdef_calculator.f90'
+xtb_srcs += 'xtb/tbdef_atomlist.f90'
 
 # global data
 xtb_srcs += 'xtb/gfn0param.f90'
@@ -331,6 +332,7 @@ xtb_test += 'TESTSUITE/gfn0.f90'
 xtb_test += 'TESTSUITE/peeq.f90'
 xtb_test += 'TESTSUITE/symmetry.f90'
 xtb_test += 'TESTSUITE/thermo.f90'
+xtb_test += 'TESTSUITE/tbdef_atomlist.f90'
 
 incdir = include_directories('include')
 
@@ -426,6 +428,8 @@ test('Geometry Reader: coord 1D',xtb_test,args: ['geometry_reader','coord_1d'])
 test('Geometry Reader: coord 0D',xtb_test,args: ['geometry_reader','coord_0d'])
 test('Geometry Reader: Xmol  0D',xtb_test,args: ['geometry_reader','xmol_0d'])
 test('Geometry Reader: POSCAR',  xtb_test,args: ['geometry_reader','poscar_3d'])
+
+test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'])
 
 test('PBC tools: convert',xtb_test,args: ['pbc_tools','convert'])
 test('PBC tools: cutoff', xtb_test,args: ['pbc_tools','cutoff'])

--- a/xtb/constrain_param.f90
+++ b/xtb/constrain_param.f90
@@ -1118,6 +1118,7 @@ subroutine set_hess(key,val,nat,at,xyz)
 end subroutine set_hess
 
 subroutine set_reactor(key,val,nat,at,xyz)
+   use tbdef_atomlist
    use setparam
    implicit none
    character(len=*),intent(in) :: key
@@ -1126,10 +1127,13 @@ subroutine set_reactor(key,val,nat,at,xyz)
    integer, intent(in) :: at(nat)
    real(wp),intent(in) :: xyz(3,nat)
 
+   type(tb_atomlist) :: atl
+
    integer  :: idum
    real(wp) :: ddum
    logical  :: ldum
-   integer  :: list(nat),nlist
+   integer  :: nlist
+   integer, allocatable :: list(:)
    integer  :: i,j
 
    integer  :: narg
@@ -1144,28 +1148,21 @@ subroutine set_reactor(key,val,nat,at,xyz)
    select case(key)
    case default ! ignore, don't even think about raising them
    case('atoms')
-      do idum = 1, narg
-         if (get_list_value(trim(argv(idum)),list,nlist)) then
-            if (reactset%nat+nlist.gt.nat) then
-               call raise('S','something is wrong in the react list',1)
-               exit
-            endif
-            if (maxval(list(:nlist)).gt.nat) then
-               call raise('S','Attempted including atom not present in molecule.',1)
-               cycle
-            endif
-            reactset%atoms(reactset%nat+1:reactset%nat+nlist) = list
-            reactset%nat = reactset%nat+nlist
-         else
-            call raise('S',"Something went wrong in set_react_ 'atoms'.",1)
-            return ! you screwed it, let's get out of here
-         endif
-      enddo
+      call atl%new(val)
+      if (atl%get_error()) then
+         call raise('S','something is wrong in the reactor atom list',1)
+         return
+      endif
+      if (reactset%nat > 0) call atl%add(reactset%atoms(:reactset%nat))
+      call atl%to_list(list)
+      reactset%atoms = list
+      reactset%nat = size(list)
    end select
  
 end subroutine set_reactor
 
 subroutine set_path(key,val,nat,at,xyz)
+   use tbdef_atomlist
    use setparam
    implicit none
    character(len=*),intent(in) :: key
@@ -1174,10 +1171,13 @@ subroutine set_path(key,val,nat,at,xyz)
    integer, intent(in) :: at(nat)
    real(wp),intent(in) :: xyz(3,nat)
 
+   type(tb_atomlist) :: atl
+
    integer  :: idum
    real(wp) :: ddum
    logical  :: ldum
-   integer  :: list(nat),nlist
+   integer  :: nlist
+   integer, allocatable :: list(:)
    integer  :: i,j
 
    integer  :: narg
@@ -1192,28 +1192,21 @@ subroutine set_path(key,val,nat,at,xyz)
    select case(key)
    case default ! ignore, don't even think about raising them
    case('atoms')
-      do idum = 1, narg
-         if (get_list_value(trim(argv(idum)),list,nlist)) then
-            if (pathset%nat+nlist.gt.nat) then
-               call raise('S','something is wrong in the path list',1)
-               exit
-            endif
-            if (maxval(list(:nlist)).gt.nat) then
-               call raise('S','Attempted including atom not present in molecule.',1)
-               cycle
-            endif
-            pathset%atoms(pathset%nat+1:pathset%nat+nlist) = list
-            pathset%nat = pathset%nat+nlist
-         else
-            call raise('S',"Something went wrong in set_path_ 'atoms'.",1)
-            return ! you screwed it, let's get out of here
-         endif
-      enddo
+      call atl%new(val)
+      if (atl%get_error()) then
+         call raise('S','something is wrong in the bias path atom list',1)
+         return
+      endif
+      if (pathset%nat > 0) call atl%add(pathset%atoms(:pathset%nat))
+      call atl%to_list(list)
+      pathset%atoms = list
+      pathset%nat = size(list)
    end select
  
 end subroutine set_path
 
 subroutine set_metadyn(key,val,nat,at,xyz)
+   use tbdef_atomlist
    use fixparam
    implicit none
    character(len=*),intent(in) :: key
@@ -1222,10 +1215,13 @@ subroutine set_metadyn(key,val,nat,at,xyz)
    integer, intent(in) :: at(nat)
    real(wp),intent(in) :: xyz(3,nat)
 
+   type(tb_atomlist) :: atl
+
    integer  :: idum
    real(wp) :: ddum
    logical  :: ldum
-   integer  :: list(nat),nlist
+   integer  :: nlist
+   integer, allocatable :: list(:)
    integer  :: i,j
 
    integer  :: narg
@@ -1240,23 +1236,15 @@ subroutine set_metadyn(key,val,nat,at,xyz)
    select case(key)
    case default ! ignore, don't even think about raising them
    case('atoms')
-      do idum = 1, narg
-         if (get_list_value(trim(argv(idum)),list,nlist)) then
-            if (metaset%nat+nlist.gt.nat) then
-               call raise('S','something is wrong in the metadyn list',1)
-               exit
-            endif
-            if (maxval(list(:nlist)).gt.nat) then
-               call raise('S','Attempted including atom not present in molecule.',1)
-               cycle
-            endif
-            metaset%atoms(metaset%nat+1:metaset%nat+nlist) = list
-            metaset%nat = metaset%nat+nlist
-         else
-            call raise('S',"Something went wrong in set_metadyn_ 'atoms'.",1)
-            return ! you screwed it, let's get out of here
-         endif
-      enddo
+      call atl%new(val)
+      if (atl%get_error()) then
+         call raise('S','something is wrong in the metadynamic atom list',1)
+         return
+      endif
+      if (metaset%nat > 0) call atl%add(metaset%atoms(:metaset%nat))
+      call atl%to_list(list)
+      metaset%atoms = list
+      metaset%nat = size(list)
    case('modify factor')
       if (mod(narg,2).ne.0) then
          call raise('S',"Something went wrong in set_metadyn_ 'modify'.",1)

--- a/xtb/tbdef_atomlist.f90
+++ b/xtb/tbdef_atomlist.f90
@@ -1,0 +1,513 @@
+!> implemenation of a list of atoms
+module tbdef_atomlist
+   use iso_fortran_env, wp => real64
+   implicit none
+   public :: tb_atomlist
+   public :: size, len, assignment(=), write(formatted), read(formatted)
+   private
+
+   character, parameter :: p_delimiter = ','
+   character, parameter :: p_skip = '-'
+
+   type :: tb_atomlist
+      private
+      logical, allocatable :: list(:)
+      logical :: default = .false.
+      character :: delimiter = p_delimiter
+      character :: skip = p_skip
+      logical :: error = .false.
+   contains
+      generic :: new => from_integers, from_logicals, from_string, from_defaults
+      procedure, private :: from_defaults => atomlist_defaults
+      procedure, private :: from_integers => atomlist_assign_integers
+      procedure, private :: from_logicals => atomlist_assign_logicals
+      procedure, private :: from_string => atomlist_assign_string
+      procedure, pass(self) :: to_string => string_assign_atomlist
+      procedure, pass(self) :: to_list => list_assign_atomlist
+      procedure :: switch_truth => atomlist_switch_truth
+      procedure :: set_truth => atomlist_set_truth
+      procedure :: get_truth => atomlist_get_truth
+      procedure :: get_error => atomlist_get_error
+      generic :: remove => remove_integer, remove_integers, remove_logicals
+      procedure, private :: remove_integer => atomlist_remove_integer
+      procedure, private :: remove_integers => atomlist_remove_integers
+      procedure, private :: remove_logicals => atomlist_remove_logicals
+      generic :: add => add_integer, add_integers, add_logicals, add_string
+      procedure, private :: add_integer => atomlist_add_integer
+      procedure, private :: add_integers => atomlist_add_integers
+      procedure, private :: add_logicals => atomlist_add_logicals
+      procedure, private :: add_string => atomlist_assign_string
+      procedure, private :: parse => atomlist_parse_string
+      procedure :: resize => atomlist_resize
+      generic :: gather => gather_int, gather_real, gather_real_2d
+      procedure, private :: gather_int => atomlist_gather_int
+      procedure, private :: gather_real => atomlist_gather_real
+      procedure, private :: gather_real_2d => atomlist_gather_real_2d
+      generic :: scatter => scatter_real_2d
+      procedure, private :: scatter_real_2d => atomlist_scatter_real_2d
+      procedure :: destroy => atomlist_destroy
+      final :: atomlist_finalizer
+   end type tb_atomlist
+
+   interface tb_atomlist
+      module procedure :: atomlist_from_logicals
+      module procedure :: atomlist_from_integers
+      module procedure :: atomlist_from_string
+   end interface tb_atomlist
+
+   interface len
+      module procedure :: atomlist_length
+   end interface len
+
+   interface size
+      module procedure :: atomlist_size
+   end interface size
+
+   interface assignment(=)
+      module procedure :: atomlist_assign_logicals
+      module procedure :: atomlist_assign_integers
+      module procedure :: atomlist_assign_string
+      module procedure :: string_assign_atomlist
+      module procedure :: list_assign_atomlist
+   end interface assignment(=)
+
+   interface write(formatted)
+      module procedure :: atomlist_write_formatted
+   end interface write(formatted)
+
+   interface read(formatted)
+      module procedure :: atomlist_read_formatted
+   end interface read(formatted)
+
+contains
+
+pure function atomlist_from_logicals(list, truth, delimiter, skip) result(self)
+   logical, intent(in) :: list(:)
+   logical, intent(in), optional :: truth
+   character, intent(in), optional :: delimiter, skip
+   type(tb_atomlist) :: self
+   if (present(truth)) self%default = .not.truth
+   if (present(delimiter)) self%delimiter = delimiter
+   if (present(skip)) self%skip = skip
+   call self%new(list)
+end function atomlist_from_logicals
+
+pure function atomlist_from_integers(list, truth, delimiter, skip) result(self)
+   integer, intent(in) :: list(:)
+   logical, intent(in), optional :: truth
+   character, intent(in), optional :: delimiter, skip
+   type(tb_atomlist) :: self
+   if (present(truth)) self%default = .not.truth
+   if (present(delimiter)) self%delimiter = delimiter
+   if (present(skip)) self%skip = skip
+   call self%new(list)
+end function atomlist_from_integers
+
+pure function atomlist_from_string(list, truth, delimiter, skip) result(self)
+   character(len=*), intent(in) :: list
+   logical, intent(in), optional :: truth
+   character, intent(in), optional :: delimiter, skip
+   type(tb_atomlist) :: self
+   if (present(truth)) self%default = .not.truth
+   if (present(delimiter)) self%delimiter = delimiter
+   if (present(skip)) self%skip = skip
+   call self%new(list)
+end function atomlist_from_string
+
+pure elemental subroutine atomlist_defaults(self)
+   class(tb_atomlist), intent(out) :: self
+end subroutine atomlist_defaults
+
+pure elemental subroutine atomlist_switch_truth(self)
+   class(tb_atomlist), intent(inout) :: self
+   self%default = .not.self%default
+end subroutine atomlist_switch_truth
+
+pure elemental subroutine atomlist_set_truth(self, truth)
+   class(tb_atomlist), intent(inout) :: self
+   logical, intent(in) :: truth
+   self%default = .not.truth
+end subroutine atomlist_set_truth
+
+pure elemental function atomlist_get_truth(self) result(truth)
+   class(tb_atomlist), intent(in) :: self
+   logical :: truth
+   truth = .not.self%default
+end function atomlist_get_truth
+
+pure elemental function atomlist_get_error(self) result(error)
+   class(tb_atomlist), intent(in) :: self
+   logical :: error
+   error = self%error
+end function atomlist_get_error
+
+subroutine atomlist_write_formatted(self, unit, iotype, v_list, iostat, iomsg)
+   class(tb_atomlist), intent(in) :: self
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: iotype
+   integer, intent(in) :: v_list(:)
+   integer, intent(out) :: iostat
+   character(len=*), intent(inout) :: iomsg
+   character(len=:), allocatable :: buffer
+   call self%to_string(buffer)
+   write(unit, '(a)', iostat=iostat, iomsg=iomsg) buffer
+end subroutine atomlist_write_formatted
+
+subroutine atomlist_read_formatted(self, unit, iotype, v_list, iostat, iomsg)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: iotype
+   integer, intent(in) :: v_list(:)
+   integer, intent(out) :: iostat
+   character(len=*), intent(inout) :: iomsg
+   character(len=:), allocatable :: string
+
+   call get_line(unit, string, iostat)
+   call self%new(string)
+
+contains
+
+subroutine get_line(unit, line, iostat)
+   use iso_fortran_env, only : iostat_eor
+   integer, intent(in) :: unit
+   character(len=:), allocatable, intent(out) :: line
+   integer, intent(out), optional :: iostat
+
+   integer, parameter :: buffersize = 256
+   character(len=buffersize) :: buffer
+   integer :: size
+   integer :: err
+
+   line = ''
+   do
+      read(unit,'(a)',advance='no',iostat=err,size=size)  &
+      &    buffer
+      if (err.gt.0) then
+         if (present(iostat)) iostat=err
+         return ! an error occurred
+      endif
+      line = line // buffer(:size)
+      if (err.lt.0) then
+         if (err.eq.iostat_eor) err = 0
+         if (present(iostat)) iostat=err
+         return
+      endif
+   enddo
+
+end subroutine get_line
+end subroutine atomlist_read_formatted
+
+integer pure elemental function atomlist_size(self)
+   class(tb_atomlist), intent(in) :: self
+   if (allocated(self%list)) then
+      atomlist_size = size(self%list)
+   else
+      atomlist_size = 0
+   endif
+end function atomlist_size
+
+integer pure elemental function atomlist_length(self)
+   class(tb_atomlist), intent(in) :: self
+   if (allocated(self%list)) then
+      atomlist_length = count(self%list.neqv.self%default)
+   else
+      atomlist_length = 0
+   endif
+end function atomlist_length
+
+pure subroutine atomlist_add_integer(self, item)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: item
+   integer :: i
+   call self%resize(item)
+   self%list(item) = .not.self%default
+end subroutine atomlist_add_integer
+
+pure subroutine atomlist_add_integers(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: list(:)
+   integer :: i
+   call self%resize(maxval(list))
+   do i = 1, size(list)
+      self%list(list(i)) = .not.self%default
+   enddo
+end subroutine atomlist_add_integers
+
+pure subroutine atomlist_add_logicals(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   logical, intent(in) :: list(:)
+   integer :: i
+   call self%resize(size(list))
+   self%list(:size(list)) = list .or. self%list(:size(list))
+end subroutine atomlist_add_logicals
+
+pure subroutine atomlist_remove_integer(self, item)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: item
+   integer :: i
+   call self%resize(item)
+   self%list(item) = self%default
+end subroutine atomlist_remove_integer
+
+pure subroutine atomlist_remove_integers(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: list(:)
+   integer :: i
+   call self%resize(maxval(list))
+   do i = 1, size(list)
+      self%list(list(i)) = self%default
+   enddo
+end subroutine atomlist_remove_integers
+
+pure subroutine atomlist_remove_logicals(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   logical, intent(in) :: list(:)
+   integer :: i
+   call self%resize(size(list))
+   self%list(:size(list)) = list .and. self%list(:size(list))
+end subroutine atomlist_remove_logicals
+
+pure subroutine list_assign_atomlist(list, self)
+   integer, allocatable, intent(out) :: list(:)
+   class(tb_atomlist), intent(in) :: self
+   integer :: i, j
+   allocate(list(len(self)), source=0)
+   j = 0
+   do i = 1, size(self)
+      if (self%list(i).neqv.self%default) then
+         j = j+1
+         list(j) = i
+      endif
+   enddo
+end subroutine list_assign_atomlist
+
+pure subroutine string_assign_atomlist(string, self)
+   character(len=:), allocatable, intent(out) :: string
+   class(tb_atomlist), intent(in) :: self
+   character(len=10) :: buffer
+   integer :: i, last
+   logical :: state, first
+   last = -1
+   first = .true.
+   state = .not.self%default
+   do i = 1, size(self)
+      if (state.eqv.self%list(i)) then
+         state = .not.state
+         if (state.eqv.self%default) then
+            last = i
+            write(buffer,'(i0)') i
+            if (first) then
+               first = .false.
+               string = trim(buffer)
+            else
+               string = string // self%delimiter // trim(buffer)
+            endif
+         else
+            if (i-1 .ne. last) then
+               write(buffer,'(i0)') i-1
+               string = string // self%skip // trim(buffer)
+            endif
+         endif
+      endif
+   enddo
+   if (state.eqv.self%default .and.last.ne.size(self)) then
+      write(buffer,'(i0)') size(self)
+      string = string // self%skip // trim(buffer)
+   endif
+end subroutine string_assign_atomlist
+
+pure subroutine atomlist_assign_logicals(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   logical, intent(in) :: list(:)
+   call self%resize(size(list))
+   self%list = list
+end subroutine atomlist_assign_logicals
+
+pure subroutine atomlist_assign_integers(self, list)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in) :: list(:)
+   integer :: i
+   call self%resize(maxval(list))
+   do i = 1, size(list)
+      self%list(list(i)) = .not.self%default
+   enddo
+end subroutine atomlist_assign_integers
+
+pure subroutine atomlist_assign_string(self, string)
+   class(tb_atomlist), intent(inout) :: self
+   character(len=*), intent(in) :: string
+   character(len=:), allocatable :: buffer
+   integer, allocatable :: list(:)
+   integer :: pos, last, n
+
+   last = 0
+   do
+      pos = index(string(last+1:), self%delimiter)
+      if (pos > 0) then
+         call self%parse(string(last+1:last+pos-1))
+         if (self%error) exit
+         last = last+pos
+      else
+         call self%parse(string(last+1:))
+         exit
+      endif
+   enddo
+
+end subroutine atomlist_assign_string
+
+pure subroutine atomlist_parse_string(self, string)
+   class(tb_atomlist), intent(inout) :: self
+   character(len=*),intent(in) :: string
+   integer :: pos, item, begin, last, err
+
+   pos = index(string,self%skip)
+   if (pos.eq.0) then
+      read(string,*,iostat=err) item
+      if (err.ne.0) then
+         self%error = .false.
+         return
+      endif
+      call self%add(item)
+   else
+      read(string(:pos-1),*,iostat=err) begin
+      if (err.ne.0) then
+         self%error = .false.
+         return
+      endif
+      read(string(pos+1:),*,iostat=err) last
+      if (err.ne.0) then
+         self%error = .false.
+         return
+      endif
+      if (last.lt.begin) then
+         self%error = .false.
+         return
+      endif
+      do item = begin, last
+         call self%add(item)
+      enddo
+   endif
+
+end subroutine atomlist_parse_string
+
+pure subroutine atomlist_resize(self, n)
+   class(tb_atomlist), intent(inout) :: self
+   integer, intent(in), optional :: n
+   logical, allocatable :: list(:)
+   integer :: length, current_length
+   current_length = size(self)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(list(length), source=self%default)
+      list(:current_length) = self%list(:current_length)
+      deallocate(self%list)
+      call move_alloc(list, self%list)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(self%list(length), source=self%default)
+   endif
+end subroutine atomlist_resize
+
+subroutine atomlist_gather_int(self, array, selected)
+   class(tb_atomlist), intent(in) :: self
+   integer, intent(in) :: array(:)
+   integer, allocatable, intent(out) :: selected(:)
+   selected = pack(array, mask=self%list.neqv.self%default)
+end subroutine atomlist_gather_int
+
+subroutine atomlist_gather_real(self, array, selected)
+   class(tb_atomlist), intent(in) :: self
+   real(wp), intent(in) :: array(:)
+   real(wp), allocatable, intent(out) :: selected(:)
+   selected = pack(array, mask=self%list.neqv.self%default)
+end subroutine atomlist_gather_real
+
+subroutine atomlist_gather_real_2d(self, array, selected, dim)
+   class(tb_atomlist), intent(in) :: self
+   real(wp), intent(in) :: array(:,:)
+   integer, intent(in), optional :: dim
+   real(wp), allocatable, intent(out) :: selected(:,:)
+   integer :: selected_dim, i, j
+   if (present(dim)) then
+      selected_dim = dim
+   else
+      selected_dim = 2
+   endif
+   if (selected_dim == 1) then
+      allocate(selected(len(self), size(array, 2)), source=0.0_wp)
+      j = 0
+      do i = 1, min(size(array, 1), size(self))
+         if (self%list(i).neqv.self%default) then
+            j = j+1
+            selected(j,:) = array(i,:)
+         endif
+      enddo
+   else
+      allocate(selected(size(array, 1), len(self)), source=0.0_wp)
+      j = 0
+      do i = 1, min(size(array, 2), size(self))
+         if (self%list(i).neqv.self%default) then
+            j = j+1
+            selected(:,j) = array(:,i)
+         endif
+      enddo
+   endif
+end subroutine atomlist_gather_real_2d
+
+subroutine atomlist_scatter_real_2d(self, reduced, array, dim, scale)
+   class(tb_atomlist), intent(in) :: self
+   real(wp), intent(inout) :: array(:,:)
+   integer, intent(in), optional :: dim
+   real(wp), intent(in), optional :: scale
+   real(wp), intent(in) :: reduced(:,:)
+   integer :: selected_dim, i, j
+   real(wp) :: alpha
+   if (present(dim)) then
+      selected_dim = dim
+   else
+      selected_dim = 2
+   endif
+   if (present(scale)) then
+      alpha = scale
+   else
+      alpha = 0.0_wp
+   endif
+   if (selected_dim == 1) then
+      j = 0
+      do i = 1, min(size(array, 1), size(self))
+         if (self%list(i).neqv.self%default) then
+            j = j+1
+            array(i,:) = reduced(j,:) + alpha * array(i,:)
+         endif
+      enddo
+   else
+      j = 0
+      do i = 1, min(size(array, 2), size(self))
+         if (self%list(i).neqv.self%default) then
+            j = j+1
+            array(:,i) = reduced(:,j) + alpha * array(:,i)
+         endif
+      enddo
+   endif
+end subroutine atomlist_scatter_real_2d
+
+pure elemental subroutine atomlist_destroy(self)
+   class(tb_atomlist), intent(inout) :: self
+   if (allocated(self%list)) deallocate(self%list)
+end subroutine atomlist_destroy
+
+pure elemental subroutine atomlist_finalizer(self)
+   type(tb_atomlist), intent(inout) :: self
+   call self%destroy
+end subroutine atomlist_finalizer
+
+end module tbdef_atomlist


### PR DESCRIPTION
- [x] new class for handling list of atoms
  - [x] easy interface between standard list (input and output)
  - [x] derived type IO (`read` & `write`)
  - [x] use in IO `fix` and `contr` block for user data (maybe also `metadyn`, etc)
  - [x] implement `gather` and `scatter` functions for atom list
  - ~replace all lists with atom lists~
  - [x] write user data in copy mode using atom lists
- [x] fixes doubled entries and unsorted list
- [x] identical storage requirements (all lists are currently allocated with `nat` as size)