### PR TITLE
remove help printout for verbose runs since it clutters the screen

### DIFF
--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -245,13 +245,6 @@ program XTBprog
 !  how to cite this program
    call citation(istdout)
 
-!! ------------------------------------------------------------------------
-!  lets show what we can do, because we can
-!  this clutters the screen quite a bit since we started actually
-!  documenting our options, so we will only do this if the user set
-!  the program in verbose mode
-   if (verbose) call help
-
 !! ========================================================================
 !  check if you are allowed to make a calculation today
    call prdate('S')


### PR DESCRIPTION
no more additional help printout in verbose mode (use `--help` or `-h` instead), since it just clutters the screen and does not add any useful information.