### PR TITLE
fix missing initialization of electronic entropy

### DIFF
--- a/xtb/scc_core.f90
+++ b/xtb/scc_core.f90
@@ -566,6 +566,9 @@ subroutine scc_gfn1(iunit,n,nel,nopen,ndim,nmat,nshell, &
          call fermismear(.false.,ndim,ihomob,et,emo,foccb,nfodb,efb,gb)
       endif
       focc = focca + foccb
+   else
+      ga = 0.0_wp
+      gb = 0.0_wp
    endif
 !! ------------------------------------------------------------------------
 
@@ -894,6 +897,9 @@ subroutine scc_gfn2(iunit,n,nel,nopen,ndim,ndp,nqp,nmat,nshell, &
          call fermismear(.false.,ndim,ihomob,et,emo,foccb,nfodb,efb,gb)
       endif
       focc = focca + foccb
+   else
+      ga = 0.0_wp
+      gb = 0.0_wp
    endif
 
 !  save q


### PR DESCRIPTION
for temperatures smaller 0.1 K the electronic entropy is not initialized in the SCC iterator (should be zero), nevertheless it is always added to the electronic energy afterwards.

This adds an explicit initialization for the electronic entropy to avoid issues in the future.

Thanks to Oliver Unke for reporting this.