### PR TITLE
New IO routines for molecular structure information

### DIFF
--- a/TESTSUITE/geometry_reader.f90
+++ b/TESTSUITE/geometry_reader.f90
@@ -359,3 +359,430 @@ subroutine test_geometry_reader_file_coord_C_1d
 
 end subroutine test_geometry_reader_file_coord_C_1D
 
+subroutine test_geometry_reader_molfile_benzen_flat
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_mol_benzen_2d = '(/,&
+      & "  Mrv1823 10191918342D          ",/,/,&
+      & " 12 12  0  0  0  0            999 V2000",/,&
+      & "    1.0868    1.0574    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.3723    1.4699    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.0868    0.2324    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.3421    1.0574    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.3723   -0.1801    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.3421    0.2324    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.8013    1.4699    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.3723    2.2949    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.8013   -0.1801    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -1.0566    1.4699    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.3723   -1.0051    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -1.0566   -0.1801    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "  2  1  2  0  0  0  0",/,&
+      & "  3  1  1  0  0  0  0",/,&
+      & "  4  2  1  0  0  0  0",/,&
+      & "  5  3  2  0  0  0  0",/,&
+      & "  6  4  2  0  0  0  0",/,&
+      & "  6  5  1  0  0  0  0",/,&
+      & "  1  7  1  0  0  0  0",/,&
+      & "  2  8  1  0  0  0  0",/,&
+      & "  3  9  1  0  0  0  0",/,&
+      & "  4 10  1  0  0  0  0",/,&
+      & "  5 11  1  0  0  0  0",/,&
+      & "  6 12  1  0  0  0  0",/,&
+      & "M  END")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_mol_benzen_2d)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%molfile)
+
+   call terminate(0) ! should fail
+end subroutine
+
+subroutine test_geometry_reader_molfile_benzen
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_mol_benzen = '(/,&
+      & "  Mrv1823 10191918163D          ",/,/,&
+      & " 12 12  0  0  0  0            999 V2000",/,&
+      & "   -0.0090   -0.0157   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.7131    1.2038   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.3990   -0.0157   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.0090    2.4232   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    2.1031    1.2038   -0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.3990    2.4232    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.5203   -0.9011   -0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -1.7355    1.2038    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.9103   -0.9011    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.5203    3.3087    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    3.1255    1.2038    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    1.9103    3.3087   -0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "  2  1  4  0  0  0  0",/,&
+      & "  3  1  4  0  0  0  0",/,&
+      & "  4  2  4  0  0  0  0",/,&
+      & "  5  3  4  0  0  0  0",/,&
+      & "  6  4  4  0  0  0  0",/,&
+      & "  6  5  4  0  0  0  0",/,&
+      & "  1  7  1  0  0  0  0",/,&
+      & "  2  8  1  0  0  0  0",/,&
+      & "  3  9  1  0  0  0  0",/,&
+      & "  4 10  1  0  0  0  0",/,&
+      & "  5 11  1  0  0  0  0",/,&
+      & "  6 12  1  0  0  0  0",/,&
+      & "M  END")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_mol_benzen)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%molfile)
+
+   call assert_eq(len(mol), 12)
+   call assert_eq(len(mol%bonds), 12)
+   call assert_eq(len(mol%info), 0)
+
+   call assert_close(mol%xyz(1,1), -0.17007533543675E-01_wp, thr)
+   call assert_close(mol%xyz(2,8), 2.2748520977640_wp, thr)
+
+   call terminate(afail)
+end subroutine
+
+subroutine test_geometry_reader_file_sdf_h2o
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_sdf_h2o = '(&
+      & "962",/,&
+      & "  Marvin  12300703363D          ",/,&
+      & "",/,&
+      & "  3  2  0  0  0  0            999 V2000",/,&
+      & "   -0.2309   -0.3265    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.7484   -0.2843    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.5175    0.6108    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "  1  2  1  0  0  0  0",/,&
+      & "  1  3  1  0  0  0  0",/,&
+      & "M  END",/,&
+      & "",/,&
+      & "> <StdInChI>",/,&
+      & "InChI=1S/H2O/h1H2",/,&
+      & "",/,&
+      & "> <StdInChIKey>",/,&
+      & "XLYOFNOQVPJJNP-UHFFFAOYSA-N",/,&
+      & "",/,&
+      & "> <AuxInfo>",/,&
+      & "1/0/N:1/rA:3nOHH/rB:s1;s1;/rC:-.2309,-.3265,0;.7484,-.2843,0;-.5175,.6108,0;",/,&
+      & "",/,&
+      & "> <Formula>",/,&
+      & "H2 O",/,&
+      & "",/,&
+      & "> <Mw>",/,&
+      & "18.01528",/,&
+      & "",/,&
+      & "> <SMILES>",/,&
+      & "O([H])[H]",/,&
+      & "",/,&
+      & "> <CSID>",/,&
+      & "937",/,&
+      & "",/,&
+      & "$$$$")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_sdf_h2o)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%sdf)
+
+   call assert_eq(len(mol), 3)
+   call assert_eq(len(mol%bonds), 2)
+   call assert_eq(len(mol%info), 22)
+
+   call assert_close(mol%xyz(1,1), -0.43633772169273_wp, thr)
+
+   call terminate(afail)
+end subroutine
+
+subroutine test_geometry_reader_file_sdf_benzen_hquery
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_sdf_benzen = '(&
+      & "benzen",/,&
+      & "  xtb     10301913453D",/,&
+      & "",/,&
+      & "  6  6  0  0  0  0  0  0  0  0999 V2000",/,&
+      & "   -0.0090   -0.0157    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "   -0.7131    1.2038    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "    1.3990   -0.0157    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "   -0.0090    2.4232    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "    2.1031    1.2038    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "    1.3990    2.4232    0.0000 C   0  0  0  2  0  0  0  0  0  0  0  0",/,&
+      & "  1  2  4  0  0  0  0",/,&
+      & "  1  3  4  0  0  0  0",/,&
+      & "  2  4  4  0  0  0  0",/,&
+      & "  3  5  4  0  0  0  0",/,&
+      & "  4  6  4  0  0  0  0",/,&
+      & "  5  6  4  0  0  0  0",/,&
+      & "M  END",/,&
+      & "$$$$")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_sdf_benzen)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%sdf)
+
+   call terminate(0) ! should fail
+end subroutine
+
+subroutine test_geometry_reader_file_sdf_h2o_flat
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_sdf_h2o = '(&
+      & "water",/,&
+      & "  xtb     10301913452D          ",/,&
+      & "",/,&
+      & "  3  2  0  0  0  0            999 V2000",/,&
+      & "   -0.2309   -0.3265    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "    0.7484   -0.2843    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "   -0.5175    0.6108    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0",/,&
+      & "  1  2  1  0  0  0  0",/,&
+      & "  1  3  1  0  0  0  0",/,&
+      & "M  END",/,&
+      & "> <SMILES>",/,&
+      & "O([H])[H]",/,&
+      & "",/,&
+      & "$$$$")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_sdf_h2o)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%sdf)
+
+   call terminate(0) ! should fail
+end subroutine
+
+subroutine test_geometry_reader_file_pdb_4qxx_noh
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_pdb_4qxx_p1 = '(&
+      & "HEADER    PROTEIN FIBRIL                          22-JUL-14   4QXX",/,&
+      & "TITLE     STRUCTURE OF THE AMYLOID FORMING PEPTIDE GNLVS (RESIDUES 26-30) FROM",/,&
+      & "TITLE    2 THE EOSINOPHIL MAJOR BASIC PROTEIN (EMBP)",/,&
+      & "DBREF  4QXX Z    1     5  UNP    P13727   PRG2_HUMAN     131    135",/,&
+      & "SEQRES   1 Z    5  GLY ASN LEU VAL SER",/,&
+      & "FORMUL   2  HOH   *2(H2 O)",/,&
+      & "CRYST1    4.755   16.816   35.759  90.00  90.00  90.00 P 2 21 21     4",/,&
+      & "ORIGX1      1.000000  0.000000  0.000000        0.00000",/,&
+      & "ORIGX2      0.000000  1.000000  0.000000        0.00000",/,&
+      & "ORIGX3      0.000000  0.000000  1.000000        0.00000",/,&
+      & "SCALE1      0.210305  0.000000  0.000000        0.00000",/,&
+      & "SCALE2      0.000000  0.059467  0.000000        0.00000",/,&
+      & "SCALE3      0.000000  0.000000  0.027965        0.00000",/,&
+      & "ATOM      1  N   GLY Z   1      -0.821  -2.072  16.609  1.00  9.93           N",/,&
+      & "ATOM      2  CA  GLY Z   1      -1.705  -2.345  15.487  1.00  7.38           C",/,&
+      & "ATOM      3  C   GLY Z   1      -0.968  -3.008  14.344  1.00  4.89           C",/,&
+      & "ATOM      4  O   GLY Z   1       0.258  -2.982  14.292  1.00  5.05           O",/,&
+      & "ATOM      5  N   ASN Z   2      -1.721  -3.603  13.425  1.00  3.53           N",/,&
+      & "ATOM      6  CA  ASN Z   2      -1.141  -4.323  12.291  1.00  1.85           C",/,&
+      & "ATOM      7  C   ASN Z   2      -1.748  -3.900  10.968  1.00  3.00           C",/,&
+      & "ATOM      8  O   ASN Z   2      -2.955  -3.683  10.873  1.00  3.99           O",/,&
+      & "ATOM      9  CB  ASN Z   2      -1.353  -5.827  12.446  1.00  5.03           C",/,&
+      & "ATOM     10  CG  ASN Z   2      -0.679  -6.391  13.683  1.00  5.08           C",/,&
+      & "ATOM     11  OD1 ASN Z   2       0.519  -6.202  13.896  1.00  6.10           O",/,&
+      & "ATOM     12  ND2 ASN Z   2      -1.448  -7.087  14.506  1.00  8.41           N")'
+   character(len=*),parameter :: file_pdb_4qxx_p2 = '(&
+      & "ATOM     13  N   LEU Z   3      -0.907  -3.803   9.944  1.00  3.47           N",/,&
+      & "ATOM     14  CA  LEU Z   3      -1.388  -3.576   8.586  1.00  3.48           C",/,&
+      & "ATOM     15  C   LEU Z   3      -0.783  -4.660   7.709  1.00  3.29           C",/,&
+      & "ATOM     16  O   LEU Z   3       0.437  -4.788   7.643  1.00  3.80           O",/,&
+      & "ATOM     17  CB  LEU Z   3      -0.977  -2.185   8.081  1.00  3.88           C",/,&
+      & "ATOM     18  CG  LEU Z   3      -1.524  -1.669   6.736  1.00  8.66           C",/,&
+      & "ATOM     19  CD1 LEU Z   3      -1.225  -0.191   6.570  1.00  9.89           C")'
+   character(len=*),parameter :: file_pdb_4qxx_p3 = '(&
+      & "ATOM     20  CD2 LEU Z   3      -0.962  -2.409   5.541  1.00 13.56           C",/,&
+      & "ATOM     21  N   VAL Z   4      -1.635  -5.424   7.029  1.00  3.17           N",/,&
+      & "ATOM     22  CA  VAL Z   4      -1.165  -6.460   6.119  1.00  3.61           C",/,&
+      & "ATOM     23  C   VAL Z   4      -1.791  -6.230   4.755  1.00  5.31           C",/,&
+      & "ATOM     24  O   VAL Z   4      -3.014  -6.209   4.620  1.00  7.31           O",/,&
+      & "ATOM     25  CB  VAL Z   4      -1.567  -7.872   6.593  1.00  5.31           C",/,&
+      & "ATOM     26  CG1 VAL Z   4      -1.012  -8.934   5.633  1.00  6.73           C",/,&
+      & "ATOM     27  CG2 VAL Z   4      -1.083  -8.120   8.018  1.00  5.48           C",/,&
+      & "ATOM     28  N   SER Z   5      -0.966  -6.052   3.736  1.00  7.53           N",/,&
+      & "ATOM     29  CA  SER Z   5      -1.526  -5.888   2.407  1.00 11.48           C",/,&
+      & "ATOM     30  C   SER Z   5      -1.207  -7.085   1.529  1.00 16.35           C",/,&
+      & "ATOM     31  O   SER Z   5      -0.437  -7.976   1.902  1.00 14.00           O",/,&
+      & "ATOM     32  CB  SER Z   5      -1.031  -4.596   1.767  1.00 13.36           C",/,&
+      & "ATOM     33  OG  SER Z   5       0.361  -4.652   1.540  1.00 15.80           O",/,&
+      & "ATOM     34  OXT SER Z   5      -1.737  -7.178   0.429  1.00 17.09           O",/,&
+      & "TER      35      SER Z   5",/,&
+      & "HETATM   36  O   HOH Z 101       0.935  -5.175  16.502  1.00 18.83           O",/,&
+      & "HETATM   37  O  AHOH Z 102       0.691  -8.408  17.879  0.91 56.55           O",/,&
+      & "HETATM   38  O  BHOH Z 102      -0.788  -9.006  16.641  0.09 38.95           O",/,&
+      & "END")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_pdb_4qxx_p1)
+   write(iunit, file_pdb_4qxx_p2)
+   write(iunit, file_pdb_4qxx_p3)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%pdb)
+
+   call terminate(0) ! should fail
+end subroutine
+
+
+subroutine test_geometry_reader_file_pdb_4qxx
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use assertion
+   use tbmod_file_utils
+   real(wp),parameter :: thr = 1.0e-9_wp
+   character(len=*),parameter :: file_pdb_4qxx_p1 = '(&
+      & "HEADER    PROTEIN FIBRIL                          22-JUL-14   4QXX",/,&
+      & "TITLE     STRUCTURE OF THE AMYLOID FORMING PEPTIDE GNLVS (RESIDUES 26-30) FROM",/,&
+      & "TITLE    2 THE EOSINOPHIL MAJOR BASIC PROTEIN (EMBP)",/,&
+      & "DBREF  4QXX Z    1     5  UNP    P13727   PRG2_HUMAN     131    135",/,&
+      & "SEQRES   1 Z    5  GLY ASN LEU VAL SER",/,&
+      & "FORMUL   2  HOH   *2(H2 O)",/,&
+      & "CRYST1    4.755   16.816   35.759  90.00  90.00  90.00 P 2 21 21     4",/,&
+      & "ORIGX1      1.000000  0.000000  0.000000        0.00000",/,&
+      & "ORIGX2      0.000000  1.000000  0.000000        0.00000",/,&
+      & "ORIGX3      0.000000  0.000000  1.000000        0.00000",/,&
+      & "SCALE1      0.210305  0.000000  0.000000        0.00000",/,&
+      & "SCALE2      0.000000  0.059467  0.000000        0.00000",/,&
+      & "SCALE3      0.000000  0.000000  0.027965        0.00000",/,&
+      & "ATOM      1  N   GLY Z   1      -0.821  -2.072  16.609  1.00  9.93           N",/,&
+      & "ATOM      2  CA  GLY Z   1      -1.705  -2.345  15.487  1.00  7.38           C",/,&
+      & "ATOM      3  C   GLY Z   1      -0.968  -3.008  14.344  1.00  4.89           C",/,&
+      & "ATOM      4  O   GLY Z   1       0.258  -2.982  14.292  1.00  5.05           O",/,&
+      & "ATOM      5  HA2 GLY Z   1      -2.130  -1.405  15.135  1.00  0.00           H",/,&
+      & "ATOM      6  HA3 GLY Z   1      -2.511  -2.999  15.819  1.00  0.00           H",/,&
+      & "ATOM      7  H1  GLY Z   1      -1.364  -1.742  17.394  1.00  0.00           H",/,&
+      & "ATOM      8  H2  GLY Z   1      -0.150  -1.365  16.344  1.00  0.00           H",/,&
+      & "ATOM      9  H3  GLY Z   1      -0.334  -2.918  16.868  1.00  0.00           H")'
+   character(len=*),parameter :: file_pdb_4qxx_p2 = '(&
+      & "ATOM     10  N   ASN Z   2      -1.721  -3.603  13.425  1.00  3.53           N",/,&
+      & "ATOM     11  CA  ASN Z   2      -1.141  -4.323  12.291  1.00  1.85           C",/,&
+      & "ATOM     12  C   ASN Z   2      -1.748  -3.900  10.968  1.00  3.00           C",/,&
+      & "ATOM     13  O   ASN Z   2      -2.955  -3.683  10.873  1.00  3.99           O",/,&
+      & "ATOM     14  CB  ASN Z   2      -1.353  -5.827  12.446  1.00  5.03           C",/,&
+      & "ATOM     15  CG  ASN Z   2      -0.679  -6.391  13.683  1.00  5.08           C",/,&
+      & "ATOM     16  OD1 ASN Z   2       0.519  -6.202  13.896  1.00  6.10           O",/,&
+      & "ATOM     17  ND2 ASN Z   2      -1.448  -7.087  14.506  1.00  8.41           N",/,&
+      & "ATOM     18  H   ASN Z   2      -2.726  -3.557  13.512  1.00  0.00           H",/,&
+      & "ATOM     19  HA  ASN Z   2      -0.070  -4.123  12.263  1.00  0.00           H",/,&
+      & "ATOM     20  HB2 ASN Z   2      -0.945  -6.328  11.568  1.00  0.00           H",/,&
+      & "ATOM     21  HB3 ASN Z   2      -2.423  -6.029  12.503  1.00  0.00           H",/,&
+      & "ATOM     22 HD21 ASN Z   2      -2.427  -7.218  14.293  1.00  0.00           H",/,&
+      & "ATOM     23 HD22 ASN Z   2      -1.056  -7.487  15.346  1.00  0.00           H",/,&
+      & "ATOM     24  N   LEU Z   3      -0.907  -3.803   9.944  1.00  3.47           N",/,&
+      & "ATOM     25  CA  LEU Z   3      -1.388  -3.576   8.586  1.00  3.48           C",/,&
+      & "ATOM     26  C   LEU Z   3      -0.783  -4.660   7.709  1.00  3.29           C",/,&
+      & "ATOM     27  O   LEU Z   3       0.437  -4.788   7.643  1.00  3.80           O",/,&
+      & "ATOM     28  CB  LEU Z   3      -0.977  -2.185   8.081  1.00  3.88           C",/,&
+      & "ATOM     29  CG  LEU Z   3      -1.524  -1.669   6.736  1.00  8.66           C",/,&
+      & "ATOM     30  CD1 LEU Z   3      -1.225  -0.191   6.570  1.00  9.89           C",/,&
+      & "ATOM     31  CD2 LEU Z   3      -0.962  -2.409   5.541  1.00 13.56           C",/,&
+      & "ATOM     32  H   LEU Z   3       0.086  -3.888  10.109  1.00  0.00           H",/,&
+      & "ATOM     33  HA  LEU Z   3      -2.475  -3.661   8.568  1.00  0.00           H",/,&
+      & "ATOM     34  HB2 LEU Z   3      -1.284  -1.469   8.843  1.00  0.00           H",/,&
+      & "ATOM     35  HB3 LEU Z   3       0.111  -2.162   8.026  1.00  0.00           H",/,&
+      & "ATOM     36  HG  LEU Z   3      -2.606  -1.798   6.737  1.00  0.00           H",/,&
+      & "ATOM     37 HD11 LEU Z   3      -1.623   0.359   7.423  1.00  0.00           H",/,&
+      & "ATOM     38 HD12 LEU Z   3      -1.691   0.173   5.654  1.00  0.00           H",/,&
+      & "ATOM     39 HD13 LEU Z   3      -0.147  -0.043   6.513  1.00  0.00           H",/,&
+      & "ATOM     40 HD21 LEU Z   3      -1.168  -3.475   5.643  1.00  0.00           H",/,&
+      & "ATOM     41 HD22 LEU Z   3      -1.429  -2.035   4.630  1.00  0.00           H",/,&
+      & "ATOM     42 HD23 LEU Z   3       0.115  -2.250   5.489  1.00  0.00           H")'
+   character(len=*),parameter :: file_pdb_4qxx_p3 = '(&
+      & "ATOM     43  N   VAL Z   4      -1.635  -5.424   7.029  1.00  3.17           N",/,&
+      & "ATOM     44  CA  VAL Z   4      -1.165  -6.460   6.119  1.00  3.61           C",/,&
+      & "ATOM     45  C   VAL Z   4      -1.791  -6.230   4.755  1.00  5.31           C",/,&
+      & "ATOM     46  O   VAL Z   4      -3.014  -6.209   4.620  1.00  7.31           O",/,&
+      & "ATOM     47  CB  VAL Z   4      -1.567  -7.872   6.593  1.00  5.31           C",/,&
+      & "ATOM     48  CG1 VAL Z   4      -1.012  -8.934   5.633  1.00  6.73           C",/,&
+      & "ATOM     49  CG2 VAL Z   4      -1.083  -8.120   8.018  1.00  5.48           C",/,&
+      & "ATOM     50  H   VAL Z   4      -2.628  -5.282   7.146  1.00  0.00           H",/,&
+      & "ATOM     51  HA  VAL Z   4      -0.080  -6.402   6.034  1.00  0.00           H",/,&
+      & "ATOM     52  HB  VAL Z   4      -2.655  -7.939   6.585  1.00  0.00           H",/,&
+      & "ATOM     53 HG11 VAL Z   4      -1.303  -9.926   5.980  1.00  0.00           H",/,&
+      & "ATOM     54 HG12 VAL Z   4      -1.414  -8.766   4.634  1.00  0.00           H",/,&
+      & "ATOM     55 HG13 VAL Z   4       0.075  -8.864   5.603  1.00  0.00           H",/,&
+      & "ATOM     56 HG21 VAL Z   4      -1.377  -9.121   8.333  1.00  0.00           H",/,&
+      & "ATOM     57 HG22 VAL Z   4       0.003  -8.032   8.053  1.00  0.00           H",/,&
+      & "ATOM     58 HG23 VAL Z   4      -1.529  -7.383   8.686  1.00  0.00           H",/,&
+      & "ATOM     59  N   SER Z   5      -0.966  -6.052   3.736  1.00  7.53           N",/,&
+      & "ATOM     60  CA  SER Z   5      -1.526  -5.888   2.407  1.00 11.48           C",/,&
+      & "ATOM     61  C   SER Z   5      -1.207  -7.085   1.529  1.00 16.35           C",/,&
+      & "ATOM     62  O   SER Z   5      -0.437  -7.976   1.902  1.00 14.00           O",/,&
+      & "ATOM     63  CB  SER Z   5      -1.031  -4.596   1.767  1.00 13.36           C",/,&
+      & "ATOM     64  OG  SER Z   5       0.361  -4.652   1.540  1.00 15.80           O",/,&
+      & "ATOM     65  OXT SER Z   5      -1.737  -7.178   0.429  1.00 17.09           O",/,&
+      & "ATOM     66  H   SER Z   5       0.033  -6.031   3.880  1.00  0.00           H",/,&
+      & "ATOM     67  HA  SER Z   5      -2.610  -5.822   2.504  1.00  0.00           H",/,&
+      & "ATOM     68  HB2 SER Z   5      -1.543  -4.449   0.816  1.00  0.00           H",/,&
+      & "ATOM     69  HB3 SER Z   5      -1.254  -3.759   2.428  1.00  0.00           H",/,&
+      & "ATOM     70  HG  SER Z   5       0.653  -3.831   1.137  1.00  0.00           H",/,&
+      & "TER      71      SER Z   5")'
+   character(len=*),parameter :: file_pdb_4qxx_p4 = '(&
+      & "HETATM   72  O   HOH Z 101       0.935  -5.175  16.502  1.00 18.83           O",/,&
+      & "HETATM   73  H1  HOH Z 101       0.794  -5.522  15.621  1.00  0.00           H",/,&
+      & "HETATM   74  H2  HOH Z 101       1.669  -4.561  16.489  1.00  0.00           H",/,&
+      & "HETATM   75  O  AHOH Z 102       0.691  -8.408  17.879  0.91 56.55           O",/,&
+      & "HETATM   76  O  BHOH Z 102      -0.788  -9.006  16.641  0.09 38.95           O",/,&
+      & "HETATM   77  H1 AHOH Z 102       1.392  -8.125  18.466  0.91  0.00           H",/,&
+      & "HETATM   78  H1 BHOH Z 102      -1.351  -9.776  16.563  0.09  0.00           H",/,&
+      & "HETATM   79  H2 AHOH Z 102       0.993  -8.356  16.972  0.91  0.00           H",/,&
+      & "HETATM   80  H2 BHOH Z 102      -0.927  -8.594  17.494  0.09  0.00           H",/,&
+      & "END")'
+   integer :: iunit
+   type(tb_molecule) :: mol
+
+   open(newunit=iunit,status='scratch')
+   write(iunit, file_pdb_4qxx_p1)
+   write(iunit, file_pdb_4qxx_p2)
+   write(iunit, file_pdb_4qxx_p3)
+   write(iunit, file_pdb_4qxx_p4)
+   rewind(iunit)
+   call mol%read(iunit, format=p_ftype%pdb)
+
+   call assert(allocated(mol%pdb))
+
+   call assert_eq(len(mol), 79)
+
+   call assert_eq(mol%at(14), 6)
+   call assert_eq(mol%at(42), 1)
+   call assert_eq(mol%at(71), 8)
+
+   call assert_close(mol%xyz(1,3),  -1.8292547189197_wp, thr)
+   call assert_close(mol%xyz(2,21), -11.393157748313_wp, thr)
+   call assert_close(mol%xyz(3,35),  15.166940469059_wp, thr)
+   call assert_close(mol%xyz(1,79), -1.7517759549985_wp, thr)
+
+   call terminate(afail) ! should fail
+end subroutine

