### PR TITLE
Change the pcgrad out format to match the amber/orca interface

### DIFF
--- a/xtb/single.f90
+++ b/xtb/single.f90
@@ -142,8 +142,9 @@ subroutine singlepoint &
    ! point charge embedding gradient file
    if (pcem%n > 0) then
       call open_file(ich,pcem_grad,'w')
+      write(ich, '(i0)') pcem%n
       do i=1,pcem%n
-         write(ich,'(3f12.8)')pcem%grd(1:3,i)
+         write(ich,'(3f17.12)')pcem%grd(1:3,i)
       enddo
       call close_file(ich)
    endif


### PR DESCRIPTION
The output of the gradient of the point charge is not consistent with the orca default output. Thus, when one uses the amber/ORCA interface with xtb. Error occurs. I have changed the pcgrad to the format which is compatible with the amber/ORCA interface and is tested against the ambertools18.

Linked to issue #41 

It is fine that this PR doesn't get merged. I just think it would be nice if people want to do this.