### PR TITLE
raise exception if calculator without PBC is called with periodic input

### DIFF
--- a/python/xtb/calculators.py
+++ b/python/xtb/calculators.py
@@ -179,6 +179,8 @@ class GFN1(XTB):
 
     def create_arguments(self) -> dict:
         """create a list of arguments."""
+        if any(self.atoms.pbc):
+            raise NotImplementedError("GFN1-xTB is not available with PBC!")
         kwargs = {
             'natoms': len(self.atoms),
             'numbers': np.array(self.atoms.get_atomic_numbers(), dtype=c_int),
@@ -237,6 +239,8 @@ class GFN2(XTB):
 
     def create_arguments(self) -> dict:
         """create a list of arguments."""
+        if any(self.atoms.pbc):
+            raise NotImplementedError("GFN2-xTB is not available with PBC!")
         kwargs = {
             'natoms': len(self.atoms),
             'numbers': np.array(self.atoms.get_atomic_numbers(), dtype=c_int),

--- a/python/xtb/solvation.py
+++ b/python/xtb/solvation.py
@@ -94,6 +94,8 @@ class GBSA(Calculator):
 
     def create_arguments(self) -> dict:
         """create a list of arguments."""
+        if any(self.atoms.pbc):
+            raise NotImplementedError("GBSA is not available with PBC!")
         kwargs = {
             'natoms': len(self.atoms),
             'numbers': np.array(self.atoms.get_atomic_numbers(), dtype=c_int),


### PR DESCRIPTION
fixes #32 

- [x] GFN1-xTB / GFN2-xTB calculator raises `NotImplementedError` for periodic input
- [x] GBSA calculator might also raise `NotImplementedError` for periodic input