--- a/TESTSUITE/geometry_reader.f90
+++ b/TESTSUITE/geometry_reader.f90
@@ -3,7 +3,7 @@ subroutine test_geometry_reader_file_poscar_sio2_3d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-9_wp
    character(len=*),parameter :: file_poscar_sio2_3d = &
       & '("Si  O ",/,&
@@ -25,7 +25,7 @@ subroutine test_geometry_reader_file_poscar_sio2_3d
    open(newunit=iunit,status='scratch')
    write(iunit,file_poscar_sio2_3d)
    rewind(iunit)
-   call read_poscar(iunit,mol)
+   call mol%read(iunit, format=p_ftype%vasp)
 
    call assert_close(mol%volume,       667.92680030347_wp,thr)
    call assert_close(mol%cellpar(1),8.7413053236641_wp,thr)
@@ -51,7 +51,7 @@ subroutine test_geometry_reader_file_xmol_water_0d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
    character(len=*),parameter :: file_xmol_water_0d = &
       & '("9",/,&
@@ -71,7 +71,7 @@ subroutine test_geometry_reader_file_xmol_water_0d
    open(newunit=iunit,status='scratch')
    write(iunit,file_xmol_water_0d)
    rewind(iunit)
-   call read_xmol(iunit,mol)
+   call mol%read(iunit, format=p_ftype%xyz)
 
    call assert_eq(mol%n,9)
 
@@ -91,7 +91,7 @@ subroutine test_geometry_reader_file_coord_general_0d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
    character(len=*),parameter :: file_coord_general_0d_p1 = &
       & '("$coord",/,&
@@ -166,7 +166,7 @@ subroutine test_geometry_reader_file_coord_general_0d
    write(iunit,file_coord_general_0d_p3)
    rewind(iunit)
 
-   call read_coord(iunit,mol)
+   call mol%read(iunit, format=p_ftype%tmol)
 
    call assert(.not.any(mol%pbc))
    call assert_eq(mol%n, 59)
@@ -181,7 +181,7 @@ subroutine test_geometry_reader_file_coord_CaF2_3d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
    character(len=*),parameter :: file_coord_CaF2_3d = &
       & '("$coord frac",/,&
@@ -202,7 +202,7 @@ subroutine test_geometry_reader_file_coord_CaF2_3d
 
    write(iunit,file_coord_CaF2_3d); rewind(iunit)
    ! reads in from cell parameters in bohr and coordinates in bohr
-   call read_coord(iunit,mol)
+   call mol%read(iunit, format=p_ftype%tmol)
 
    call assert(all(mol%pbc))
    call assert_eq(mol%npbc,3)
@@ -233,7 +233,7 @@ subroutine test_geometry_reader_file_coord_CaMgCO_3d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
    character(len=*),parameter :: file_coord_CaMgCO_3d = &
       & '("$cell",/,&
@@ -252,7 +252,7 @@ subroutine test_geometry_reader_file_coord_CaMgCO_3d
 
    write(iunit,file_coord_CaMgCO_3d); rewind(iunit)
    ! reads in from cell parameters in bohr and coordinates in bohr
-   call read_coord(iunit,mol)
+   call mol%read(iunit, format=p_ftype%tmol)
 
    call assert(all(mol%pbc))
    call assert_eq(mol%npbc,3)
@@ -267,7 +267,7 @@ subroutine test_geometry_reader_file_coord_CaMgCO_3d
    call assert_close(mol%rec_lat(3,3),0.206273246164110_wp,thr)
 
    ! this value should get's wrapped back from -7.51993484
-   call assert_close(mol%xyz(1,3),    -0.57949455800000_wp,thr)
+   call assert_close(mol%xyz(1,3),    8.5195367720000_wp,thr)
 
    call mol%deallocate; close(iunit,status='delete')
 
@@ -279,7 +279,7 @@ subroutine test_geometry_reader_file_coord_C_2d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
 
    character(len=*),parameter :: file_coord_C_2d = &
@@ -304,7 +304,7 @@ subroutine test_geometry_reader_file_coord_C_1d
    use iso_fortran_env, wp => real64
    use tbdef_molecule
    use assertion
-   use geometry_reader
+   use tbmod_file_utils
    real(wp),parameter :: thr = 1.0e-10_wp
 
    character(len=*),parameter :: file_coord_C_1d = &

--- a/TESTSUITE/tests_peeq.f90
+++ b/TESTSUITE/tests_peeq.f90
@@ -91,6 +91,13 @@ program peeq_tester
       case('coord_0d');   call test_geometry_reader_file_coord_general_0d
       case('xmol_0d');    call test_geometry_reader_file_xmol_water_0d
       case('poscar_3d');  call test_geometry_reader_file_poscar_sio2_3d
+      case('molfile'); call test_geometry_reader_molfile_benzen
+      case('molfile_flat'); call test_geometry_reader_molfile_benzen_flat
+      case('sdfile'); call test_geometry_reader_file_sdf_h2o
+      case('sdfile_flat'); call test_geometry_reader_file_sdf_h2o_flat
+      case('sdfile_noh'); call test_geometry_reader_file_sdf_benzen_hquery
+      case('pdb'); call test_geometry_reader_file_pdb_4qxx
+      case('pdb_noh'); call test_geometry_reader_file_pdb_4qxx_noh
       end select
    case('pbc_tools')
       select case(sec)

--- a/mctc/mctc_resize_arrays.f90
+++ b/mctc/mctc_resize_arrays.f90
@@ -1,0 +1,128 @@
+module mctc_resize_arrays
+   use iso_fortran_env, only: wp => real64
+   implicit none
+   public :: resize
+   private
+
+   interface resize
+      module procedure :: resize_char
+      module procedure :: resize_int
+      module procedure :: resize_real
+      module procedure :: resize_real_2d
+   end interface resize
+
+contains
+
+subroutine resize_int(var, n)
+   integer, allocatable, intent(inout) :: var(:)
+   integer, intent(in), optional :: n
+   integer, allocatable :: tmp(:)
+   integer :: length, current_length
+   current_length = size(var)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(tmp(length), source=0)
+      tmp(:current_length) = var(:current_length)
+      deallocate(var)
+      call move_alloc(tmp, var)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(var(length), source=0)
+   endif
+end subroutine resize_int
+
+subroutine resize_char(var, n)
+   character(len=*), allocatable, intent(inout) :: var(:)
+   integer, intent(in), optional :: n
+   character(len=:), allocatable :: tmp(:)
+   integer :: length, current_length
+   current_length = size(var)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(tmp(length), mold=var)
+      tmp(:current_length) = var(:current_length)
+      deallocate(var)
+      call move_alloc(tmp, var)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(var(length), source=' ')
+   endif
+end subroutine resize_char
+
+subroutine resize_real(var, n)
+   real(wp), allocatable, intent(inout) :: var(:)
+   integer, intent(in), optional :: n
+   real(wp), allocatable :: tmp(:)
+   integer :: length, order, current_length
+   current_length = size(var)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(tmp(length), source=0.0_wp)
+      tmp(:current_length) = var(:current_length)
+      deallocate(var)
+      call move_alloc(tmp, var)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(var(length), source=0.0_wp)
+   endif
+end subroutine resize_real
+
+subroutine resize_real_2d(var, n)
+   real(wp), allocatable, intent(inout) :: var(:,:)
+   integer, intent(in), optional :: n(2)
+   real(wp), allocatable :: tmp(:,:)
+   integer :: length, order, current_length
+   current_length = size(var, 2)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n(2) <= current_length) return
+         order = n(1)
+         length = n(2)
+      else
+         length = current_length + current_length/2 + 1
+         order = size(var, 1)
+      endif
+      allocate(tmp(order, length), source=0.0_wp)
+      tmp(:, :current_length) = var(:, :current_length)
+      deallocate(var)
+      call move_alloc(tmp, var)
+   else
+      if (present(n)) then
+         order = n(1)
+         length = n(2)
+      else
+         order = 3
+         length = 64
+      endif
+      allocate(var(order,length), source=0.0_wp)
+   endif
+end subroutine resize_real_2d
+
+end module mctc_resize_arrays

--- a/meson.build
+++ b/meson.build
@@ -118,6 +118,7 @@ mctc_srcs += 'mctc/mctc_timings.f90'
 mctc_srcs += 'mctc/mctc_filetools.f90'
 mctc_srcs += 'mctc/mctc_la.f90'
 mctc_srcs += 'mctc/mctc_init.f90'
+mctc_srcs += 'mctc/mctc_resize_arrays.f90'
 mctc_srcs += 'mctc/error.f90'
 mctc_srcs += 'mctc/signal.c'
 

--- a/meson.build
+++ b/meson.build
@@ -139,6 +139,7 @@ xtb_srcs += 'xtb/tbdef_calculator.f90'
 xtb_srcs += 'xtb/tbdef_atomlist.f90'
 xtb_srcs += 'xtb/tbdef_topology.f90'
 xtb_srcs += 'xtb/tbdef_fragments.f90'
+xtb_srcs += 'xtb/tbdef_buffer.f90'
 
 # global data
 xtb_srcs += 'xtb/gfn0param.f90'

--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,7 @@ xtb_srcs += 'xtb/tbdef_options.f90'
 xtb_srcs += 'xtb/tbdef_calculator.f90'
 xtb_srcs += 'xtb/tbdef_atomlist.f90'
 xtb_srcs += 'xtb/tbdef_topology.f90'
+xtb_srcs += 'xtb/tbdef_fragments.f90'
 
 # global data
 xtb_srcs += 'xtb/gfn0param.f90'

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,7 @@ xtb_srcs += 'xtb/tbdef_wsc.f90'
 xtb_srcs += 'xtb/tbdef_options.f90'
 xtb_srcs += 'xtb/tbdef_calculator.f90'
 xtb_srcs += 'xtb/tbdef_atomlist.f90'
+xtb_srcs += 'xtb/tbdef_topology.f90'
 
 # global data
 xtb_srcs += 'xtb/gfn0param.f90'

--- a/meson.build
+++ b/meson.build
@@ -435,6 +435,17 @@ test('Geometry Reader: coord 1D',xtb_test,args: ['geometry_reader','coord_1d'])
 test('Geometry Reader: coord 0D',xtb_test,args: ['geometry_reader','coord_0d'])
 test('Geometry Reader: Xmol  0D',xtb_test,args: ['geometry_reader','xmol_0d'])
 test('Geometry Reader: POSCAR',  xtb_test,args: ['geometry_reader','poscar_3d'])
+test('Geometry Reader: molfile', xtb_test,args: ['geometry_reader','molfile'])
+test('Geometry Reader: molfile flat', xtb_test, should_fail: true,
+     args: ['geometry_reader','molfile_flat'])
+test('Geometry Reader: SDF', xtb_test, args: ['geometry_reader','sdfile'])
+test('Geometry Reader: SDF flat', xtb_test, should_fail: true,
+     args: ['geometry_reader','sdfile_flat'])
+test('Geometry Reader: SDF no H', xtb_test, should_fail: true,
+     args: ['geometry_reader','sdfile_noh'])
+test('Geometry Reader: PDB', xtb_test, args: ['geometry_reader','pdb'])
+test('Geometry Reader: PDB no H', xtb_test, should_fail: true,
+     args: ['geometry_reader','pdb_noh'])
 
 test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'])
 

--- a/meson.build
+++ b/meson.build
@@ -172,6 +172,9 @@ xtb_srcs += 'xtb/gfn_prparam.f90'
 xtb_srcs += 'xtb/wrgbw.f90'
 xtb_srcs += 'xtb/enso_printout.f90'
 xtb_srcs += 'xtb/read_gfn_param.f90'
+xtb_srcs += 'xtb/molecule_reader.f90'
+xtb_srcs += 'xtb/molecule_writer.f90'
+xtb_srcs += 'xtb/tbmod_file_utils.f90'
 
 # parameters
 xtb_srcs += 'xtb/gfn_paramset.f90'

--- a/xtb/dynamic.f90
+++ b/xtb/dynamic.f90
@@ -141,13 +141,13 @@ subroutine md(mol,wfx,calc, &
    use tbdef_calculator
    use tbdef_wavefunction
    use tbdef_data
+   use tbmod_file_utils
    use shake_module, only: do_shake,ncons,xhonly
    use aoparam
    use setparam
    use fixparam
    use scanparam
    use splitparam
-   use write_geometry
    implicit none
    type(tb_molecule),intent(inout) :: mol
    type(tb_wavefunction),intent(inout) :: wfx
@@ -460,7 +460,7 @@ subroutine md(mol,wfx,calc, &
          cdump2=cdump2+1
          call getname1(cdump2,atmp)
          call open_file(ich,trim(atmp),'w')
-         call write_coord(ich,mol%n,mol%at,mol%xyz)
+         call mol%write(ich,format=p_ftype%tmol)
          call close_file(ich)
          cdump=0
       endif
@@ -479,7 +479,7 @@ subroutine md(mol,wfx,calc, &
       ! dump xyz (trj)
       if(ndump.gt.dumpstep-1)then
          ndump=0
-         call write_xyzlog(trj,mol%n,mol%at,mol%xyz,epot,res%gnorm)
+         call mol%write(trj, format=p_ftype%xyz, energy=epot, gnorm=res%gnorm)
          if(velodump)then
             do i=1,mol%n
                write(trj,'(3f20.14)')velo(1:3,i)

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -62,7 +62,7 @@ subroutine read_molecule_xyz(mol, unit, status, iomsg)
 
    conv = aatoau
 
-   rewind(unit)
+   rewind(unit) ! FIXME
 
    read(unit,*,iostat=err) n
    if (err.ne.0) then
@@ -149,7 +149,7 @@ subroutine read_molecule_tmol(mol, unit, status, iomsg)
    natoms = -1
 
 !  we need to read this file twice, for a lot of reasons
-   rewind(unit)
+   rewind(unit) ! FIXME
 
 !  read first line before the readloop starts, I have to do this
 !  to avoid using backspace on unit (dammit Turbomole format)
@@ -204,7 +204,7 @@ subroutine read_molecule_tmol(mol, unit, status, iomsg)
          &                   0.0_wp,0.0_wp,1.0_wp],[3,3])
    endif
 
-   rewind(unit)
+   rewind(unit) ! FIXME
 
 !  read first line before the readloop starts, I have to do this
 !  to avoid using backspace on unit (dammit Turbomole format)
@@ -250,7 +250,7 @@ subroutine read_molecule_tmol(mol, unit, status, iomsg)
       if (index(line,flag_end).ne.0) exit readlat
    enddo readlat
 
-   rewind(unit)
+   rewind(unit) ! FIXME
    endif
 
 !  read first line before the readloop starts, I have to do this
@@ -543,18 +543,18 @@ subroutine read_molecule_sdf(mol, unit, status, iomsg)
       call getline(unit, line, error)
       read(line, '(3f10.4,1x,a3,i2,11i3)', iostat=error) &
          & x, y, z, symbol, list12
-      print*, line
-      print*, x, y, z, symbol
       call elem(symbol, atomtype)
       mol%xyz(:, iatom) = [x, y, z] * aatoau
       mol%at(iatom) = atomtype
       mol%sym(iatom) = trim(symbol)
    enddo
 
+   call mol%bonds%allocate(size=number_of_bonds)
    do ibond = 1, number_of_bonds
       call getline(unit, line, error)
       read(line, '(7i3)', iostat=error) &
          & iatom, jatom, btype, list4
+      call mol%bonds%push_back([iatom, jatom])
    enddo
 
    do while(error /= 0)
@@ -633,7 +633,7 @@ subroutine get_coord(unit,lattice,n,xyz,at,sym)
 
    lattice=0
 
-   rewind(unit)
+   rewind(unit) ! FIXME
    ncheck=0
    ntype=0
    ! first line contains the symbols of different atom types
@@ -785,7 +785,7 @@ subroutine get_atomnumber(unit,n)
 
    integer :: iat, inum, idum, err
 
-   rewind(unit)
+   rewind(unit) ! FIXME
    ntype=0
    ! first line contains the symbols of different atom types
    call getline(unit,line,err)

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -153,7 +153,7 @@ subroutine read_molecule_turbomole(mol, unit, status, iomsg)
    use mctc_resize_arrays
    use readin, getline => strip_line
    use pbc_tools
-   logical, parameter :: debug = .true.
+   logical, parameter :: debug = .false.
    type(tb_molecule),intent(inout) :: mol
    integer,intent(in) :: unit !< file handle
    logical, intent(out) :: status

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -1,0 +1,866 @@
+submodule(tbdef_molecule) molecule_reader
+   use tbdef_molecule
+   implicit none
+
+contains
+
+module subroutine read_molecule_generic(self, unit, format)
+   use tbmod_file_utils
+   class(tb_molecule), intent(out) :: self
+   integer, intent(in) :: unit
+   integer, intent(in), optional :: format
+   integer :: ftype
+   logical :: status
+   character(len=:), allocatable :: message
+   if (present(format)) then
+      ftype = format
+   else
+      ftype = self%ftype
+   endif
+
+   select case(ftype)
+   case(p_ftype%xyz)
+      call read_molecule_xyz(self, unit, status, iomsg=message)
+   case(p_ftype%tmol)
+      call read_molecule_tmol(self, unit, status, iomsg=message)
+   case(p_ftype%sdf)
+      call read_molecule_sdf(self, unit, status, iomsg=message)
+   case(p_ftype%vasp)
+      call read_molecule_vasp(self, unit, status, iomsg=message)
+   case default
+      status = .false.
+      message = "coordinate format known"
+   end select
+
+   if (.not.status) call raise('E', message, 1)
+
+   self%ftype = ftype
+
+end subroutine read_molecule_generic
+
+
+subroutine read_molecule_xyz(mol, unit, status, iomsg)
+   use iso_fortran_env, wp => real64
+   use mctc_econv
+   use pbc_tools
+   use readin, only : getline => strip_line
+   logical, parameter :: debug = .false.
+   class(tb_molecule), intent(out) :: mol
+   integer, intent(in) :: unit
+   logical, intent(out) :: status
+   character(len=:), allocatable, intent(out) :: iomsg
+   integer  :: n, iat
+   real(wp) :: xyz(3)
+   real(wp) :: conv
+
+   character(len=:),allocatable :: message
+   character(len=:),allocatable :: line
+   character(len=10) :: chdum
+   integer  :: err
+
+   status = .false.
+
+   conv = aatoau
+
+   rewind(unit)
+
+   read(unit,*,iostat=err) n
+   if (err.ne.0) then
+      iomsg = "Could not read number of atoms, check format!"
+      return
+   endif
+
+   if (n.lt.1) then
+      iomsg = "Found no atoms, cannot work without atoms!"
+      return
+   endif
+
+   call mol%allocate(n)
+   mol%npbc = 0 ! Xmol is always molecular (there are extensions to this...)
+   mol%pbc = .false.
+
+   ! drop next record
+   read(unit,'(a)')
+
+   n = 0
+   do while (n < mol%n)
+      call getline(unit,line,err)
+      if (is_iostat_end(err)) exit
+      if (err.ne.0) then
+         iomsg = "Could not read geometry from Xmol file"
+         return
+      endif
+      if (debug) print'(">",a)',line
+      read(line,*,iostat=err) chdum, xyz(1), xyz(2), xyz(3)
+      if (err.ne.0) then
+         iomsg = "Could not parse coordinates from Xmol file"
+         return
+      endif
+      if (debug) print'("->",a)',chdum
+      if (debug) print'("->",3g0)',xyz
+
+      call elem(line,iat)
+      if (debug) print'("->",g0)',iat
+      if (iat > 0) then
+         n = n+1
+         mol%at(n) = iat
+         mol%sym(n) = line(1:2)
+         mol%xyz(:,n) = xyz*conv
+      else
+         iomsg = "Unknown element symbol: '"//trim(chdum)//"'"
+         return
+      endif
+   enddo
+
+   if (n.ne.mol%n) then
+      iomsg = "Atom number missmatch in Xmol file"
+      return
+   endif
+
+   status = .true.
+end subroutine read_molecule_xyz
+
+
+subroutine read_molecule_tmol(mol, unit, status, iomsg)
+   use iso_fortran_env, wp => real64
+   use readin, getline => strip_line
+   use pbc_tools
+   implicit none
+   type(tb_molecule),intent(inout) :: mol
+   integer,intent(in) :: unit !< file handle
+   logical, intent(out) :: status
+   character(len=:), allocatable, intent(out) :: iomsg
+   character(len=:),allocatable :: line
+   integer :: err
+   integer :: idum
+   logical,parameter :: debug = .false.
+   integer :: natoms
+   integer :: i
+   integer :: npbc
+   logical :: exist
+
+   character,parameter :: flag = '$'
+   character(len=*),parameter :: flag_end = flag//'end'
+
+   status = .false.
+
+   exist  = .false.
+   npbc   = -1
+   natoms = -1
+
+!  we need to read this file twice, for a lot of reasons
+   rewind(unit)
+
+!  read first line before the readloop starts, I have to do this
+!  to avoid using backspace on unit (dammit Turbomole format)
+   if (debug) print'("first scan")'
+   call getline(unit,line,err)
+   scanfile: do
+      !  check if there is a $ in the *first* column
+      if (index(line,flag).eq.1) then
+         if (index(line,'coord').eq.2) then
+            if (debug) print'("*>",a)',line
+            call get_atomnumber(natoms,unit,line,err)
+         elseif (index(line,'periodic').eq.2) then
+            if (debug) print'("*>",a)',line
+            call get_periodic(npbc,unit,line,err)
+         else
+!           get a new line
+            if (debug) print'(" >",a)',line
+            call getline(unit,line,err)
+         endif
+      else ! not a keyword -> ignore
+         if (debug) print'(" >",a)',line
+         call getline(unit,line,err)
+      endif
+   !  check for end of file, which I will tolerate as alternative to $end
+      if (err.eq.iostat_end) exit scanfile
+      if (index(line,flag_end).ne.0) exit scanfile
+   enddo scanfile
+
+   if (natoms.eq.-1) then
+      iomsg = "coord keyword was not found"
+      return
+   endif
+   if (npbc.eq.-1) npbc = 0
+
+   if (natoms.lt.1) then ! this will catch an empty coord data group
+      iomsg = 'Found no atoms, cannot work without atoms!'
+      return
+   endif
+
+   call mol%allocate(natoms)
+   mol%npbc = npbc
+   do i = 1, npbc
+      mol%pbc(i) = .true.
+   enddo
+   if (mol%npbc == 0) then
+      ! this might be wrong
+      mol%lattice = reshape([0.0_wp,0.0_wp,0.0_wp,&
+         &                   0.0_wp,0.0_wp,0.0_wp,&
+         &                   0.0_wp,0.0_wp,0.0_wp],[3,3])
+      mol%rec_lat = reshape([1.0_wp,0.0_wp,0.0_wp,&
+         &                   0.0_wp,1.0_wp,0.0_wp,&
+         &                   0.0_wp,0.0_wp,1.0_wp],[3,3])
+   endif
+
+   rewind(unit)
+
+!  read first line before the readloop starts, I have to do this
+!  to avoid using backspace on unit (dammit Turbomole format)
+   if (debug) print'("one''n''half read")'
+   if (npbc > 0) then
+   call getline(unit,line,err)
+   readlat: do
+      !  check if there is a $ in the *first* column
+      if (index(line,flag).eq.1) then
+         if (index(line,'lattice').eq.2) then
+            if (exist) then
+               iomsg = "Multiple definitions of lattice present!"
+               return
+            endif
+            exist = .true.
+            if (debug) print'("*>",a)',line
+            call get_lattice(unit,line,err,npbc,mol%lattice)
+            call dlat_to_cell(mol%lattice,mol%cellpar)
+            call dlat_to_rlat(mol%lattice,mol%rec_lat)
+            mol%volume = dlat_to_dvol(mol%lattice)
+         elseif (index(line,'cell').eq.2) then
+            if (exist) then
+               iomsg = "Multiple definitions of lattice present!"
+               return
+            endif
+            exist = .true.
+            if (debug) print'("*>",a)',line
+            call get_cell(unit,line,err,npbc,mol%cellpar)
+            call cell_to_dlat(mol%cellpar,mol%lattice)
+            call cell_to_rlat(mol%cellpar,mol%rec_lat)
+            mol%volume = cell_to_dvol(mol%cellpar)
+         else
+!           get a new line
+            if (debug) print'(" >",a)',line
+            call getline(unit,line,err)
+         endif
+      else ! not a keyword -> ignore
+         if (debug) print'(" >",a)',line
+         call getline(unit,line,err)
+      endif
+   !  check for end of file, which I will tolerate as alternative to $end
+      if (err.eq.iostat_end) exit readlat
+      if (index(line,flag_end).ne.0) exit readlat
+   enddo readlat
+
+   rewind(unit)
+   endif
+
+!  read first line before the readloop starts, I have to do this
+!  to avoid using backspace on unit (dammit Turbomole format)
+   if (debug) print'("second read")'
+   call getline(unit,line,err)
+   readfile: do
+      !  check if there is a $ in the *first* column
+      if (index(line,flag).eq.1) then
+         if (index(line,'coord').eq.2) then
+            if (debug) print'("*>",a)',line
+            call get_coord(unit,line,err,mol)
+         else
+!           get a new line
+            if (debug) print'(" >",a)',line
+            call getline(unit,line,err)
+         endif
+      else ! not a keyword -> ignore
+         if (debug) print'(" >",a)',line
+         call getline(unit,line,err)
+      endif
+   !  check for end of file, which I will tolerate as alternative to $end
+      if (err.eq.iostat_end) exit readfile
+      if (index(line,flag_end).ne.0) exit readfile
+   enddo readfile
+
+   if (.not.exist .and. npbc > 0) then
+      iomsg = "There is no definition of the lattice present!"
+      return
+   endif
+
+   status = .true.
+
+contains
+
+!> count the number of lines in the coord block -> number of atoms
+subroutine get_atomnumber(ncount,unit,line,err)
+   implicit none
+   integer,intent(in) :: unit          !< file handle
+   character(len=:),allocatable :: line !< string buffer
+   integer,intent(out) :: ncount        !< number of readin lines
+   integer,intent(out) :: err           !< status of unit
+   ncount = 0
+   do
+      call getline(unit,line,err)
+      if (err.eq.iostat_end) return
+      if (index(line,flag).ne.0) return
+      if (debug) print'(" ->",a)',line
+
+      if (line.eq.'') cycle ! skip empty lines
+      ncount = ncount + 1   ! but count non-empty lines first
+   enddo
+end subroutine get_atomnumber
+
+!> get the dimensionality of the system
+subroutine get_periodic(npbc,unit,line,err)
+   implicit none
+   integer,intent(in) :: unit          !< file handle
+   character(len=:),allocatable :: line !< string buffer
+   integer,intent(out) :: npbc          !< number of periodic dimensions
+   integer,intent(out) :: err           !< status of unit
+   integer :: idum
+   if (get_value(line(10:),idum)) then
+      if (idum.eq.0 .or. idum.eq.3) then
+         npbc = idum
+      else
+         iomsg = "This kind of periodicity is not implemented"
+         return
+      endif
+   else
+      iomsg = "Could not read periodicity from '"//line//"'"
+      return
+   endif
+   call getline(unit,line,err)
+end subroutine get_periodic
+
+!> read the lattice vectors from the data group
+subroutine get_lattice(unit,line,err,npbc,lat)
+   use mctc_econv
+   implicit none
+   integer,intent(in) :: unit          !< file handle
+   character(len=:),allocatable :: line !< string buffer
+   integer,intent(out) :: err           !< status of unit
+   integer,intent(in)  :: npbc          !< number of periodic dimensions
+   real(wp),intent(out) :: lat(3,3)     !< lattice vectors
+   integer :: ncount
+   real(wp) :: lvec(3)
+   real(wp) :: conv
+   if (npbc == 0) then
+      iomsg = "lattice data group is present but not periodic?"
+      return
+   endif
+   if (len(line).le.8) then
+      conv = 1.0_wp ! default is bohr
+   elseif (index(line(9:),'bohr').gt.0) then
+      conv = 1.0_wp
+   elseif (index(line(9:),'angs').gt.0) then
+      conv = aatoau
+   else ! fall back to default
+      iomsg = "Could not make sense out of unit '"//line(7:)//"'"
+      conv = 1.0_wp
+   endif
+   lat = 0.0_wp
+   ncount = 0
+   do
+      call getline(unit,line,err)
+      if (err.eq.iostat_end) return
+      if (index(line,flag).ne.0) return
+      if (debug) print'(" ->",a)',line
+
+      if (line.eq.'') cycle ! skip empty lines
+      ncount = ncount + 1   ! but count non-empty lines first
+      if (ncount.gt.npbc) then
+         iomsg = "Input error in lattice data group"
+         return
+      endif
+      read(line,*,iostat=err) lvec(1:npbc)
+      if (err.ne.0) then
+         iomsg = "Input error in lattice data group"
+         return
+      endif
+      lat(1:npbc,ncount) = lvec(1:npbc)*conv
+   enddo
+end subroutine get_lattice
+
+!> read the cell parameters and transform to lattice
+subroutine get_cell(unit,line,err,npbc,cellpar)
+   use mctc_constants
+   use mctc_econv
+   implicit none
+   integer,intent(in)   :: unit        !< file handle
+   character(len=:),allocatable :: line !< string buffer
+   integer,intent(out)  :: err          !< status of unit
+   integer,intent(in)   :: npbc         !< number of periodic dimensions
+   real(wp),intent(out) :: cellpar(6)   !< cell parameter
+   real(wp) :: conv,vol
+   if (npbc == 0) then
+      iomsg = "cell data group is present but not periodic?"
+      return
+   endif
+
+   associate( alen => cellpar(1), blen => cellpar(2), clen => cellpar(3), &
+              alp  => cellpar(4), bet  => cellpar(5), gam  => cellpar(6) )
+
+   alen = 1.0_wp; blen = 1.0_wp; clen = 1.0_wp
+   alp = 90.0_wp; bet = 90.0_wp; gam = 90.0_wp
+
+   if (len(line).le.5) then
+      conv = 1.0_wp ! default is bohr
+   elseif (index(line(6:),'bohr').gt.0) then
+      conv = 1.0_wp
+   elseif (index(line(6:),'angs').gt.0) then
+      conv = aatoau
+   else ! fall back to default
+      iomsg = "Could not make sense out of unit '"//line(7:)//"'"
+      conv = 1.0_wp
+   endif
+   call getline(unit,line,err)
+   if (err.eq.iostat_end) return
+   if (index(line,flag).ne.0) return
+   if (debug) print'(" ->",a)',line
+   if (npbc == 3) &
+      read(line,*,iostat=err) alen,blen,clen,alp,bet,gam
+   if (npbc == 2) &
+      read(line,*,iostat=err) alen,blen,             gam
+   if (npbc == 1) &
+      read(line,*,iostat=err) alen
+   if (err.ne.0) then
+      iomsg = "Could not read cell from '"//line//"'"
+      return
+   endif
+
+   if(alen < 0.0d0 .or. blen < 0.0d0 .or. clen < 0.0d0 .or. &
+      alp < 0.0d0 .or. bet < 0.0d0 .or. gam < 0.0d0) then
+      iomsg = "Negative cell parameters make no sense!"
+      return
+   endif
+
+   alen = alen*conv
+   blen = blen*conv
+   clen = clen*conv
+   alp  = alp*pi/180.0_wp
+   bet  = bet*pi/180.0_wp
+   gam  = gam*pi/180.0_wp
+
+   end associate
+
+end subroutine get_cell
+
+!> read the coordinates from coord data group
+subroutine get_coord(unit,line,err,mol)
+   use mctc_econv
+   use mctc_strings
+   use tbdef_molecule
+   implicit none
+   integer,intent(in) :: unit            !< file handle
+   character(len=:),allocatable :: line   !< string buffer
+   integer,intent(out) :: err             !< status of unit
+   type(tb_molecule),intent(inout) :: mol !< molecular structure information
+   integer  :: narg
+   integer  :: ncount,iat,icoord
+   character(len=10) :: chdum
+   real(wp) :: conv,ddum,xyz(3)
+   logical  :: frac
+   if (len(line).le.6) then
+      frac = .false.
+      conv = 1.0_wp ! default is bohr
+   elseif (index(line(7:),'bohr').gt.0) then
+      frac = .false.
+      conv = 1.0_wp
+   elseif (index(line(7:),'angs').gt.0) then
+      frac = .false.
+      conv = aatoau
+   elseif (index(line(7:),'frac').gt.0) then
+      frac = .true.
+      conv = 1.0_wp
+   else ! fall back to default
+      iomsg = "Could not make sense out of unit '"//line(7:)//"'"
+      frac = .false.
+      conv = 1.0_wp
+   endif
+
+   ncount = 0
+   do
+      call getline(unit,line,err)
+      if (err.eq.iostat_end) return
+      if (index(line,flag).ne.0) return
+      if (debug) print'(" ->",a)',line
+
+      if (line.eq.'') cycle ! skip empty lines
+      ncount = ncount + 1   ! but count non-empty lines first
+      if (ncount.gt.mol%n) then
+         iomsg = "Internal error while reading coord data group"
+         return
+      endif
+      read(line,*,iostat=err) xyz(1), xyz(2), xyz(3), chdum
+      if (err.ne.0) then
+         iomsg = "not enough arguments in line in coord data group"
+         return
+      endif
+      call elem(chdum,iat)
+      if (iat.eq.0) then
+         iomsg = "invalid element input in line in coord data group"
+         return
+      endif
+      mol%sym(ncount) = trim(chdum)
+      mol%at(ncount) = iat
+      ! in case of fractional coordinates we perform a gemv with the lattice
+      if (frac) then
+         mol%xyz(:,ncount) = matmul(mol%lattice,xyz)
+      else
+         mol%xyz(:,ncount) = conv*xyz
+      endif
+   enddo
+end subroutine get_coord
+
+end subroutine read_molecule_tmol
+
+
+subroutine read_molecule_sdf(mol, unit, status, iomsg)
+   use mctc_econv
+   use mctc_systools
+   class(tb_molecule), intent(out) :: mol
+   integer, intent(in) :: unit
+   logical, intent(out) :: status
+   character(len=:), allocatable, intent(out) :: iomsg
+   character(len=:), allocatable :: line
+   integer :: iatom, jatom, ibond, btype, atomtype
+   integer :: error
+   integer :: number_of_atoms, number_of_bonds, number_of_atom_lists, &
+      &       chiral_flag, number_of_stext_entries, i999
+   integer :: list4(4), list12(12)
+   real(wp) :: x, y, z
+   character(len=3) :: symbol
+   character(len=5) :: v2000
+
+   status = .false.
+
+   call getline(unit, line, error)
+   call getline(unit, line, error)
+   call getline(unit, line, error)
+   call getline(unit, line, error)
+   read(line, '(3i3,3x,2i3,12x,i3,1x,a5)', iostat=error) &
+      & number_of_atoms, number_of_bonds, number_of_atom_lists, &
+      & chiral_flag, number_of_stext_entries, i999, v2000
+
+   call mol%allocate(number_of_atoms)
+
+   do iatom = 1, number_of_atoms
+      call getline(unit, line, error)
+      read(line, '(3f10.4,1x,a3,i2,11i3)', iostat=error) &
+         & x, y, z, symbol, list12
+      print*, line
+      print*, x, y, z, symbol
+      call elem(symbol, atomtype)
+      mol%xyz(:, iatom) = [x, y, z] * aatoau
+      mol%at(iatom) = atomtype
+      mol%sym(iatom) = trim(symbol)
+   enddo
+
+   do ibond = 1, number_of_bonds
+      call getline(unit, line, error)
+      read(line, '(7i3)', iostat=error) &
+         & iatom, jatom, btype, list4
+   enddo
+
+   do while(error /= 0)
+      call getline(unit, line, error)
+      if (index(line, '$$$$') == 1) exit
+   enddo
+
+   status = .true.
+
+end subroutine read_molecule_sdf
+
+
+subroutine read_molecule_vasp(mol, unit, status, iomsg)
+   use iso_fortran_env, wp => real64
+   use tbdef_molecule
+   use pbc_tools
+   logical, parameter :: debug = .false.
+   type(tb_molecule),intent(out) :: mol
+   integer,intent(in) :: unit
+   logical, intent(out) :: status
+   character(len=:), allocatable, intent(out) :: iomsg
+   integer :: n
+
+   status = .false.
+
+   call get_atomnumber(unit,n)
+   if (allocated(iomsg)) return
+
+   if (n.lt.1) then
+      iomsg = 'Found no atoms, cannot work without atoms!'
+      return
+   endif
+
+   call mol%allocate(n)
+   mol%npbc = 3 ! VASP is always 3D
+   mol%pbc = .true.
+
+   call get_coord(unit,mol%lattice,mol%n,mol%xyz,mol%at,mol%sym)
+   if (allocated(iomsg)) return
+   call dlat_to_cell(mol%lattice,mol%cellpar)
+   call dlat_to_rlat(mol%lattice,mol%rec_lat)
+   mol%volume = dlat_to_dvol(mol%lattice)
+
+   call xyz_to_abc(mol%n,mol%lattice,mol%xyz,mol%abc,mol%pbc)
+
+   status = .true.
+
+contains
+
+!> read the coordinates from POSCAR
+subroutine get_coord(unit,lattice,n,xyz,at,sym)
+   use mctc_econv
+   use mctc_strings
+   use mctc_systools
+
+   implicit none
+
+   integer, intent(in)  :: n
+   real(wp),intent(out) :: xyz(3,n)
+   real(wp),intent(out) :: lattice(3,3)
+   integer, intent(out) :: at(n)
+   character(len=2),intent(out) :: sym(n)
+   integer, intent(in)  :: unit
+   logical              :: selective=.false. ! Selective dynamics
+   logical              :: cartesian=.true.  ! Cartesian or direct
+
+   real(wp) :: ddum,latvec(3)
+   real(wp) xx(10),scalar
+   real(wp) :: coord(3)
+   character(len=:),allocatable :: line
+   character(len=80) :: args(90),args2(90)
+
+   integer i,j,nn,ntype,ntype2,atnum,i_dummy1,i_dummy2,ncheck
+
+   integer :: iat, inum, idum, err
+
+   lattice=0
+
+   rewind(unit)
+   ncheck=0
+   ntype=0
+   ! first line contains the symbols of different atom types
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   call parse(line,' ',args,ntype)
+
+   ! this line contains the global scaling factor,
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   read(line,*,iostat=err) ddum
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   ! the Ang->au conversion is included in the scaling factor
+   scalar = ddum*aatoau
+
+   ! reading the lattice constants
+   do i=1,3
+      call getline(unit,line,err)
+      if (err.ne.0) then
+         iomsg = "Could not read lattice from POSCAR"
+         return
+      endif
+      if (debug) print'("->",a)',line
+      read(line,*,iostat=err) latvec
+      if (err.ne.0) then
+         iomsg = "Could not read lattice from POSCAR"
+         return
+      endif
+      lattice(:,i) = latvec * scalar
+   enddo
+   ! Either here are the numbers of each element,
+   ! or (>vasp.5.1) here are the element symbols
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   ! try to read first element
+   read(line,*,iostat=err) idum
+   ! CONTCAR files have additional Element line here since vasp.5.1
+   if (err.ne.0) then
+      call parse(line,' ',args,ntype)
+      call getline(unit,line,err)
+      if (debug) print'("->",a)',line
+      if (err.ne.0) then
+         iomsg = "Could not read POSCAR"
+         return
+      endif
+   endif
+   call parse(line,' ',args2,nn)
+   if (nn.ne.ntype) then
+      iomsg = 'Error reading number of atomtypes'
+      return
+   endif
+   ncheck=0
+   do i=1,nn
+      read(args2(i),*,iostat=err) inum
+      call elem(args(i),iat)
+      if (iat < 1 .or. inum < 1) then
+         iomsg = 'unknown element.'
+         return
+      endif
+      do j=1,inum
+         ncheck=ncheck+1
+         sym(ncheck) = args(i)(1:2)
+         at(ncheck)=iat
+      enddo
+   enddo
+   if (n.ne.ncheck) then
+      iomsg = 'Error reading Number of Atoms'
+      return
+   endif
+
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   line=adjustl(line)
+   if (line(:1).eq.'s' .or. line(:1).eq.'S') then
+      selective=.true.
+      call getline(unit,line,err)
+      if (debug) print'("->",a)',line
+      if (err.ne.0) then
+         iomsg = "Could not read POSCAR"
+         return
+      endif
+      line=adjustl(line)
+   endif
+
+   cartesian=(line(:1).eq.'c' .or. line(:1).eq.'C' .or. &
+      &       line(:1).eq.'k' .or. line(:1).eq.'K')
+   do i=1,n
+      call getline(unit,line,err)
+      if (err.ne.0) then
+         iomsg = "Could not read geometry from POSCAR"
+         return
+      endif
+      if (debug) print'("-->",a)',line
+      read(line,*,iostat=err) coord
+      if (err.ne.0) then
+         iomsg = "Could not read geometry from POSCAR"
+         return
+      endif
+
+      if (cartesian) then
+         xyz(:,i)=coord*scalar
+      else
+         xyz(:,i)=matmul(lattice,coord)
+      endif
+
+   enddo
+
+end subroutine get_coord
+
+!> read the coordinates from POSCAR
+subroutine get_atomnumber(unit,n)
+   use mctc_econv
+   use mctc_strings
+   use mctc_systools
+
+   implicit none
+
+   integer, intent(out) :: n
+   integer, intent(in)  :: unit
+   logical              :: selective=.false. ! Selective dynamics
+   logical              :: cartesian=.true.  ! Cartesian or direct
+
+   real(wp) :: ddum,latvec(3)
+   real(wp) xx(10),scalar
+   real(wp) :: coord(3)
+   character(len=:),allocatable :: line
+   character(len=80) :: args(90),args2(90)
+
+   integer i,j,nn,ntype,ntype2,atnum
+
+   integer :: iat, inum, idum, err
+
+   rewind(unit)
+   ntype=0
+   ! first line contains the symbols of different atom types
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   call parse(line,' ',args,ntype)
+
+   ! this line contains the global scaling factor,
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   read(line,*,iostat=err) ddum
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   ! the Ang->au conversion is included in the scaling factor
+   scalar = ddum*aatoau
+
+   ! reading the lattice constants
+   do i=1,3
+      call getline(unit,line,err)
+      if (err.ne.0) then
+         iomsg = "Could not read lattice from POSCAR"
+         return
+      endif
+      if (debug) print'("->",a)',line
+   enddo
+   ! Either here are the numbers of each element,
+   ! or (>vasp.5.1) here are the element symbols
+   call getline(unit,line,err)
+   if (err.ne.0) then
+      iomsg = "Could not read POSCAR"
+      return
+   endif
+   if (debug) print'(">",a)',line
+   ! try to read first element
+   read(line,*,iostat=err) idum
+   ! CONTCAR files have additional Element line here since vasp.5.1
+   if (err.ne.0) then
+      call parse(line,' ',args,ntype)
+      call getline(unit,line,err)
+      if (debug) print'("->",a)',line
+      if (err.ne.0) then
+         iomsg = "Could not read POSCAR"
+         return
+      endif
+   endif
+   call parse(line,' ',args2,nn)
+   if (nn.ne.ntype) then
+      iomsg = 'Error reading number of atomtypes'
+      return
+   endif
+   n=0
+   do i=1,nn
+      read(args2(i),*,iostat=err) inum
+      call elem(args(i),iat)
+      if (iat < 1 .or. inum < 1) then
+         iomsg = 'unknown element'
+         return
+      endif
+      do j=1,inum
+         n=n+1
+      enddo
+   enddo
+
+end subroutine get_atomnumber
+
+end subroutine read_molecule_vasp
+
+
+end submodule molecule_reader

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -55,7 +55,7 @@ module subroutine write_molecule_generic(self, unit, format, energy, gnorm, numb
    case(p_ftype%xyz)
       call write_xyz(self, unit, trim(comment_line))
    case(p_ftype%tmol)
-      call write_tmol(self, unit, trim(comment_line))
+      call write_tmol(self, unit)
    case(p_ftype%molfile)
       call write_molfile(self, unit, trim(comment_line))
    case(p_ftype%sdf)
@@ -87,13 +87,12 @@ subroutine write_xyz(mol, unit, comment_line)
 
 end subroutine write_xyz
 
-subroutine write_tmol(mol, unit, comment_line)
+subroutine write_tmol(mol, unit)
    class(tb_molecule), intent(in) :: mol
    integer, intent(in) :: unit
-   character(len=*), intent(in) :: comment_line
    integer :: i
 
-   write(unit,'(a,1x,"#",1x,a)') "$coord bohr", comment_line
+   write(unit,'(a)') "$coord"
    do i = 1, mol%n
       write(unit,'(3f20.14,6x,a2)') mol%xyz(:,i), mol%sym(i)
    enddo

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -125,7 +125,6 @@ subroutine write_vasp(mol, unit, comment_line)
    character(len=*), intent(in) :: comment_line
    integer :: i,j,iat
    integer,allocatable :: kinds(:)
-   character(len=2),external :: asym
 
    allocate(kinds(mol%n), source = 1)
 
@@ -133,15 +132,15 @@ subroutine write_vasp(mol, unit, comment_line)
    write(unit,'(a)') comment_line
 
    ! scaling factor for lattice parameters is always one
-   write(unit,'(f20.14)') 1.0_wp
+   write(unit,'(f20.14)') mol%vasp%scale
    ! write the lattice parameters
    do i = 1, 3
-      write(unit,'(3f20.14)') mol%lattice(:,i)*autoaa
+      write(unit,'(3f20.14)') mol%lattice(:,i)*autoaa/mol%vasp%scale
    enddo
 
    j = 0
    iat = 0
-   do i = 1, mol%n
+   do i = 1, len(mol)
       if (iat.eq.mol%at(i)) then
          kinds(j) = kinds(j)+1
       else
@@ -159,13 +158,24 @@ subroutine write_vasp(mol, unit, comment_line)
    write(unit,'(a)')
    deallocate(kinds)
 
-   ! we write cartesian coordinates
-   write(unit,'("Cartesian")')
+   if (mol%vasp%selective) write(unit,'("Selective")')
 
-   ! now write the cartesian coordinates
-   do i = 1, mol%n
-      write(unit,'(3f20.14)') mol%xyz(:,i)*autoaa
-   enddo
+   ! we write cartesian coordinates
+   if (mol%vasp%cartesian) then
+      write(unit,'("Cartesian")')
+
+      ! now write the cartesian coordinates
+      do i = 1, len(mol)
+         write(unit,'(3f20.14)') mol%xyz(:,i)*autoaa/mol%vasp%scale
+      enddo
+   else
+      write(unit,'("Direct")')
+
+      ! now write the fractional coordinates
+      do i = 1, len(mol)
+         write(unit,'(3f20.14)') mol%abc(:,i)
+      enddo
+   endif
 
 end subroutine write_vasp
 

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -86,7 +86,7 @@ subroutine write_sdf(mol, unit, comment_line)
    integer, intent(in) :: unit
    character(len=*), intent(in) :: comment_line
    integer, parameter :: list4(4) = 0, list12(12) = 0
-   integer :: iatom
+   integer :: iatom, ibond, iatoms(2)
 
    write(unit, '(a)')
    write(unit, '(a)') comment_line
@@ -97,6 +97,12 @@ subroutine write_sdf(mol, unit, comment_line)
    do iatom = 1, mol%n
       write(unit, '(3f10.4,1x,a3,i2,11i3)') &
          & mol%xyz(:, iatom)*autoaa, mol%sym(iatom), list12
+   enddo
+
+   do ibond = 1, len(mol%bonds)
+      call mol%bonds%get_item(ibond, iatoms)
+      write(unit, '(7i3)') &
+         & iatoms, 1, list4
    enddo
 
    write(unit, '(a,*(1x,i3))') "M  CHG", 1, 1, nint(mol%chrg)

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -92,16 +92,26 @@ subroutine write_sdf(mol, unit, comment_line)
    class(tb_molecule), intent(in) :: mol
    integer, intent(in) :: unit
    character(len=*), intent(in) :: comment_line
-   integer, parameter :: list4(4) = 0, list12(12) = 0
-   integer :: iatom, ibond, iatoms(2)
+   integer, parameter :: list4(4) = 0
+   integer :: iatom, ibond, iatoms(2), list12(12)
+   logical :: has_sdf_data
+   integer, parameter :: charge_to_ccc(-3:3) = [7, 6, 5, 0, 3, 2, 1]
 
    write(unit, '(a)')
    write(unit, '(a)') comment_line
    write(unit, '(a)')
    write(unit, '(3i3,3x,2i3,12x,i3,1x,a5)') &
-      & mol%n, 0, 0, 0, 0, 999, 'V2000'
+      & len(mol), len(mol%bonds), 0, 0, 0, 999, 'V2000'
+
+   has_sdf_data = allocated(mol%sdf)
 
    do iatom = 1, mol%n
+      if (has_sdf_data) then
+         list12 = [mol%sdf(iatom)%isotope, charge_to_ccc(mol%sdf(iatom)%charge), &
+            &      0, 0, 0, mol%sdf(iatom)%valence, 0, 0, 0, 0, 0, 0]
+      else
+         list12 = 0
+      endif
       write(unit, '(3f10.4,1x,a3,i2,11i3)') &
          & mol%xyz(:, iatom)*autoaa, mol%sym(iatom), list12
    enddo

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -1,0 +1,159 @@
+submodule(tbdef_molecule) molecule_writer
+   use tbdef_molecule
+   implicit none
+
+contains
+
+module subroutine write_molecule_generic(self, unit, format, energy, gnorm)
+   use tbmod_file_utils
+   include 'xtb_version.fh'
+   class(tb_molecule), intent(in) :: self
+   integer, intent(in) :: unit
+   integer, intent(in), optional :: format
+   real(wp), intent(in), optional :: energy
+   real(wp), intent(in), optional :: gnorm
+   character(len=:), allocatable :: comment_line
+   character(len=20) :: energy_line
+   character(len=20) :: gnorm_line
+   integer :: ftype
+   if (present(format)) then
+      ftype = format
+   else
+      ftype = self%ftype
+   endif
+
+   comment_line = ''
+   if (present(energy)) then
+      write(energy_line, '(f20.12)') energy
+      comment_line = comment_line // " energy: " // trim(adjustl(energy_line))
+   endif
+   if (present(gnorm)) then
+      write(gnorm_line, '(f20.12)') gnorm
+      comment_line = comment_line // " gnorm: " // trim(adjustl(gnorm_line))
+   endif
+   comment_line = comment_line // " xtb: " // version
+
+   select case(ftype)
+   case(p_ftype%xyz)
+      call write_xyz(self, unit, trim(comment_line))
+   case(p_ftype%tmol)
+      call write_tmol(self, unit, trim(comment_line))
+   case(p_ftype%sdf)
+      call write_sdf(self, unit, trim(comment_line))
+   case(p_ftype%vasp)
+      call write_vasp(self, unit, trim(comment_line))
+   end select
+
+end subroutine write_molecule_generic
+
+subroutine write_xyz(mol, unit, comment_line)
+   use mctc_econv
+   class(tb_molecule), intent(in) :: mol
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: comment_line
+   integer :: i
+
+   write(unit, '(i0)') mol%n
+   write(unit, '(a)') comment_line
+   do i = 1, mol%n
+      write(unit, '(a2,6x,3f20.14)') mol%sym(i), mol%xyz(:,i)*autoaa
+   enddo
+
+end subroutine write_xyz
+
+subroutine write_tmol(mol, unit, comment_line)
+   class(tb_molecule), intent(in) :: mol
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: comment_line
+   integer :: i
+
+   write(unit,'(a,1x,"#",1x,a)') "$coord bohr", comment_line
+   do i = 1, mol%n
+      write(unit,'(3f20.14,6x,a2)') mol%xyz(:,i), mol%sym(i)
+   enddo
+   write(unit,'(a,1x,i0)') "$periodic", mol%npbc
+   if (mol%npbc > 0) then
+      write(unit,'(a)') "$lattice bohr"
+      write(unit,'(3f20.14)') mol%lattice
+   endif
+   write(unit,'(a)') "$end"
+
+end subroutine write_tmol
+
+subroutine write_sdf(mol, unit, comment_line)
+   use mctc_econv
+   class(tb_molecule), intent(in) :: mol
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: comment_line
+   integer, parameter :: list4(4) = 0, list12(12) = 0
+   integer :: iatom
+
+   write(unit, '(a)')
+   write(unit, '(a)') comment_line
+   write(unit, '(a)')
+   write(unit, '(3i3,3x,2i3,12x,i3,1x,a5)') &
+      & mol%n, 0, 0, 0, 0, 999, 'V2000'
+
+   do iatom = 1, mol%n
+      write(unit, '(3f10.4,1x,a3,i2,11i3)') &
+         & mol%xyz(:, iatom)*autoaa, mol%sym(iatom), list12
+   enddo
+
+   write(unit, '(a,*(1x,i3))') "M  CHG", 1, 1, nint(mol%chrg)
+   write(unit, '(a)') "M  END"
+   write(unit, '(a)') "$$$$"
+
+end subroutine write_sdf
+
+subroutine write_vasp(mol, unit, comment_line)
+   use mctc_econv
+   class(tb_molecule), intent(in) :: mol
+   integer, intent(in) :: unit
+   character(len=*), intent(in) :: comment_line
+   integer :: i,j,iat
+   integer,allocatable :: kinds(:)
+   character(len=2),external :: asym
+
+   allocate(kinds(mol%n), source = 1)
+
+   ! use vasp 5.x format
+   write(unit,'(a)') comment_line
+
+   ! scaling factor for lattice parameters is always one
+   write(unit,'(f20.14)') 1.0_wp
+   ! write the lattice parameters
+   do i = 1, 3
+      write(unit,'(3f20.14)') mol%lattice(:,i)*autoaa
+   enddo
+
+   j = 0
+   iat = 0
+   do i = 1, mol%n
+      if (iat.eq.mol%at(i)) then
+         kinds(j) = kinds(j)+1
+      else
+         j = j+1
+         iat = mol%at(i)
+         write(unit,'(1x,a)',advance='no') mol%sym(i)
+      endif
+   enddo
+   write(unit,'(a)')
+
+   ! write the count of the consequtive atom types
+   do i = 1, j
+      write(unit,'(1x,i0)',advance='no') kinds(i)
+   enddo
+   write(unit,'(a)')
+   deallocate(kinds)
+
+   ! we write cartesian coordinates
+   write(unit,'("Cartesian")')
+
+   ! now write the cartesian coordinates
+   do i = 1, mol%n
+      write(unit,'(3f20.14)') mol%xyz(:,i)*autoaa
+   enddo
+
+end subroutine write_vasp
+
+end submodule molecule_writer

--- a/xtb/optimizer.f90
+++ b/xtb/optimizer.f90
@@ -418,7 +418,7 @@ subroutine relax(iunit,iter,mol,anc,restart,maxcycle,maxdispl,ethr,gthr, &
    use tbdef_timer
 
    use single, only : singlepoint
-   use write_geometry
+   use tbmod_file_utils
 
    implicit none
 
@@ -516,7 +516,7 @@ subroutine relax(iunit,iter,mol,anc,restart,maxcycle,maxdispl,ethr,gthr, &
       return
    endif
    if (profile) call timer%measure(6,'optimization log')
-   call write_xyzlog(ilog,mol%n,mol%at,mol%xyz,res%e_total,res%gnorm)
+   call mol%write(ilog, format=p_ftype%xyz, energy=res%e_total, gnorm=res%gnorm)
    if (profile) call timer%measure(6)
 ! transform xyz to internal gradient
    if (profile) call timer%measure(4)

--- a/xtb/tbdef_buffer.f90
+++ b/xtb/tbdef_buffer.f90
@@ -1,0 +1,158 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+module tbdef_buffer
+   use iso_fortran_env
+   implicit none
+   public :: tb_buffer
+   public :: len, size
+   private
+
+
+   type :: tb_buffer
+      private
+      integer :: error_code = 0
+      integer :: length = 0
+      integer :: pos = 0
+      character(len=:), allocatable :: raw
+      integer, allocatable :: table(:,:)
+   contains
+      generic :: allocate => new_default
+      procedure, private :: new_default => buffer_new_default
+      procedure :: get_error => buffer_get_error
+      procedure :: push_back => buffer_push_back
+      procedure :: reset => buffer_reset
+      procedure :: next => buffer_next
+      procedure :: getline => buffer_getline
+      procedure :: resize => buffer_resize
+      procedure :: deallocate => buffer_destroy
+   end type tb_buffer
+
+
+   interface len
+      module procedure :: buffer_length
+   end interface
+
+   interface size
+      module procedure :: buffer_size
+   end interface
+
+
+contains
+
+
+subroutine buffer_new_default(self)
+   class(tb_buffer), intent(out) :: self
+end subroutine buffer_new_default
+
+
+integer pure elemental function buffer_size(self)
+   class(tb_buffer), intent(in) :: self
+   if (allocated(self%table)) then
+      buffer_size = size(self%table, 2)
+   else
+      buffer_size = 0
+   endif
+end function buffer_size
+
+integer pure elemental function buffer_length(self)
+   class(tb_buffer), intent(in) :: self
+   if (allocated(self%table)) then
+      buffer_length = self%length
+   else
+      buffer_length = 0
+   endif
+end function buffer_length
+
+pure subroutine buffer_resize(self, n)
+   class(tb_buffer), intent(inout) :: self
+   integer, intent(in), optional :: n
+   integer, allocatable :: table(:,:)
+   integer :: length, current_length
+   current_length = size(self)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(table(2, length), source=0)
+      table(:, :current_length) = self%table(:, :current_length)
+      deallocate(self%table)
+      call move_alloc(table, self%table)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(self%table(2, length), source=0)
+   endif
+end subroutine buffer_resize
+
+
+subroutine buffer_push_back(self, string)
+   class(tb_buffer), intent(inout) :: self
+   character(len=*), intent(in) :: string
+   integer :: pos, last, length
+
+   pos = len(self%raw)
+   length = len(string)
+   last = len(self)
+   if (last >= size(self)) call self%resize
+
+   ! increment counter
+   self%length = self%length+1
+   ! save position of string in buffer
+   self%table(:,last+1) = pos+[1,length]
+   ! append string to buffer
+   self%raw = self%raw // string
+end subroutine buffer_push_back
+
+
+subroutine buffer_reset(self)
+   class(tb_buffer), intent(inout) :: self
+   self%pos = 0
+end subroutine buffer_reset
+
+logical function buffer_next(self) result(next)
+   class(tb_buffer), intent(inout) :: self
+   next = self%pos < self%length
+   if (next) self%pos = self%pos+1
+end function buffer_next
+
+subroutine buffer_getline(self, line)
+   class(tb_buffer), intent(in) :: self
+   character(len=:), allocatable, intent(out) :: line
+   line = self%raw(self%table(1,self%pos):self%table(2,self%pos))
+end subroutine buffer_getline
+
+
+logical pure elemental function buffer_get_error(self) result(error)
+   class(tb_buffer), intent(in) :: self
+   error = self%error_code /= 0
+end function buffer_get_error
+
+subroutine buffer_destroy(self)
+   class(tb_buffer), intent(inout) :: self
+   if (allocated(self%raw)) deallocate(self%raw)
+   if (allocated(self%table)) deallocate(self%table)
+end subroutine buffer_destroy
+
+
+end module tbdef_buffer

--- a/xtb/tbdef_fragments.f90
+++ b/xtb/tbdef_fragments.f90
@@ -1,0 +1,62 @@
+module tbdef_fragments
+   implicit none
+   public :: tb_fragments
+   public :: len, size
+   private
+
+
+   type :: tb_fragments
+      integer, allocatable :: list(:)
+      integer :: n = 0
+   contains
+      generic :: allocate => new_default, new_from_list
+      procedure, private :: new_default => frag_new_default
+      procedure, private :: new_from_list => frag_new_from_list
+      procedure :: get_list => frag_get_list
+   end type tb_fragments
+
+
+   interface len
+      module procedure :: frag_length
+   end interface len
+
+
+contains
+
+
+subroutine frag_new_default(self, number_of_atoms)
+   class(tb_fragments), intent(out) :: self
+   integer, intent(in) :: number_of_atoms
+   allocate(self%list(number_of_atoms), source=0)
+end subroutine frag_new_default
+
+subroutine frag_new_from_list(self, list)
+   class(tb_fragments), intent(out) :: self
+   integer, intent(in) :: list(:)
+   if (all(list > 0)) then
+      self%list = list
+      self%n = maxval(list)
+   endif
+end subroutine frag_new_from_list
+
+
+integer pure elemental function frag_length(self) result(length)
+   class(tb_fragments), intent(in) :: self
+   if (allocated(self%list)) then
+      length = maxval(self%list)
+   else
+      length = 0
+   endif
+end function frag_length
+
+
+subroutine frag_get_list(self, fragment, list)
+   class(tb_fragments), intent(in) :: self
+   integer, intent(in) :: fragment
+   integer, allocatable, intent(out) :: list(:)
+   integer :: i
+   list = pack([(i, i=1, size(self%list))], mask=self%list.eq.fragment)
+end subroutine frag_get_list
+
+
+end module tbdef_fragments

--- a/xtb/tbdef_fragments.f90
+++ b/xtb/tbdef_fragments.f90
@@ -1,3 +1,20 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
 module tbdef_fragments
    implicit none
    public :: tb_fragments

--- a/xtb/tbdef_fragments.f90
+++ b/xtb/tbdef_fragments.f90
@@ -13,6 +13,7 @@ module tbdef_fragments
       procedure, private :: new_default => frag_new_default
       procedure, private :: new_from_list => frag_new_from_list
       procedure :: get_list => frag_get_list
+      procedure :: deallocate => frag_destroy
    end type tb_fragments
 
 
@@ -57,6 +58,12 @@ subroutine frag_get_list(self, fragment, list)
    integer :: i
    list = pack([(i, i=1, size(self%list))], mask=self%list.eq.fragment)
 end subroutine frag_get_list
+
+
+subroutine frag_destroy(self)
+   class(tb_fragments), intent(inout) :: self
+   if (allocated(self%list)) deallocate(self%list)
+end subroutine frag_destroy
 
 
 end module tbdef_fragments

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -24,9 +24,11 @@
 module tbdef_molecule
    use iso_fortran_env, only : wp => real64
    use tbdef_wsc
+   use tbdef_topology
    implicit none
 
    public :: tb_molecule
+   public :: len, size
 
    private
 
@@ -51,6 +53,7 @@ module tbdef_molecule
       real(wp) :: volume = 0.0_wp            !< volume of unit cell
       type(tb_wsc) :: wsc                    !< Wigner--Seitz cell
       integer  :: ftype = 0
+      type(tb_topology) :: bonds
    contains
    procedure :: allocate => allocate_molecule
    procedure :: deallocate => deallocate_molecule
@@ -82,6 +85,7 @@ module tbdef_molecule
          integer, intent(in), optional :: format
       end subroutine read_molecule_generic
    end interface
+
 
 contains
 

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -64,6 +64,17 @@ module tbdef_molecule
       character(len=4) :: segid = ' '
    end type pdb_data
 
+   !> sdf atomic data
+   !
+   !  we only support some entries, the rest is simply dropped.
+   !  the format is: ddcccssshhhbbbvvvHHHrrriiimmmnnneee
+   type :: sdf_data
+      integer :: isotope = 0   !< d field
+      integer :: charge = 0    !< c field
+      integer :: hydrogens = 0 !< h field
+      integer :: valence = 0   !< v field
+   end type sdf_data
+
    !> vasp input data
    !
    !  contains specific vasp keywords that modify the appearance of the
@@ -99,6 +110,8 @@ module tbdef_molecule
       type(tb_fragments) :: frag
       !> PDB specific information about residues and chains
       type(pdb_data), allocatable :: pdb(:)
+      !> SDF specific information about atom types
+      type(sdf_data), allocatable :: sdf(:)
       !> VASP specific information about input type
       type(vasp_data) :: vasp = vasp_data()
    contains
@@ -192,6 +205,9 @@ subroutine deallocate_molecule(self)
    if (allocated(self%z))      deallocate(self%z)
    if (allocated(self%cn))     deallocate(self%cn)
    if (allocated(self%pdb))    deallocate(self%pdb)
+   if (allocated(self%sdf))    deallocate(self%sdf)
+   call self%bonds%deallocate
+   call self%frag%deallocate
 end subroutine deallocate_molecule
 
 subroutine mol_update(self)

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -86,6 +86,17 @@ module tbdef_molecule
       logical :: cartesian = .false.
    end type vasp_info
 
+   !> Turbomole input data
+   !
+   !  Saves preferences for cartesian vs. direct coordinates and lattice vs. cell.
+   !  Also saves units of input data groups.
+   type :: turbo_info
+      logical :: cartesian = .true.
+      logical :: lattice = .true.
+      logical :: angs_lattice = .false.
+      logical :: angs_coord = .false.
+   end type turbo_info
+
    !> molecular structure information
    type :: tb_molecule
       integer  :: n = 0            !< number of atoms
@@ -116,6 +127,8 @@ module tbdef_molecule
       type(sdf_data), allocatable :: sdf(:)
       !> VASP specific information about input type
       type(vasp_info) :: vasp = vasp_info()
+      !> Turbomole specific information about input type
+      type(turbo_info) :: turbo = turbo_info()
       !> raw input buffer
       type(tb_buffer) :: info
    contains

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -79,11 +79,11 @@ module tbdef_molecule
    !
    !  contains specific vasp keywords that modify the appearance of the
    !  input file and can be used to reproduce it in the output
-   type :: vasp_data
+   type :: vasp_info
       real(wp) :: scale = 1.0_wp
       logical :: selective = .false.
       logical :: cartesian = .false.
-   end type
+   end type vasp_info
 
    !> molecular structure information
    type :: tb_molecule
@@ -106,6 +106,7 @@ module tbdef_molecule
       real(wp) :: volume = 0.0_wp            !< volume of unit cell
       type(tb_wsc) :: wsc                    !< Wigner--Seitz cell
       integer  :: ftype = 0                  !< file type of the input
+      character(len=:), allocatable :: name
       type(tb_topology) :: bonds
       type(tb_fragments) :: frag
       !> PDB specific information about residues and chains
@@ -113,7 +114,7 @@ module tbdef_molecule
       !> SDF specific information about atom types
       type(sdf_data), allocatable :: sdf(:)
       !> VASP specific information about input type
-      type(vasp_data) :: vasp = vasp_data()
+      type(vasp_info) :: vasp = vasp_info()
    contains
       procedure :: allocate => allocate_molecule
       procedure :: deallocate => deallocate_molecule
@@ -206,6 +207,7 @@ subroutine deallocate_molecule(self)
    if (allocated(self%cn))     deallocate(self%cn)
    if (allocated(self%pdb))    deallocate(self%pdb)
    if (allocated(self%sdf))    deallocate(self%sdf)
+   if (allocated(self%name))   deallocate(self%name)
    call self%bonds%deallocate
    call self%frag%deallocate
 end subroutine deallocate_molecule

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -36,6 +36,7 @@ module tbdef_molecule
    use tbdef_wsc
    use tbdef_topology
    use tbdef_fragments
+   use tbdef_buffer
    implicit none
 
    public :: tb_molecule
@@ -115,6 +116,8 @@ module tbdef_molecule
       type(sdf_data), allocatable :: sdf(:)
       !> VASP specific information about input type
       type(vasp_info) :: vasp = vasp_info()
+      !> raw input buffer
+      type(tb_buffer) :: info
    contains
       procedure :: allocate => allocate_molecule
       procedure :: deallocate => deallocate_molecule
@@ -210,6 +213,7 @@ subroutine deallocate_molecule(self)
    if (allocated(self%name))   deallocate(self%name)
    call self%bonds%deallocate
    call self%frag%deallocate
+   call self%info%deallocate
 end subroutine deallocate_molecule
 
 subroutine mol_update(self)

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -50,13 +50,15 @@ module tbdef_molecule
       real(wp) :: rec_lat(3,3) = 0.0_wp      !< reciprocal lattice parameters
       real(wp) :: volume = 0.0_wp            !< volume of unit cell
       type(tb_wsc) :: wsc                    !< Wigner--Seitz cell
+      integer  :: ftype = 0
    contains
    procedure :: allocate => allocate_molecule
    procedure :: deallocate => deallocate_molecule
    procedure :: calculate_distances
    procedure :: set_nuclear_charge
    procedure :: set_atomic_masses
-   procedure :: write => write_molecule
+   procedure :: write => write_molecule_generic
+   procedure :: read => read_molecule_generic
    procedure :: update
    procedure :: wrap_back
    procedure :: center_of_geometry,center_of_mass
@@ -64,6 +66,22 @@ module tbdef_molecule
    procedure :: moments_of_inertia
    procedure :: align_to_principal_axes
    end type tb_molecule
+
+   interface
+      module subroutine write_molecule_generic(self, unit, format, energy, gnorm)
+         class(tb_molecule), intent(in) :: self
+         integer, intent(in) :: unit
+         integer, intent(in), optional :: format
+         real(wp), intent(in), optional :: energy
+         real(wp), intent(in), optional :: gnorm
+      end subroutine write_molecule_generic
+
+      module subroutine read_molecule_generic(self, unit, format)
+         class(tb_molecule), intent(out) :: self
+         integer, intent(in) :: unit
+         integer, intent(in), optional :: format
+      end subroutine read_molecule_generic
+   end interface
 
 contains
 

--- a/xtb/tbdef_topology.f90
+++ b/xtb/tbdef_topology.f90
@@ -1,0 +1,146 @@
+module tbdef_topology
+   implicit none
+   public :: tb_topology
+   public :: len, size, assignment(=)
+   private
+
+
+   type :: tb_topology
+      private
+      integer :: order = 2
+      integer :: length = 0
+      integer, allocatable :: list(:,:)
+   contains
+      generic :: allocate => new_default, new_from_list
+      procedure, private :: new_default => top_new_default
+      procedure, private :: new_from_list => top_new_from_list
+      procedure, pass(self) :: to_list => list_assign_top
+      procedure :: push_back => top_push_back
+      procedure :: set_item => top_set_item
+      procedure :: get_item => top_get_item
+      procedure :: resize => top_resize
+      procedure :: deallocate => top_destroy
+   end type tb_topology
+
+
+   interface len
+      module procedure :: top_length
+   end interface len
+
+   interface size
+      module procedure :: top_size
+   end interface size
+
+   interface assignment(=)
+      module procedure :: top_new_from_list
+      module procedure :: list_assign_top
+   end interface assignment(=)
+
+
+contains
+
+
+subroutine top_new_default(self, order, size)
+   class(tb_topology), intent(out) :: self
+   integer, intent(in), optional :: order
+   integer, intent(in), optional :: size
+   if (present(order)) self%order = order
+   if (present(size)) call self%resize(size)
+end subroutine top_new_default
+
+subroutine top_new_from_list(self, list)
+   class(tb_topology), intent(out) :: self
+   integer, intent(in) :: list(:,:)
+   self%order = size(list, 1)
+   call self%resize(size(list, 2))
+   self%list = list
+end subroutine top_new_from_list
+
+subroutine list_assign_top(list, self)
+   class(tb_topology), intent(in) :: self
+   integer, allocatable, intent(out) :: list(:,:)
+   list = self%list(:,:len(self))
+end subroutine list_assign_top
+
+
+integer pure elemental function top_length(self) result(length)
+   class(tb_topology), intent(in) :: self
+   if (allocated(self%list)) then
+      length = self%length
+   else
+      length = 0
+   endif
+end function top_length
+
+integer pure elemental function top_size(self) result(length)
+   class(tb_topology), intent(in) :: self
+   if (allocated(self%list)) then
+      length = size(self%list, 2)
+   else
+      length = 0
+   endif
+end function top_size
+
+
+subroutine top_get_item(self, at, item)
+   class(tb_topology), intent(in) :: self
+   integer, intent(in) :: at
+   integer, intent(out) :: item(:)
+   if (at > len(self)) item = 0
+   item = self%list(:, at)
+end subroutine top_get_item
+
+subroutine top_set_item(self, at, item)
+   class(tb_topology), intent(inout) :: self
+   integer, intent(in) :: at
+   integer, intent(in) :: item(:)
+   if (at > len(self)) call self%resize(at)
+   self%list(:, at) = item
+end subroutine top_set_item
+
+
+subroutine top_push_back(self, item)
+   class(tb_topology), intent(inout) :: self
+   integer, intent(in) :: item(:)
+   integer :: pos, last, length
+
+   last = len(self)
+   if (last >= size(self)) call self%resize
+
+   self%length = last+1
+   self%list(:,last+1) = item
+end subroutine top_push_back
+
+subroutine top_resize(self, n)
+   class(tb_topology), intent(inout) :: self
+   integer, intent(in), optional :: n
+   integer, allocatable :: list(:,:)
+   integer :: length, current_length
+   current_length = size(self)
+   if (current_length > 0) then
+      if (present(n)) then
+         if (n <= current_length) return
+         length = n
+      else
+         length = current_length + current_length/2 + 1
+      endif
+      allocate(list(self%order, length), source=0)
+      list(:, :current_length) = self%list(:, :current_length)
+      deallocate(self%list)
+      call move_alloc(list, self%list)
+   else
+      if (present(n)) then
+         length = n
+      else
+         length = 64
+      endif
+      allocate(self%list(self%order, length), source=0)
+   endif
+end subroutine top_resize
+
+subroutine top_destroy(self)
+   class(tb_topology), intent(inout) :: self
+   if (allocated(self%list)) deallocate(self%list)
+end subroutine top_destroy
+
+end module tbdef_topology

--- a/xtb/tbdef_topology.f90
+++ b/xtb/tbdef_topology.f90
@@ -1,3 +1,20 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
 module tbdef_topology
    implicit none
    public :: tb_topology

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -7,6 +7,7 @@ module tbmod_file_utils
       integer :: tmol = 2
       integer :: sdf  = 3
       integer :: vasp = 4
+      integer :: pdb  = 5
    end type tb_enum_molecule
    type(tb_enum_molecule), public, parameter :: p_ftype = tb_enum_molecule()
 
@@ -54,6 +55,8 @@ subroutine file_generate_name(fname, basename, extension, ftype)
          fname = fname//'.sdf'
       case(p_ftype%vasp)
          fname = fname//'.poscar'
+      case(p_ftype%pdb)
+         fname = fname//'.pdb'
       end select
    endif
 end subroutine file_generate_name
@@ -76,6 +79,8 @@ subroutine file_figure_out_ftype(ftype, extension, basename)
          ftype = p_ftype%sdf
       case('poscar', 'contcar', 'vasp')
          ftype = p_ftype%vasp
+      case('pdb')
+         ftype = p_ftype%pdb
       case default
          if (len(basename) > 0) then
             select case(lowercase(basename))

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -5,7 +5,7 @@ module tbmod_file_utils
       integer :: default = 2  ! Turbomole format is default
       integer :: xyz  = 1
       integer :: tmol = 2
-      integer :: sdf  = 3
+      integer :: molfile = 3
       integer :: vasp = 4
       integer :: pdb  = 5
    end type tb_enum_molecule
@@ -51,8 +51,8 @@ subroutine file_generate_name(fname, basename, extension, ftype)
          fname = fname//'.xyz'
       case(p_ftype%tmol)
          fname = fname//'.coord'
-      case(p_ftype%sdf)
-         fname = fname//'.sdf'
+      case(p_ftype%molfile)
+         fname = fname//'.mol'
       case(p_ftype%vasp)
          fname = fname//'.poscar'
       case(p_ftype%pdb)
@@ -75,8 +75,8 @@ subroutine file_figure_out_ftype(ftype, extension, basename)
          ftype = p_ftype%tmol
       case('xyz')
          ftype = p_ftype%xyz
-      case('sdf')
-         ftype = p_ftype%sdf
+      case('mol')
+         ftype = p_ftype%molfile
       case('poscar', 'contcar', 'vasp')
          ftype = p_ftype%vasp
       case('pdb')

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -1,13 +1,31 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
 module tbmod_file_utils
    implicit none
 
    type, private :: tb_enum_molecule
       integer :: default = 2  ! Turbomole format is default
-      integer :: xyz  = 1
+      integer :: xyz = 1
       integer :: tmol = 2
       integer :: molfile = 3
       integer :: vasp = 4
-      integer :: pdb  = 5
+      integer :: pdb = 5
+      integer :: sdf = 6
    end type tb_enum_molecule
    type(tb_enum_molecule), public, parameter :: p_ftype = tb_enum_molecule()
 
@@ -53,6 +71,8 @@ subroutine file_generate_name(fname, basename, extension, ftype)
          fname = fname//'.coord'
       case(p_ftype%molfile)
          fname = fname//'.mol'
+      case(p_ftype%sdf)
+         fname = fname//'.sdf'
       case(p_ftype%vasp)
          fname = fname//'.poscar'
       case(p_ftype%pdb)
@@ -77,6 +97,8 @@ subroutine file_figure_out_ftype(ftype, extension, basename)
          ftype = p_ftype%xyz
       case('mol')
          ftype = p_ftype%molfile
+      case('sdf')
+         ftype = p_ftype%sdf
       case('poscar', 'contcar', 'vasp')
          ftype = p_ftype%vasp
       case('pdb')

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -1,0 +1,93 @@
+module tbmod_file_utils
+   implicit none
+
+   type, private :: tb_enum_molecule
+      integer :: default = 2  ! Turbomole format is default
+      integer :: xyz  = 1
+      integer :: tmol = 2
+      integer :: sdf  = 3
+      integer :: vasp = 4
+   end type tb_enum_molecule
+   type(tb_enum_molecule), public, parameter :: p_ftype = tb_enum_molecule()
+
+contains
+
+subroutine file_generate_meta_info(fname, extension, basename, directory)
+   character(len=*), intent(in) :: fname
+   character(len=:), allocatable, intent(out) :: extension, basename, directory
+   integer :: idot, islash
+   idot = index(fname, '.', back=.true.)
+   islash = index(fname, '/', back=.true.)
+   if (idot > islash .and. idot > 0) then
+      extension = fname(idot+1:)
+   else ! means point is somewhere in the path or absent
+      idot = len(fname)+1
+   endif
+   if (idot > islash .and. islash > 0) then
+      basename = fname(islash+1:idot-1)
+   endif
+   if (islash > 0) directory = fname(:islash)
+end subroutine file_generate_meta_info
+
+subroutine file_generate_name(fname, basename, extension, ftype)
+   use readin, only: find_new_name
+   character(len=:), allocatable, intent(out) :: fname
+   character(len=*), intent(in) :: basename
+   character(len=*), intent(in) :: extension
+   integer, intent(in) :: ftype
+
+   if (len(basename) > 0) then
+      fname = basename
+   else
+      fname = find_new_name('xtb')
+   endif
+
+   if (len(extension) > 0) then
+      fname = fname//'.'//extension
+   else
+      select case(ftype)
+      case(p_ftype%xyz)
+         fname = fname//'.xyz'
+      case(p_ftype%tmol)
+         fname = fname//'.coord'
+      case(p_ftype%sdf)
+         fname = fname//'.sdf'
+      case(p_ftype%vasp)
+         fname = fname//'.poscar'
+      end select
+   endif
+end subroutine file_generate_name
+
+subroutine file_figure_out_ftype(ftype, extension, basename)
+   use mctc_strings, only: lowercase
+   integer, intent(out) :: ftype
+   character(len=*), intent(in) :: extension
+   character(len=*), intent(in) :: basename
+
+   ftype = p_ftype%default
+
+   if (len(extension) > 0) then
+      select case(lowercase(extension))
+      case('coord', 'tmol')
+         ftype = p_ftype%tmol
+      case('xyz')
+         ftype = p_ftype%xyz
+      case('sdf')
+         ftype = p_ftype%sdf
+      case('poscar', 'contcar', 'vasp')
+         ftype = p_ftype%vasp
+      case default
+         if (len(basename) > 0) then
+            select case(lowercase(basename))
+            case('coord')
+               ftype = p_ftype%tmol
+            case('poscar', 'contcar')
+               ftype = p_ftype%vasp
+            end select
+         endif
+      end select
+   endif
+
+end subroutine file_figure_out_ftype
+
+end module tbmod_file_utils


### PR DESCRIPTION
With this PR we aim to restructure the IO for molecular structure information. Currently every driver is implementing its own reader and writer routines, also most of the meta data from the input is dropped or not stored in a suitable place close to the molecular structure.

- [x] add type-bound procedures for `tb_molecule` class
  - [x] generic reader from unit
  - ~generic reader from file name~ (handled by caller)
  - [x] generic writer to unit
  - ~generic writer to file name~ (handled by caller)
  - [x] allow additional tags on atoms (no generalized tags, to much overhead)
    - [x] molfile/SDF specific tags
    - [x] PDB specific tags
  - [x] allow meta data stored along with the molecule (needed for SDF)
    - [x] VASP input format information
    - [x] SDF info block (~either key-value pairs or~ raw string block)
- [x] rework backend reader/writer for common formats (remove `rewind` statements)
  - [x] Turbomole coordinate format
  - [x] xyz coordinate format
  - [x] molfile coordinate format
  - [x] SDF coordinate format (see #26)
  - [x] VASP coordinate format
  - [x] PDB coordinate format
- [x] add topology information to molecule class
  - [x] new topology class
  - ~allow additional tags on bonds/angles~ (information produced in `xtb`)
- [x] add fragment information to molecule class
  - [x] new fragment class

closes #26 
- addresses R1 -> error on 2D structure
- addresses R3 -> adds error for H atom query, otherwise GIGO
- addresses R5 -> checks for charges, ignores radical information
- ignores R2, R6 (not in scope for the PR, see #34)
- ignores R4 (not in scope for `xtb`)

closes #28 (adds error for H atom query)