### PR TITLE
Enable Build with GCC

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -1,0 +1,16 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  linux-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: sudo apt install -yq --no-install-recommends gfortran ninja-build liblapack-dev libblas-dev
+    - run: pip3 install meson
+    - run: meson setup build_gcc --buildtype release -Dla_backend=netlib --warnlevel 0
+    - run: ninja -C build_gcc
+    - run: cd build_gcc && meson test --suite basic

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -9,8 +9,18 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
-    - run: sudo apt install -yq --no-install-recommends gfortran ninja-build liblapack-dev libblas-dev
+    - run: sudo apt install -yq --no-install-recommends gfortran-8 ninja-build liblapack-dev libblas-dev
     - run: pip3 install meson
-    - run: meson setup build_gcc --buildtype release -Dla_backend=netlib --warnlevel 0
-    - run: ninja -C build_gcc
-    - run: cd build_gcc && meson test --suite basic
+    - run: FC=gfortran-8 CC=gcc-8 meson setup build_gcc --buildtype release -Dla_backend=netlib --warnlevel 0
+    - run: ninja -C build_gcc test
+
+  osx-build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: brew install gcc@8 ninja meson lapack
+    - run: FC=gfortran-8 CC=gcc-8 meson setup build_gcc --buildtype release -Dla_backend=netlib --warnlevel 0
+    - run: ninja -C build_gcc test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Semiempirical Extended Tight-Binding Program Package
 
+[![Build Status](https://github.com/grimme-lab/xtb/workflows/CI/badge.svg)](https://github.com/grimme-lab/xtb/actions)
 [![License](https://img.shields.io/github/license/grimme-lab/xtb)](https://github.com/grimme-lab/xtb/blob/master/COPYING)
 [![Latest Version](https://img.shields.io/github/v/release/grimme-lab/xtb)](https://github.com/grimme-lab/xtb/releases/latest)
 [![Github Downloads All Releases](https://img.shields.io/github/downloads/grimme-lab/xtb/total)](https://github.com/grimme-lab/xtb/releases)

--- a/TESTSUITE/gfn0.f90
+++ b/TESTSUITE/gfn0.f90
@@ -39,7 +39,6 @@ subroutine test_gfn0_sp
    logical, parameter :: restart = .false.
    real(wp),parameter :: acc = 1.0_wp
 
-   type(gfn_parameter)   :: gfn
    type(tb_environment)  :: env
    type(tb_molecule)     :: mol
    type(scc_results)     :: res
@@ -157,7 +156,6 @@ subroutine test_gfn0_api
 
    type(tb_molecule)    :: mol
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
 
    real(wp) :: energy
    real(wp) :: hl_gap
@@ -178,7 +176,7 @@ subroutine test_gfn0_api
    gradient = 0.0_wp
 
    call gfn0_calculation &
-      (istdout,env,opt,mol,gfn,hl_gap,energy,gradient,dum,dum)
+      (istdout,env,opt,mol,hl_gap,energy,gradient,dum,dum)
 
    call assert_close(hl_gap, 5.5384029314207_wp,thr)
    call assert_close(energy,-8.6908532561691_wp,thr)

--- a/TESTSUITE/gfn1.f90
+++ b/TESTSUITE/gfn1.f90
@@ -145,7 +145,6 @@ subroutine test_gfn1_api
 
    type(tb_molecule)    :: mol
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
    type(tb_wavefunction):: wfn
 
@@ -167,7 +166,7 @@ subroutine test_gfn1_api
    gradient = 0.0_wp
 
    call gfn1_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 5.6067613075402_wp,thr)
    call assert_close(energy,-8.4156335932985_wp,thr)
@@ -215,7 +214,6 @@ subroutine test_gfn1gbsa_api
 
    type(tb_molecule)    :: mol
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
    type(tb_wavefunction):: wfn
 
@@ -237,7 +235,7 @@ subroutine test_gfn1gbsa_api
    gradient = 0.0_wp
 
    call gfn1_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 6.641641300724_wp,1e-4_wp)
    call assert_close(energy,-14.215790820910_wp,thr)
@@ -268,7 +266,7 @@ subroutine test_gfn1_pcem_api
 
    implicit none
 
-   real(wp),parameter :: thr = 1.0e-10_wp
+   real(wp),parameter :: thr = 1.0e-9_wp
    integer, parameter :: nat = 12, nat2 = nat/2
    integer, parameter :: at(nat) = [8,1,1, 8,1,1, 8,1,1, 8,1,1]
    real(wp),parameter :: xyz(3,nat) = reshape([&
@@ -292,7 +290,6 @@ subroutine test_gfn1_pcem_api
 
    type(tb_molecule)    :: mol
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
    type(tb_wavefunction):: wfn
 
@@ -314,7 +311,7 @@ subroutine test_gfn1_pcem_api
    gradient = 0.0_wp
 
    call gfn1_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 9.0155275960407_wp,thr*10)
    call assert_close(energy,-23.113490916186_wp,thr)
@@ -344,7 +341,7 @@ subroutine test_gfn1_pcem_api
    pcem%grd = 0.0_wp
 
    call gfn1_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 8.7253450666347_wp,thr)
    call assert_close(energy,-11.559896105984_wp,thr)
@@ -368,7 +365,7 @@ subroutine test_gfn1_pcem_api
    pcem%gam = 999.0_wp ! point charges
 
    call gfn1_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 8.9183046297437_wp,thr)
    call assert_close(energy,-11.565012263827_wp,thr)

--- a/TESTSUITE/gfn2.f90
+++ b/TESTSUITE/gfn2.f90
@@ -153,7 +153,6 @@ subroutine test_gfn2_api
    type(tb_molecule)    :: mol
    type(tb_wavefunction):: wfn
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
 
    real(wp) :: energy
@@ -174,7 +173,7 @@ subroutine test_gfn2_api
    gradient = 0.0_wp
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 7.0005867526665_wp,thr)
    call assert_close(energy,-8.3824793818504_wp,thr)
@@ -226,7 +225,6 @@ subroutine test_gfn2gbsa_api
    type(tb_molecule)    :: mol
    type(tb_wavefunction):: wfn
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
 
    real(wp) :: energy
@@ -247,7 +245,7 @@ subroutine test_gfn2gbsa_api
    gradient = 0.0_wp
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 3.408607724814_wp,1e-5_wp)
    call assert_close(energy,-22.002501380096_wp,thr)
@@ -297,7 +295,6 @@ subroutine test_gfn2salt_api
    type(tb_molecule)    :: mol
    type(tb_wavefunction):: wfn
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
 
    real(wp) :: energy
@@ -322,7 +319,7 @@ subroutine test_gfn2salt_api
    ionst = 1.0e-3_wp
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 6.895830675032_wp,5e-5_wp)
    call assert_close(energy,-13.027106170796_wp,thr)
@@ -379,7 +376,6 @@ subroutine test_gfn2_pcem_api
    type(tb_molecule)    :: mol
    type(tb_wavefunction):: wfn
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
    type(tb_pcem)        :: pcem
 
    real(wp) :: energy
@@ -400,7 +396,7 @@ subroutine test_gfn2_pcem_api
    gradient = 0.0_wp
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 12.391144583778_wp,thr)
    call assert_close(energy,-20.323978513218_wp,thr)
@@ -430,7 +426,7 @@ subroutine test_gfn2_pcem_api
    pcem%grd = 0.0_wp
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 12.718203165741_wp,thr)
    call assert_close(energy,-10.160927752124_wp,thr)
@@ -454,7 +450,7 @@ subroutine test_gfn2_pcem_api
    pcem%gam = 999.0_wp ! point charges
 
    call gfn2_calculation &
-      (istdout,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (istdout,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    call assert_close(hl_gap, 13.024345612330_wp,thr)
    call assert_close(energy,-10.168788269555_wp,thr)

--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -1,0 +1,130 @@
+# This file is part of xtb.
+#
+# Copyright (C) 2019-2020 Sebastian Ehlert
+#
+# xtb is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+xtb_test = [files('tests_peeq.f90')]
+xtb_test += files('assertion.f90')
+xtb_test += files('tbdef_molecule.f90')
+xtb_test += files('tbdef_wsc.f90')
+xtb_test += files('geometry_reader.f90')
+xtb_test += files('eeq_model.f90')
+xtb_test += files('pbc_tools.f90')
+xtb_test += files('dftd4.f90')
+xtb_test += files('gfn2.f90')
+xtb_test += files('gfn1.f90')
+xtb_test += files('gfn0.f90')
+xtb_test += files('peeq.f90')
+xtb_test += files('symmetry.f90')
+xtb_test += files('thermo.f90')
+xtb_test += files('tbdef_atomlist.f90')
+
+xtb_test = executable('xtb_test',
+                      xtb_test,
+                      dependencies: dependencies_exe,
+                      include_directories: incdir,
+                      link_with: xtb_lib_static)
+
+# some very basic checks to see if the executable reacts at all
+test('Argparser: print version', xtb_exe, args: '--version', env: xtbenv)
+test('Argparser: print help', xtb_exe, args: '--help', env: xtbenv)
+test('Argparser: print license', xtb_exe, args: '--license', env: xtbenv)
+test('Argparser: no arguments', xtb_exe, should_fail: true, env: xtbenv)
+
+test('Singlepoint', xtb_exe, args: ['--coffee', '--strict', '--norestart'], env: xtbenv)
+if get_option('la_backend') != 'netlib'
+  test('Geometry opt.', xtb_exe, args: ['--coffee', '--opt', '--strict', '--norestart'], env: xtbenv)
+endif
+test('IP/EA', xtb_exe, args: ['--coffee', '--gfn', '2', '--vipea', '--strict', '--norestart'], env: xtbenv)
+test('GFN0-xTB', xtb_exe, args: ['--coffee', '--gfn', '0', '--strict', '--norestart'], env: xtbenv)
+test('GFN1-xTB', xtb_exe, args: ['--coffee', '--gfn', '1', '--strict', '--norestart'], env: xtbenv)
+test('GFN2-xTB/GBSA', xtb_exe, args: ['--coffee', '--gfn', '2', '--strict', '--gbsa', 'h2o', '--norestart'], env: xtbenv)
+
+# more specific tests are implemented by the tester binary
+test('Molecule: axis', xtb_test, args: ['tbdef_molecule', 'axis'], env: xtbenv)
+test('Molecule: MIC', xtb_test, args: ['tbdef_molecule', 'mic'], env: xtbenv)
+
+if fc.get_id() == 'intel'
+  test('Wigner-Seitz Cell (0D)', xtb_test, args: ['tbdef_wsc', '0d'], env: xtbenv)
+endif
+test('Wigner-Seitz Cell (3D)', xtb_test, args: ['tbdef_wsc', '3d'], env: xtbenv)
+
+if fc.get_id() == 'intel'
+  test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'], env: xtbenv)
+endif
+
+test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_a'], env: xtbenv)
+test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_b'], env: xtbenv)
+test('coord 2D', xtb_test, args: ['geometry_reader', 'coord_2d'], env: xtbenv)
+test('coord 1D', xtb_test, args: ['geometry_reader', 'coord_1d'], env: xtbenv)
+test('coord 0D', xtb_test, args: ['geometry_reader', 'coord_0d'], env: xtbenv)
+test('Xmol  0D', xtb_test, args: ['geometry_reader', 'xmol_0d'], env: xtbenv)
+test('POSCAR', xtb_test, args: ['geometry_reader', 'poscar_3d'], env: xtbenv)
+test('molfile', xtb_test, args: ['geometry_reader', 'molfile'], env: xtbenv)
+test('molfile flat', xtb_test, should_fail: true, args: ['geometry_reader', 'molfile_flat'], env: xtbenv)
+test('SDF', xtb_test, args: ['geometry_reader', 'sdfile'], env: xtbenv)
+test('SDF flat', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_flat'], env: xtbenv)
+test('SDF no H', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_noh'], env: xtbenv)
+test('PDB', xtb_test, args: ['geometry_reader', 'pdb'], env: xtbenv)
+test('PDB no H', xtb_test, should_fail: true, args: ['geometry_reader', 'pdb_noh'], env: xtbenv)
+test('genFormat', xtb_test, args: ['geometry_reader', 'gen'], env: xtbenv)
+
+test('PBC tools: convert',xtb_test, args: ['pbc_tools', 'convert'], env: xtbenv)
+test('PBC tools: cutoff', xtb_test, args: ['pbc_tools', 'cutoff'], env: xtbenv)
+
+test('Symmetry: Water', xtb_test, args: ['symmetry', 'water'], env: xtbenv)
+test('Symmetry: Li8', xtb_test, args: ['symmetry', 'li8'], env: xtbenv)
+test('Symmetry: PCl3', xtb_test, args: ['symmetry', 'pcl3'], env: xtbenv)
+test('Symmetry: large', xtb_test, args: ['symmetry', 'c20'], env: xtbenv)
+
+test('Thermo: axis', xtb_test, args: ['thermo', 'axis'], env: xtbenv)
+test('Thermo: calculation', xtb_test, args: ['thermo', 'calc'], env: xtbenv)
+test('Thermo: print', xtb_test, args: ['thermo', 'print'], env: xtbenv)
+
+test('EEQ model: water', xtb_test,args: ['eeq_model', 'water'], env: xtbenv)
+test('EEQ model: 3D Ewald', xtb_test,args: ['eeq_model', 'ewald'], env: xtbenv)
+test('EEQ model: GBSA', xtb_test,args: ['eeq_model', 'gbsa'], env: xtbenv)
+test('EEQ model: GBSA (salt)', xtb_test,args: ['eeq_model', 'salt'], env: xtbenv)
+test('EEQ model: GBSA (H-bond)', xtb_test,args: ['eeq_model', 'hbond'], env: xtbenv)
+
+test('Dispersion: properties', xtb_test,args: ['dftd4', 'properties'], env: xtbenv)
+test('Dispersion: energies', xtb_test,args: ['dftd4', 'energies'], env: xtbenv)
+test('Dispersion: energies (PBC)', xtb_test,args: ['dftd4', 'pbc_disp'], env: xtbenv)
+#test('Dispersion: cell gradients', xtb_test,args: ['dftd4', 'cell_gradient'] env: xtbenv)
+test('Dispersion: API', xtb_test,args: ['dftd4', 'api'], env: xtbenv)
+#test('Dispersion: API (PBC)', xtb_test,args: ['dftd4', 'pbc_api'] env: xtbenv)
+
+test('GFN2-xTB: SCC', xtb_test, args: ['gfn2', 'scc'], env: xtbenv)
+test('GFN2-xTB: API', xtb_test, args: ['gfn2', 'api'], env: xtbenv)
+test('GFN2-xTB: API (GBSA)', xtb_test, args: ['gfn2', 'gbsa'], env: xtbenv)
+test('GFN2-xTB: API (GBSA+salt)', xtb_test, args: ['gfn2', 'salt'], env: xtbenv)
+test('GFN2-xTB: API (PCEM)', xtb_test, args: ['gfn2', 'pcem'], env: xtbenv)
+if cc.get_id() == 'intel'
+   test('GFN2-xTB: C', executable('xtb_c_test', files('c_api_example.c'),
+                                  include_directories: incdir,
+                                  link_with: xtb_lib_static,
+                                  dependencies: dependencies_exe),
+                                  env: xtbenv)
+endif
+
+test('GFN1-xTB: SCC', xtb_test, args: ['gfn1', 'scc'], env: xtbenv)
+test('GFN1-xTB: API', xtb_test, args: ['gfn1', 'api'], env: xtbenv)
+test('GFN1-xTB: API (GBSA)', xtb_test, args: ['gfn1', 'gbsa'], env: xtbenv)
+test('GFN1-xTB: API (PCEM)', xtb_test, args: ['gfn1', 'pcem'], env: xtbenv)
+
+test('GFN0-xTB: SP', xtb_test, args: ['gfn0', 'sp'], env: xtbenv)
+test('GFN0-xTB: API', xtb_test, args: ['gfn0', 'api'], env: xtbenv)
+test('GFN0-xTB: SP  (PBC)', xtb_test, args: ['peeq', 'sp'], env: xtbenv)
+test('GFN0-xTB: API (PBC)', xtb_test, args: ['peeq', 'api'], env: xtbenv)

--- a/TESTSUITE/peeq.f90
+++ b/TESTSUITE/peeq.f90
@@ -42,7 +42,6 @@ subroutine test_peeq_sp
    real(wp),parameter :: acc = 1.0_wp
 
    type(tb_molecule)     :: mol
-   type(gfn_parameter)   :: gfn
    type(tb_environment)  :: env
    type(tb_wavefunction) :: wfn
    type(tb_basisset)     :: basis
@@ -197,7 +196,6 @@ subroutine test_peeq_api
 
    type(tb_molecule)    :: mol
    type(tb_environment) :: env
-   type(gfn_parameter)  :: gfn
 
    real(wp) :: energy
    real(wp) :: hl_gap
@@ -229,7 +227,7 @@ subroutine test_peeq_api
    call mctc_mute
 
    call gfn0_calculation &
-      (istdout,env,opt,mol,gfn,hl_gap,energy,gradient,stress,gradlatt)
+      (istdout,env,opt,mol,hl_gap,energy,gradient,stress,gradlatt)
 
    call assert_close(hl_gap, 4.8620892163953_wp,thr)
    call assert_close(energy,-8.4898922181241_wp,thr)

--- a/meson.build
+++ b/meson.build
@@ -17,10 +17,17 @@
 
 # extended tight binding program package
 project('xtb',
-        'fortran', 'c', 'cpp',
+        'fortran', 'c',
         version: '6.2.2',
         license: 'LGPL3',
         meson_version: '>=0.49')
+
+fc = meson.get_compiler('fortran')
+cc = meson.get_compiler('c')
+
+if fc.get_id() != cc.get_id()
+  warning('FC and CC are not from the same vendor')
+endif
 
 # build a configuration data containing all the important data to propagate
 # it to the automatically generated files
@@ -42,10 +49,6 @@ config = configuration_data({
 configure_file(input : 'xtb'/'version.f90', output : 'xtb_version.fh',
   configuration : config)
 
-fc = meson.get_compiler('fortran')
-cc = meson.get_compiler('c')
-cxx= meson.get_compiler('cpp')
-
 if fc.get_id() == 'gcc'
   add_project_arguments('-fdefault-real-8', language: 'fortran')
   add_project_arguments('-fdefault-double-8', language: 'fortran')
@@ -57,12 +60,6 @@ elif fc.get_id() == 'intel'
   add_project_arguments('-traceback', language: 'fortran')
   add_project_link_arguments('-static', language: 'fortran')
   add_project_link_arguments('-static', language: 'c') # icc will do linking
-endif
-
-if cxx.get_id() == 'gcc'
-  add_project_arguments('-std=c++11', language: 'cpp')
-elif cxx.get_id() == 'intel'
-  add_project_arguments('-std=c++11', language: 'cpp')
 endif
 
 if cc.get_id() == 'gcc'
@@ -83,9 +80,6 @@ dependencies_sha = []
 
 if get_option('la_backend') == 'mkl'
   add_project_arguments('-DWITH_MKL', language: 'fortran')
-  libmkl = [fc.find_library('pthread')]
-  libmkl += fc.find_library('m')
-  libmkl += fc.find_library('dl')
   if fc.get_id() == 'gcc'
     libmkl_exe = [fc.find_library('mkl_gf_lp64')]
     libmkl_exe += fc.find_library('mkl_gnu_thread')
@@ -96,22 +90,30 @@ if get_option('la_backend') == 'mkl'
   libmkl_exe += fc.find_library('mkl_core')
   libmkl_exe += fc.find_library('iomp5')
   libmkl_sha = [fc.find_library('mkl_rt')]
-  dependencies += libmkl
   dependencies_sha += libmkl_sha
   dependencies_exe += libmkl_exe
+elif get_option('la_backend') == 'openblas'
+  dependencies += fc.find_library('openblas', required: true)
+  dependencies += fc.find_library('lapack', required: true)
+elif get_option('la_backend') == 'custom'
+  foreach lib: get_option('custom_libraries')
+    dependencies += fc.find_library(lib)
+  endforeach
 else
   dependencies += fc.find_library('blas', required: true)
   dependencies += fc.find_library('lapack', required: true)
 endif
 
-if fc.get_id() == 'gcc'
-  add_project_arguments('-fopenmp', language: 'fortran')
-  add_project_link_arguments('-fopenmp', language: 'fortran')
-  add_project_link_arguments('-fopenmp', language: 'c')
-elif fc.get_id() == 'intel'
-  add_project_arguments('-qopenmp', language: 'fortran')
-  add_project_link_arguments('-qopenmp', language: 'fortran')
-  add_project_link_arguments('-qopenmp', language: 'c')
+if get_option('openmp')
+  if fc.get_id() == 'gcc'
+    add_project_arguments('-fopenmp', language: 'fortran')
+    add_project_link_arguments('-fopenmp', language: 'fortran')
+    add_project_link_arguments('-fopenmp', language: 'c')
+  elif fc.get_id() == 'intel'
+    add_project_arguments('-qopenmp', language: 'fortran')
+    add_project_link_arguments('-qopenmp', language: 'fortran')
+    add_project_link_arguments('-qopenmp', language: 'c')
+  endif
 endif
 dependencies += dependency('threads')
 
@@ -352,22 +354,6 @@ xtb_srcs += 'xtb/gfn1_calculator.f90'
 xtb_srcs += 'xtb/gfn2_calculator.f90'
 xtb_srcs += 'xtb/c_api.f90'
 
-xtb_test = ['TESTSUITE/tests_peeq.f90']
-xtb_test += 'TESTSUITE/assertion.f90'
-xtb_test += 'TESTSUITE/tbdef_molecule.f90'
-xtb_test += 'TESTSUITE/tbdef_wsc.f90'
-xtb_test += 'TESTSUITE/geometry_reader.f90'
-xtb_test += 'TESTSUITE/eeq_model.f90'
-xtb_test += 'TESTSUITE/pbc_tools.f90'
-xtb_test += 'TESTSUITE/dftd4.f90'
-xtb_test += 'TESTSUITE/gfn2.f90'
-xtb_test += 'TESTSUITE/gfn1.f90'
-xtb_test += 'TESTSUITE/gfn0.f90'
-xtb_test += 'TESTSUITE/peeq.f90'
-xtb_test += 'TESTSUITE/symmetry.f90'
-xtb_test += 'TESTSUITE/thermo.f90'
-xtb_test += 'TESTSUITE/tbdef_atomlist.f90'
-
 incdir = include_directories('include')
 
 xtb_srcs += mctc_srcs
@@ -443,122 +429,33 @@ endif
 ## ========================================== ##
 ## TESTSUITE
 ## ========================================== ##
-xtb_test = executable('xtb_test',
-                      xtb_test,
-                      dependencies: dependencies_exe,
-                      include_directories: incdir,
-                      link_with: xtb_lib_static)
-
 # make sure the correct library is loaded
 xtbenv = environment()
 xtbenv.prepend('LD_LIBRARY_PATH', meson.current_build_dir())
 xtbenv.prepend('PYTHONPATH', meson.current_source_dir() / 'python')
 xtbenv.set('XTBPATH', meson.current_source_dir())
 
-# some very basic checks to see if the executable reacts at all
-test('Argparser: print version', xtb_exe, args: '--version', env: xtbenv, suite: 'basic')
-test('Argparser: print help', xtb_exe, args: '--help', env: xtbenv, suite: 'basic')
-test('Argparser: print license', xtb_exe, args: '--license', env: xtbenv, suite: 'basic')
-test('Argparser: no arguments', xtb_exe, should_fail: true, env: xtbenv, suite: 'basic')
-
-test('Singlepoint', xtb_exe, args: ['--coffee', '--strict', '--norestart'], env: xtbenv, suite: 'run')
-test('Geometry opt.', xtb_exe, args: ['--coffee', '--opt', '--strict', '--norestart'], env: xtbenv, suite: 'run')
-test('IP/EA', xtb_exe, args: ['--coffee', '--gfn', '2', '--vipea', '--strict', '--norestart'], env: xtbenv, suite: 'run')
-test('GFN0-xTB', xtb_exe, args: ['--coffee', '--gfn', '0', '--strict', '--norestart'], env: xtbenv, suite: 'run')
-test('GFN1-xTB', xtb_exe, args: ['--coffee', '--gfn', '1', '--strict', '--norestart'], env: xtbenv, suite: 'run')
-test('GFN2-xTB/GBSA', xtb_exe, args: ['--coffee', '--gfn', '2', '--strict', '--gbsa', 'h2o', '--norestart'], env: xtbenv, suite: 'run')
-
-# more specific tests are implemented by the tester binary
-test('Molecule: axis', xtb_test, args: ['tbdef_molecule', 'axis'], env: xtbenv, suite: 'class')
-test('Molecule: MIC', xtb_test, args: ['tbdef_molecule', 'mic'], env: xtbenv, suite: 'class')
-
-test('Wigner-Seitz Cell (0D)', xtb_test, args: ['tbdef_wsc', '0d'], env: xtbenv, suite: 'class')
-test('Wigner-Seitz Cell (3D)', xtb_test, args: ['tbdef_wsc', '3d'], env: xtbenv, suite: 'class')
-
-test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'], env: xtbenv, suite: 'class')
-
-test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_a'], env: xtbenv, suite: 'input')
-test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_b'], env: xtbenv, suite: 'input')
-test('coord 2D', xtb_test, args: ['geometry_reader', 'coord_2d'], env: xtbenv, suite: 'input')
-test('coord 1D', xtb_test, args: ['geometry_reader', 'coord_1d'], env: xtbenv, suite: 'input')
-test('coord 0D', xtb_test, args: ['geometry_reader', 'coord_0d'], env: xtbenv, suite: 'input')
-test('Xmol  0D', xtb_test, args: ['geometry_reader', 'xmol_0d'], env: xtbenv, suite: 'input')
-test('POSCAR', xtb_test, args: ['geometry_reader', 'poscar_3d'], env: xtbenv, suite: 'input')
-test('molfile', xtb_test, args: ['geometry_reader', 'molfile'], env: xtbenv, suite: 'input')
-test('molfile flat', xtb_test, should_fail: true, args: ['geometry_reader', 'molfile_flat'], env: xtbenv, suite: 'input')
-test('SDF', xtb_test, args: ['geometry_reader', 'sdfile'], env: xtbenv, suite: 'input')
-test('SDF flat', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_flat'], env: xtbenv, suite: 'input')
-test('SDF no H', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_noh'], env: xtbenv, suite: 'input')
-test('PDB', xtb_test, args: ['geometry_reader', 'pdb'], env: xtbenv, suite: 'input')
-test('PDB no H', xtb_test, should_fail: true, args: ['geometry_reader', 'pdb_noh'], env: xtbenv, suite: 'input')
-test('genFormat', xtb_test, args: ['geometry_reader', 'gen'], env: xtbenv, suite: 'input')
-
-test('PBC tools: convert',xtb_test, args: ['pbc_tools', 'convert'], env: xtbenv, suite: 'utils')
-test('PBC tools: cutoff', xtb_test, args: ['pbc_tools', 'cutoff'], env: xtbenv, suite: 'utils')
-
-test('Symmetry: Water', xtb_test, args: ['symmetry', 'water'], env: xtbenv, suite: 'utils')
-test('Symmetry: Li8', xtb_test, args: ['symmetry', 'li8'], env: xtbenv, suite: 'utils')
-test('Symmetry: PCl3', xtb_test, args: ['symmetry', 'pcl3'], env: xtbenv, suite: 'utils')
-test('Symmetry: large', xtb_test, args: ['symmetry', 'c20'], env: xtbenv, suite: 'utils')
-
-test('Thermo: axis', xtb_test, args: ['thermo', 'axis'], env: xtbenv, suite: 'utils')
-test('Thermo: calculation', xtb_test, args: ['thermo', 'calc'], env: xtbenv, suite: 'utils')
-test('Thermo: print', xtb_test, args: ['thermo', 'print'], env: xtbenv, suite: 'utils')
-
-test('EEQ model: water', xtb_test,args: ['eeq_model', 'water'], env: xtbenv, suite: 'core')
-test('EEQ model: 3D Ewald', xtb_test,args: ['eeq_model', 'ewald'], env: xtbenv, suite: 'core')
-test('EEQ model: GBSA', xtb_test,args: ['eeq_model', 'gbsa'], env: xtbenv, suite: 'core')
-test('EEQ model: GBSA (salt)', xtb_test,args: ['eeq_model', 'salt'], env: xtbenv, suite: 'core')
-test('EEQ model: GBSA (H-bond)', xtb_test,args: ['eeq_model', 'hbond'], env: xtbenv, suite: 'core')
-
-test('Dispersion: properties', xtb_test,args: ['dftd4', 'properties'], env: xtbenv, suite: 'core')
-test('Dispersion: energies', xtb_test,args: ['dftd4', 'energies'], env: xtbenv, suite: 'core')
-test('Dispersion: energies (PBC)', xtb_test,args: ['dftd4', 'pbc_disp'], env: xtbenv, suite: 'core')
-#test('Dispersion: cell gradients', xtb_test,args: ['dftd4', 'cell_gradient'] env: xtbenv, suite: 'core')
-test('Dispersion: API', xtb_test,args: ['dftd4', 'api'], env: xtbenv, suite: 'core')
-#test('Dispersion: API (PBC)', xtb_test,args: ['dftd4', 'pbc_api'] env: xtbenv, suite: 'core')
-
-test('GFN2-xTB: SCC', xtb_test, args: ['gfn2', 'scc'], env: xtbenv, suite: 'core')
-test('GFN2-xTB: API', xtb_test, args: ['gfn2', 'api'], env: xtbenv, suite: 'core')
-test('GFN2-xTB: API (GBSA)', xtb_test, args: ['gfn2', 'gbsa'], env: xtbenv, suite: 'core')
-test('GFN2-xTB: API (GBSA+salt)', xtb_test, args: ['gfn2', 'salt'], env: xtbenv, suite: 'core')
-test('GFN2-xTB: API (PCEM)', xtb_test, args: ['gfn2', 'pcem'], env: xtbenv, suite: 'core')
-test('GFN2-xTB: C++', executable('xtb_cpp_test', 'TESTSUITE/cpp_api_example.cpp',
-                                 include_directories: incdir,
-                                 dependencies: xtb_dep),
-                                 env: xtbenv, suite: 'extern')
-
-test('GFN1-xTB: SCC', xtb_test, args: ['gfn1', 'scc'], env: xtbenv, suite: 'core')
-test('GFN1-xTB: API', xtb_test, args: ['gfn1', 'api'], env: xtbenv, suite: 'core')
-test('GFN1-xTB: API (GBSA)', xtb_test, args: ['gfn1', 'gbsa'], env: xtbenv, suite: 'core')
-test('GFN1-xTB: API (PCEM)', xtb_test, args: ['gfn1', 'pcem'], env: xtbenv, suite: 'core')
-
-test('GFN0-xTB: SP', xtb_test, args: ['gfn0', 'sp'], env: xtbenv, suite: 'core')
-test('GFN0-xTB: API', xtb_test, args: ['gfn0', 'api'], env: xtbenv, suite: 'core')
-test('GFN0-xTB: SP  (PBC)', xtb_test, args: ['peeq', 'sp'], env: xtbenv, suite: 'core')
-test('GFN0-xTB: API (PBC)', xtb_test, args: ['peeq', 'api'], env: xtbenv, suite: 'core')
+# all tests are defined in a separate meson.build
+subdir('TESTSUITE')
 
 py_xtb = meson.current_source_dir() / 'python' / 'xtb'
 
 pytest = find_program('pytest', required: false)
 if pytest.found()
-  test('pytest: xtb.py', pytest, args: ['--pyargs', 'xtb'], env: xtbenv, suite: 'python')
+  test('pytest: xtb.py', pytest, args: ['--pyargs', 'xtb'], env: xtbenv)
 endif
 
 mypy = find_program('mypy', required: false)
 if mypy.found()
-  test('mypy: xtb.py', mypy, args: [py_xtb, '--ignore-missing-imports'],
-       env: xtbenv, suite: 'python')
+  test('mypy: xtb.py', mypy, args: [py_xtb, '--ignore-missing-imports'], env: xtbenv)
 endif
 
 pylint = find_program('pylint', required: false)
 if pylint.found()
-  test('pylint: xtb.py', pylint, args: [py_xtb, '--disable=invalid-names,duplicate-code'],
-       env: xtbenv, suite: 'python')
+  test('pylint: xtb.py', pylint, args: [py_xtb, '--disable=invalid-names,duplicate-code'], env: xtbenv)
 endif
 
 flake8 = find_program('flake8', required: false)
 if flake8.found()
-  test('flake8: xtb.py', flake8, args: [py_xtb, '--max-line-length=83'],
-       env: xtbenv, suite: 'python')
+  test('flake8: xtb.py', flake8, args: [py_xtb, '--max-line-length=83'], env: xtbenv)
 endif

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,8 @@ cc = meson.get_compiler('c')
 cxx= meson.get_compiler('cpp')
 
 if fc.get_id() == 'gcc'
+  add_project_arguments('-fdefault-real-8', language: 'fortran')
+  add_project_arguments('-fdefault-double-8', language: 'fortran')
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
 elif fc.get_id() == 'intel'
@@ -80,6 +82,7 @@ dependencies_exe = []
 dependencies_sha = []
 
 if get_option('la_backend') == 'mkl'
+  add_project_arguments('-DWITH_MKL', language: 'fortran')
   libmkl = [fc.find_library('pthread')]
   libmkl += fc.find_library('m')
   libmkl += fc.find_library('dl')
@@ -104,9 +107,11 @@ endif
 if fc.get_id() == 'gcc'
   add_project_arguments('-fopenmp', language: 'fortran')
   add_project_link_arguments('-fopenmp', language: 'fortran')
+  add_project_link_arguments('-fopenmp', language: 'c')
 elif fc.get_id() == 'intel'
   add_project_arguments('-qopenmp', language: 'fortran')
   add_project_link_arguments('-qopenmp', language: 'fortran')
+  add_project_link_arguments('-qopenmp', language: 'c')
 endif
 dependencies += dependency('threads')
 
@@ -176,7 +181,7 @@ xtb_srcs += 'xtb/readin.f90'
 xtb_srcs += 'xtb/filetools.f90'
 xtb_srcs += 'xtb/set_module.f90'
 xtb_srcs += 'xtb/constrain_param.f90'
-xtb_srcs += 'xtb/argparser.f90'
+xtb_srcs += 'xtb/argparser.F90'
 xtb_srcs += 'xtb/header.f90'
 xtb_srcs += 'xtb/printout.f90'
 xtb_srcs += 'xtb/xhelp.f90'
@@ -293,7 +298,7 @@ xtb_srcs += 'xtb/qsort.f90'
 xtb_srcs += 'xtb/locmode.f'
 xtb_srcs += 'xtb/intmodes.f'
 xtb_srcs += 'xtb/wrmodef.f'
-xtb_srcs += 'xtb/hessian.f90'
+xtb_srcs += 'xtb/hessian.F90'
 xtb_srcs += 'xtb/xbond.f90'
 xtb_srcs += 'xtb/timing.f90'
 xtb_srcs += 'xtb/prmat.f'
@@ -342,6 +347,9 @@ xtb_srcs += 'symmetry/symmetry_i.c'
 
 # API
 xtb_srcs += 'xtb/calculator.f90'
+xtb_srcs += 'xtb/gfn0_calculator.f90'
+xtb_srcs += 'xtb/gfn1_calculator.f90'
+xtb_srcs += 'xtb/gfn2_calculator.f90'
 xtb_srcs += 'xtb/c_api.f90'
 
 xtb_test = ['TESTSUITE/tests_peeq.f90']
@@ -448,109 +456,109 @@ xtbenv.prepend('PYTHONPATH', meson.current_source_dir() / 'python')
 xtbenv.set('XTBPATH', meson.current_source_dir())
 
 # some very basic checks to see if the executable reacts at all
-test('Argparser: print version', xtb_exe, args: '--version', env: xtbenv)
-test('Argparser: print help', xtb_exe, args: '--help', env: xtbenv)
-test('Argparser: print license', xtb_exe, args: '--license', env: xtbenv)
-test('Argparser: no arguments', xtb_exe, should_fail: true, env: xtbenv)
+test('Argparser: print version', xtb_exe, args: '--version', env: xtbenv, suite: 'basic')
+test('Argparser: print help', xtb_exe, args: '--help', env: xtbenv, suite: 'basic')
+test('Argparser: print license', xtb_exe, args: '--license', env: xtbenv, suite: 'basic')
+test('Argparser: no arguments', xtb_exe, should_fail: true, env: xtbenv, suite: 'basic')
 
-test('Runtyp: singlepoint', xtb_exe, args: ['--coffee', '--strict', '--norestart'], env: xtbenv)
-test('Runtyp: geometry opt.', xtb_exe, args: ['--coffee', '--opt', '--strict', '--norestart'], env: xtbenv)
-test('Runtyp: IP/EA', xtb_exe, args: ['--coffee', '--gfn', '2', '--vipea', '--strict', '--norestart'], env: xtbenv)
-test('Method: GFN0-xTB', xtb_exe, args: ['--coffee', '--gfn', '0', '--strict', '--norestart'], env: xtbenv)
-test('Method: GFN1-xTB', xtb_exe, args: ['--coffee', '--gfn', '1', '--strict', '--norestart'], env: xtbenv)
-test('Method: GFN2-xTB/GBSA', xtb_exe, args: ['--coffee', '--gfn', '2', '--strict', '--gbsa', 'h2o', '--norestart'], env: xtbenv)
+test('Singlepoint', xtb_exe, args: ['--coffee', '--strict', '--norestart'], env: xtbenv, suite: 'run')
+test('Geometry opt.', xtb_exe, args: ['--coffee', '--opt', '--strict', '--norestart'], env: xtbenv, suite: 'run')
+test('IP/EA', xtb_exe, args: ['--coffee', '--gfn', '2', '--vipea', '--strict', '--norestart'], env: xtbenv, suite: 'run')
+test('GFN0-xTB', xtb_exe, args: ['--coffee', '--gfn', '0', '--strict', '--norestart'], env: xtbenv, suite: 'run')
+test('GFN1-xTB', xtb_exe, args: ['--coffee', '--gfn', '1', '--strict', '--norestart'], env: xtbenv, suite: 'run')
+test('GFN2-xTB/GBSA', xtb_exe, args: ['--coffee', '--gfn', '2', '--strict', '--gbsa', 'h2o', '--norestart'], env: xtbenv, suite: 'run')
 
 # more specific tests are implemented by the tester binary
-test('Molecule Class: axis', xtb_test, args: ['tbdef_molecule', 'axis'], env: xtbenv)
-test('Molecule Class: MIC', xtb_test, args: ['tbdef_molecule', 'mic'], env: xtbenv)
+test('Molecule: axis', xtb_test, args: ['tbdef_molecule', 'axis'], env: xtbenv, suite: 'class')
+test('Molecule: MIC', xtb_test, args: ['tbdef_molecule', 'mic'], env: xtbenv, suite: 'class')
 
-test('Wigner-Seitz Cell (0D)', xtb_test, args: ['tbdef_wsc', '0d'], env: xtbenv)
-test('Wigner-Seitz Cell (3D)', xtb_test, args: ['tbdef_wsc', '3d'], env: xtbenv)
+test('Wigner-Seitz Cell (0D)', xtb_test, args: ['tbdef_wsc', '0d'], env: xtbenv, suite: 'class')
+test('Wigner-Seitz Cell (3D)', xtb_test, args: ['tbdef_wsc', '3d'], env: xtbenv, suite: 'class')
 
-test('Geometry Reader: coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_a'], env: xtbenv)
-test('Geometry Reader: coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_b'], env: xtbenv)
-test('Geometry Reader: coord 2D', xtb_test, args: ['geometry_reader', 'coord_2d'], env: xtbenv)
-test('Geometry Reader: coord 1D', xtb_test, args: ['geometry_reader', 'coord_1d'], env: xtbenv)
-test('Geometry Reader: coord 0D', xtb_test, args: ['geometry_reader', 'coord_0d'], env: xtbenv)
-test('Geometry Reader: Xmol  0D', xtb_test, args: ['geometry_reader', 'xmol_0d'], env: xtbenv)
-test('Geometry Reader: POSCAR', xtb_test, args: ['geometry_reader', 'poscar_3d'], env: xtbenv)
-test('Geometry Reader: molfile', xtb_test, args: ['geometry_reader', 'molfile'], env: xtbenv)
-test('Geometry Reader: molfile flat', xtb_test, should_fail: true, args: ['geometry_reader', 'molfile_flat'], env: xtbenv)
-test('Geometry Reader: SDF', xtb_test, args: ['geometry_reader', 'sdfile'], env: xtbenv)
-test('Geometry Reader: SDF flat', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_flat'], env: xtbenv)
-test('Geometry Reader: SDF no H', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_noh'], env: xtbenv)
-test('Geometry Reader: PDB', xtb_test, args: ['geometry_reader', 'pdb'], env: xtbenv)
-test('Geometry Reader: PDB no H', xtb_test, should_fail: true, args: ['geometry_reader', 'pdb_noh'], env: xtbenv)
-test('Geometry Reader: genFormat', xtb_test, args: ['geometry_reader', 'gen'], env: xtbenv)
+test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'], env: xtbenv, suite: 'class')
 
-test('IO: atom list', xtb_test, args: ['tbdef_atomlist', 'list'], env: xtbenv)
+test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_a'], env: xtbenv, suite: 'input')
+test('coord 3D', xtb_test, args: ['geometry_reader', 'coord_3d_b'], env: xtbenv, suite: 'input')
+test('coord 2D', xtb_test, args: ['geometry_reader', 'coord_2d'], env: xtbenv, suite: 'input')
+test('coord 1D', xtb_test, args: ['geometry_reader', 'coord_1d'], env: xtbenv, suite: 'input')
+test('coord 0D', xtb_test, args: ['geometry_reader', 'coord_0d'], env: xtbenv, suite: 'input')
+test('Xmol  0D', xtb_test, args: ['geometry_reader', 'xmol_0d'], env: xtbenv, suite: 'input')
+test('POSCAR', xtb_test, args: ['geometry_reader', 'poscar_3d'], env: xtbenv, suite: 'input')
+test('molfile', xtb_test, args: ['geometry_reader', 'molfile'], env: xtbenv, suite: 'input')
+test('molfile flat', xtb_test, should_fail: true, args: ['geometry_reader', 'molfile_flat'], env: xtbenv, suite: 'input')
+test('SDF', xtb_test, args: ['geometry_reader', 'sdfile'], env: xtbenv, suite: 'input')
+test('SDF flat', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_flat'], env: xtbenv, suite: 'input')
+test('SDF no H', xtb_test, should_fail: true, args: ['geometry_reader', 'sdfile_noh'], env: xtbenv, suite: 'input')
+test('PDB', xtb_test, args: ['geometry_reader', 'pdb'], env: xtbenv, suite: 'input')
+test('PDB no H', xtb_test, should_fail: true, args: ['geometry_reader', 'pdb_noh'], env: xtbenv, suite: 'input')
+test('genFormat', xtb_test, args: ['geometry_reader', 'gen'], env: xtbenv, suite: 'input')
 
-test('PBC tools: convert',xtb_test, args: ['pbc_tools', 'convert'], env: xtbenv)
-test('PBC tools: cutoff', xtb_test, args: ['pbc_tools', 'cutoff'], env: xtbenv)
+test('PBC tools: convert',xtb_test, args: ['pbc_tools', 'convert'], env: xtbenv, suite: 'utils')
+test('PBC tools: cutoff', xtb_test, args: ['pbc_tools', 'cutoff'], env: xtbenv, suite: 'utils')
 
-test('Symmetry: Water', xtb_test, args: ['symmetry', 'water'], env: xtbenv)
-test('Symmetry: Li8', xtb_test, args: ['symmetry', 'li8'], env: xtbenv)
-test('Symmetry: PCl3', xtb_test, args: ['symmetry', 'pcl3'], env: xtbenv)
-test('Symmetry: large', xtb_test, args: ['symmetry', 'c20'], env: xtbenv)
+test('Symmetry: Water', xtb_test, args: ['symmetry', 'water'], env: xtbenv, suite: 'utils')
+test('Symmetry: Li8', xtb_test, args: ['symmetry', 'li8'], env: xtbenv, suite: 'utils')
+test('Symmetry: PCl3', xtb_test, args: ['symmetry', 'pcl3'], env: xtbenv, suite: 'utils')
+test('Symmetry: large', xtb_test, args: ['symmetry', 'c20'], env: xtbenv, suite: 'utils')
 
-test('Thermo: axis', xtb_test, args: ['thermo', 'axis'], env: xtbenv)
-test('Thermo: calculation', xtb_test, args: ['thermo', 'calc'], env: xtbenv)
-test('Thermo: print', xtb_test, args: ['thermo', 'print'], env: xtbenv)
+test('Thermo: axis', xtb_test, args: ['thermo', 'axis'], env: xtbenv, suite: 'utils')
+test('Thermo: calculation', xtb_test, args: ['thermo', 'calc'], env: xtbenv, suite: 'utils')
+test('Thermo: print', xtb_test, args: ['thermo', 'print'], env: xtbenv, suite: 'utils')
 
-test('EEQ model: water', xtb_test,args: ['eeq_model', 'water'], env: xtbenv)
-test('EEQ model: 3D Ewald', xtb_test,args: ['eeq_model', 'ewald'], env: xtbenv)
-test('EEQ model: GBSA', xtb_test,args: ['eeq_model', 'gbsa'], env: xtbenv)
-test('EEQ model: GBSA (salt)', xtb_test,args: ['eeq_model', 'salt'], env: xtbenv)
-test('EEQ model: GBSA (H-bond)', xtb_test,args: ['eeq_model', 'hbond'], env: xtbenv)
+test('EEQ model: water', xtb_test,args: ['eeq_model', 'water'], env: xtbenv, suite: 'core')
+test('EEQ model: 3D Ewald', xtb_test,args: ['eeq_model', 'ewald'], env: xtbenv, suite: 'core')
+test('EEQ model: GBSA', xtb_test,args: ['eeq_model', 'gbsa'], env: xtbenv, suite: 'core')
+test('EEQ model: GBSA (salt)', xtb_test,args: ['eeq_model', 'salt'], env: xtbenv, suite: 'core')
+test('EEQ model: GBSA (H-bond)', xtb_test,args: ['eeq_model', 'hbond'], env: xtbenv, suite: 'core')
 
-test('Dispersion: properties', xtb_test,args: ['dftd4', 'properties'], env: xtbenv)
-test('Dispersion: energies', xtb_test,args: ['dftd4', 'energies'], env: xtbenv)
-test('Dispersion: energies (PBC)', xtb_test,args: ['dftd4', 'pbc_disp'], env: xtbenv)
-#test('Dispersion: cell gradients', xtb_test,args: ['dftd4', 'cell_gradient'] env: xtbenv)
-test('Dispersion: API', xtb_test,args: ['dftd4', 'api'], env: xtbenv)
-#test('Dispersion: API (PBC)', xtb_test,args: ['dftd4', 'pbc_api'] env: xtbenv)
+test('Dispersion: properties', xtb_test,args: ['dftd4', 'properties'], env: xtbenv, suite: 'core')
+test('Dispersion: energies', xtb_test,args: ['dftd4', 'energies'], env: xtbenv, suite: 'core')
+test('Dispersion: energies (PBC)', xtb_test,args: ['dftd4', 'pbc_disp'], env: xtbenv, suite: 'core')
+#test('Dispersion: cell gradients', xtb_test,args: ['dftd4', 'cell_gradient'] env: xtbenv, suite: 'core')
+test('Dispersion: API', xtb_test,args: ['dftd4', 'api'], env: xtbenv, suite: 'core')
+#test('Dispersion: API (PBC)', xtb_test,args: ['dftd4', 'pbc_api'] env: xtbenv, suite: 'core')
 
-test('GFN2-xTB: SCC', xtb_test, args: ['gfn2', 'scc'], env: xtbenv)
-test('GFN2-xTB: API', xtb_test, args: ['gfn2', 'api'], env: xtbenv)
-test('GFN2-xTB: API (GBSA)', xtb_test, args: ['gfn2', 'gbsa'], env: xtbenv)
-test('GFN2-xTB: API (GBSA+salt)', xtb_test, args: ['gfn2', 'salt'], env: xtbenv)
-test('GFN2-xTB: API (PCEM)', xtb_test, args: ['gfn2', 'pcem'], env: xtbenv)
+test('GFN2-xTB: SCC', xtb_test, args: ['gfn2', 'scc'], env: xtbenv, suite: 'core')
+test('GFN2-xTB: API', xtb_test, args: ['gfn2', 'api'], env: xtbenv, suite: 'core')
+test('GFN2-xTB: API (GBSA)', xtb_test, args: ['gfn2', 'gbsa'], env: xtbenv, suite: 'core')
+test('GFN2-xTB: API (GBSA+salt)', xtb_test, args: ['gfn2', 'salt'], env: xtbenv, suite: 'core')
+test('GFN2-xTB: API (PCEM)', xtb_test, args: ['gfn2', 'pcem'], env: xtbenv, suite: 'core')
 test('GFN2-xTB: C++', executable('xtb_cpp_test', 'TESTSUITE/cpp_api_example.cpp',
                                  include_directories: incdir,
                                  dependencies: xtb_dep),
-                                 env: xtbenv)
+                                 env: xtbenv, suite: 'extern')
 
-test('GFN1-xTB: SCC', xtb_test, args: ['gfn1', 'scc'], env: xtbenv)
-test('GFN1-xTB: API', xtb_test, args: ['gfn1', 'api'], env: xtbenv)
-test('GFN1-xTB: API (GBSA)', xtb_test, args: ['gfn1', 'gbsa'], env: xtbenv)
-test('GFN1-xTB: API (PCEM)', xtb_test, args: ['gfn1', 'pcem'], env: xtbenv)
+test('GFN1-xTB: SCC', xtb_test, args: ['gfn1', 'scc'], env: xtbenv, suite: 'core')
+test('GFN1-xTB: API', xtb_test, args: ['gfn1', 'api'], env: xtbenv, suite: 'core')
+test('GFN1-xTB: API (GBSA)', xtb_test, args: ['gfn1', 'gbsa'], env: xtbenv, suite: 'core')
+test('GFN1-xTB: API (PCEM)', xtb_test, args: ['gfn1', 'pcem'], env: xtbenv, suite: 'core')
 
-test('GFN0-xTB: SP', xtb_test, args: ['gfn0', 'sp'], env: xtbenv)
-test('GFN0-xTB: API', xtb_test, args: ['gfn0', 'api'], env: xtbenv)
-test('GFN0-xTB: SP  (PBC)', xtb_test, args: ['peeq', 'sp'], env: xtbenv)
-test('GFN0-xTB: API (PBC)', xtb_test, args: ['peeq', 'api'], env: xtbenv)
+test('GFN0-xTB: SP', xtb_test, args: ['gfn0', 'sp'], env: xtbenv, suite: 'core')
+test('GFN0-xTB: API', xtb_test, args: ['gfn0', 'api'], env: xtbenv, suite: 'core')
+test('GFN0-xTB: SP  (PBC)', xtb_test, args: ['peeq', 'sp'], env: xtbenv, suite: 'core')
+test('GFN0-xTB: API (PBC)', xtb_test, args: ['peeq', 'api'], env: xtbenv, suite: 'core')
 
 py_xtb = meson.current_source_dir() / 'python' / 'xtb'
 
 pytest = find_program('pytest', required: false)
 if pytest.found()
-  test('pytest: xtb.py', pytest, args: ['--pyargs', 'xtb'], env: xtbenv)
+  test('pytest: xtb.py', pytest, args: ['--pyargs', 'xtb'], env: xtbenv, suite: 'python')
 endif
 
 mypy = find_program('mypy', required: false)
 if mypy.found()
   test('mypy: xtb.py', mypy, args: [py_xtb, '--ignore-missing-imports'],
-       env: xtbenv)
+       env: xtbenv, suite: 'python')
 endif
 
 pylint = find_program('pylint', required: false)
 if pylint.found()
   test('pylint: xtb.py', pylint, args: [py_xtb, '--disable=invalid-names,duplicate-code'],
-       env: xtbenv)
+       env: xtbenv, suite: 'python')
 endif
 
 flake8 = find_program('flake8', required: false)
 if flake8.found()
   test('flake8: xtb.py', flake8, args: [py_xtb, '--max-line-length=83'],
-       env: xtbenv)
+       env: xtbenv, suite: 'python')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,7 +15,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
-option('la_backend', type: 'string', value: 'mkl',
+option('la_backend', type: 'combo', value: 'mkl',
+       choices: ['mkl', 'openblas', 'netlib', 'custom'],
        description : 'Linear algebra backend for program.')
+option('custom_libraries', type: 'array', value: [],
+       description: 'libraries to load for custom linear algebra backend')
+option('openmp', type: 'boolean', value: true,
+       description: 'use OpenMP parallelisation')
 option('install_modules', type: 'boolean', value: false,
        description : 'Install Fortran module files to include directory.')

--- a/xtb/argparser.F90
+++ b/xtb/argparser.F90
@@ -136,7 +136,9 @@ subroutine rdxargs(fname,xcontrol,fnv,fnx,acc,lgrad,restart,gsolvstate,strict,  
       !$       & call raise('S','Process number higher than OMP_NUM_THREADS, '//&
       !$       &                'I hope you know what you are doing.',1)
       !$       call omp_set_num_threads(idum)
+#ifdef WITH_MKL
       !$       call mkl_set_num_threads(idum)
+#endif
       !$    endif
          case(     '--restart')
             restart = .true.
@@ -500,7 +502,7 @@ subroutine rdxargs(fname,xcontrol,fnv,fnx,acc,lgrad,restart,gsolvstate,strict,  
    endif
 
    if (.not.allocated(xcontrol)) then
-      if (.not.copycontrol) then
+      if (.not.copycontrol.and.allocated(fname)) then
          xcontrol = fname
       else
          xcontrol = 'xcontrol'

--- a/xtb/c_api.f90
+++ b/xtb/c_api.f90
@@ -79,7 +79,6 @@ function peeq_api &
    real(c_double),intent(out) :: glat(3,3)
 
    type(tb_molecule)    :: mol
-   type(gfn_parameter)  :: gfn
    type(peeq_options)   :: opt
    type(tb_environment) :: env
 
@@ -158,7 +157,7 @@ function peeq_api &
    call mctc_mute
 
    call gfn0_calculation &
-      (iunit,env,opt,mol,gfn,hl_gap,energy,gradient,stress_tensor,lattice_gradient)
+      (iunit,env,opt,mol,hl_gap,energy,gradient,stress_tensor,lattice_gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
@@ -223,7 +222,6 @@ function gfn2_api &
 
    type(tb_molecule)    :: mol
    type(tb_wavefunction):: wfn
-   type(gfn_parameter)  :: gfn
    type(scc_options)    :: opt
    type(tb_environment) :: env
    type(tb_pcem)        :: pcem
@@ -297,7 +295,7 @@ function gfn2_api &
    call mctc_mute
 
    call gfn2_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
@@ -362,7 +360,6 @@ function gfn1_api &
    real(c_double),intent(out) :: dipole(3)
 
    type(tb_molecule)    :: mol
-   type(gfn_parameter)  :: gfn
    type(scc_options)    :: opt
    type(tb_environment) :: env
    type(tb_pcem)        :: pcem
@@ -437,7 +434,7 @@ function gfn1_api &
    call mctc_mute
 
    call gfn1_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
@@ -495,7 +492,6 @@ function gfn0_api &
    real(c_double),intent(out) :: grad(3,natoms)
 
    type(tb_molecule)    :: mol
-   type(gfn_parameter)  :: gfn
    type(peeq_options)    :: opt
    type(tb_environment) :: env
 
@@ -569,7 +565,7 @@ function gfn0_api &
    call mctc_mute
 
    call gfn0_calculation &
-      (iunit,env,opt,mol,gfn,hl_gap,energy,gradient,dum,dum)
+      (iunit,env,opt,mol,hl_gap,energy,gradient,dum,dum)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
@@ -635,7 +631,6 @@ function gfn2_pcem_api &
    real(c_double),intent(out) :: pc_grad(3,npc)
 
    type(tb_molecule)    :: mol
-   type(gfn_parameter)  :: gfn
    type(scc_options)    :: opt
    type(tb_wavefunction):: wfn
    type(tb_environment) :: env
@@ -719,7 +714,7 @@ function gfn2_pcem_api &
    call mctc_mute
 
    call gfn2_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)
@@ -788,7 +783,6 @@ function gfn1_pcem_api &
    real(c_double),intent(out) :: pc_grad(3,npc)
 
    type(tb_molecule)    :: mol
-   type(gfn_parameter)  :: gfn
    type(scc_options)    :: opt
    type(tb_environment) :: env
    type(tb_pcem)        :: pcem
@@ -872,7 +866,7 @@ function gfn1_pcem_api &
    call mctc_mute
 
    call gfn1_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
 
    ! check if the MCTC environment is still sane, if not tell the caller
    call mctc_sanity(sane)

--- a/xtb/calculator.f90
+++ b/xtb/calculator.f90
@@ -15,493 +15,74 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 module tb_calculators
+   use iso_fortran_env, wp => real64
    implicit none
+   private
+
+   public :: gfn0_calculation, gfn1_calculation, gfn2_calculation
+   public :: d4_calculation, d4_pbc_calculation
+
+   interface
+      module subroutine gfn0_calculation &
+            (iunit,env,opt,mol,hl_gap,energy,gradient,stress,lattice_gradient)
+         use tbdef_options
+         use tbdef_molecule
+         use tbdef_wavefunction
+         use tbdef_basisset
+         use tbdef_param
+         use tbdef_data
+         integer, intent(in) :: iunit
+         type(tb_molecule),    intent(inout) :: mol
+         type(peeq_options),   intent(in)    :: opt
+         type(tb_environment), intent(in)    :: env
+         real(wp), intent(out) :: energy
+         real(wp), intent(out) :: hl_gap
+         real(wp), intent(out) :: gradient(3,mol%n)
+         real(wp), intent(out) :: stress(3,3)
+         real(wp), intent(out) :: lattice_gradient(3,3)
+      end subroutine gfn0_calculation
+      module subroutine gfn1_calculation &
+            (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
+         use tbdef_options
+         use tbdef_molecule
+         use tbdef_wavefunction
+         use tbdef_basisset
+         use tbdef_param
+         use tbdef_data
+         use tbdef_pcem
+         integer, intent(in) :: iunit
+         type(tb_molecule),    intent(inout) :: mol
+         type(scc_options),    intent(in)    :: opt
+         type(tb_environment), intent(in)    :: env
+         type(tb_pcem),        intent(inout) :: pcem
+         type(tb_wavefunction),intent(inout) :: wfn
+         real(wp), intent(out) :: energy
+         real(wp), intent(out) :: hl_gap
+         real(wp), intent(out) :: gradient(3,mol%n)
+      end subroutine gfn1_calculation
+      module subroutine gfn2_calculation &
+            (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
+         use tbdef_options
+         use tbdef_molecule
+         use tbdef_wavefunction
+         use tbdef_basisset
+         use tbdef_param
+         use tbdef_data
+         use tbdef_pcem
+         integer, intent(in) :: iunit
+         type(tb_molecule),    intent(inout) :: mol
+         type(tb_wavefunction),intent(inout) :: wfn
+         type(scc_options),    intent(in)    :: opt
+         type(tb_environment), intent(in)    :: env
+         type(tb_pcem),        intent(inout) :: pcem
+         real(wp), intent(out) :: energy
+         real(wp), intent(out) :: hl_gap
+         real(wp), intent(out) :: gradient(3,mol%n)
+      end subroutine gfn2_calculation
+   end interface
 contains
 
-! ========================================================================
-!> periodic GFN0-xTB (PEEQ) calculation
-subroutine gfn0_calculation &
-      (iunit,env,opt,mol,gfn,hl_gap,energy,gradient,stress,lattice_gradient)
-   use iso_fortran_env, wp => real64
 
-   use mctc_systools
-
-   use tbdef_options
-   use tbdef_molecule
-   use tbdef_wavefunction
-   use tbdef_basisset
-   use tbdef_param
-   use tbdef_data
-
-   use setparam, only : gfn_method, ngrida
-   use aoparam,  only : use_parameterset
-
-   use pbc_tools
-   use xbasis
-   use peeq_module
-   use gbobc
-
-   implicit none
-
-   integer, intent(in) :: iunit
-
-   type(tb_molecule),    intent(inout) :: mol
-   type(gfn_parameter),  intent(in)    :: gfn
-   type(peeq_options),   intent(in)    :: opt
-   type(tb_environment), intent(in)    :: env
-
-   real(wp), intent(out) :: energy
-   real(wp), intent(out) :: hl_gap
-   real(wp), intent(out) :: gradient(3,mol%n)
-   real(wp), intent(out) :: stress(3,3)
-   real(wp), intent(out) :: lattice_gradient(3,3)
-   real(wp)              :: sigma(3,3)
-   real(wp)              :: inv_lat(3,3)
-
-   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
-
-   type(tb_wavefunction) :: wfn
-   type(tb_basisset)     :: basis
-   type(scc_parameter)   :: param
-   type(scc_results)     :: res
-
-   character(len=*),parameter :: outfmt = &
-      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
-   character(len=*), parameter   :: p_fnv_gfn0 = '.param_gfn0.xtb'
-   character(len=:), allocatable :: fnv
-   real(wp) :: globpar(25)
-   integer  :: ipar,i
-   logical  :: exist
-
-   logical  :: okbas,diff
-
-   gfn_method = 0
-   sigma = 0.0_wp
-
-   ! ====================================================================
-   !  STEP 1: prepare geometry input
-   ! ====================================================================
-   ! we assume that the user provides a resonable molecule input
-   ! -> all atoms are inside the unit cell, all data is set and consistent
-
-   wfn%nel = nint(sum(mol%z) - mol%chrg)
-   wfn%nopen = mol%uhf
-   ! at this point, don't complain about odd multiplicities for even electron
-   ! systems and just fix it silently, the API is supposed catch this
-   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
-   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
-
-   if (mol%npbc > 0) then
-      ! get Wigner-Seitz cell if necessary
-      ! -> this modifies the molecule, since the WSC is bound to a molecule
-      call generate_wsc(mol,mol%wsc,wsc_rep)
-   endif
-
-   ! give an optional summary on the geometry used
-   if (opt%prlevel > 2) then
-      call print_pbcsum(iunit,mol)
-   endif
-
-   ! ====================================================================
-   !  STEP 2: get the parametrisation
-   ! ====================================================================
-   ! we could require our user to perform this step, but if we want
-   ! to be sure about getting the correct parameters, we should do it here
-
-   ! we will try an internal parameter file first to avoid IO
-   call use_parameterset(p_fnv_gfn0,globpar,exist)
-   ! no luck, we have to fire up some IO to get our parameters
-   if (.not.exist) then
-      ! let's check if we can find the parameter file
-      call rdpath(env%xtbpath,p_fnv_gfn0,fnv,exist)
-      ! maybe the user provides a local parameter file, this was always
-      ! an option in `xtb', so we will give it a try
-      if (.not.exist) fnv = p_fnv_gfn0
-      call open_file(ipar,fnv,'r')
-      if (ipar.eq.-1) then
-         ! at this point there is no chance to recover from this error
-         ! THEREFORE, we have to kill the program
-         call raise('E',"Parameter file '"//fnv//"' not found!",1)
-         return
-      endif
-      call read_gfn_param(ipar,globpar,.true.)
-      call close_file(ipar)
-   endif
-   call set_gfn0_parameter(param,globpar,mol%n,mol%at)
-   if (opt%prlevel > 1) then
-      call gfn0_header(iunit)
-      call gfn0_prparam(iunit,mol%n,mol%at,param)
-   endif
-
-   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none" &
-      &    .and. mol%npbc == 0 ! GBSA is not yet periodic
-   if (lgbsa) then
-      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
-   endif
-
-   ! ====================================================================
-   !  STEP 3: expand our Slater basis set in contracted Gaussians
-   ! ====================================================================
-
-   call xbasis0(mol%n,mol%at,basis)
-   call xbasis_gfn0(mol%n,mol%at,basis,okbas,diff)
-   call xbasis_cao2sao(mol%n,mol%at,basis)
-
-   ! ====================================================================
-   !  STEP 4: setup the initial wavefunction
-   ! ====================================================================
-
-   call wfn%allocate(mol%n,basis%nshell,basis%nao)
-   ! do a SAD guess since we are not need any of this information later
-   wfn%q = mol%chrg / real(mol%n,wp)
-
-   ! ====================================================================
-   !  STEP 5: do the calculation
-   ! ====================================================================
-
-   call peeq(iunit,mol,wfn,basis,param,hl_gap,opt%etemp,opt%prlevel,opt%grad, &
-      &      opt%ccm,opt%acc,energy,gradient,sigma,res)
-
-   if (mol%npbc > 0) then
-      inv_lat = mat_inv_3x3(mol%lattice)
-      call sigma_to_latgrad(sigma,inv_lat,lattice_gradient)
-      stress = sigma/mol%volume
-   endif
-
-   if (opt%prlevel > 0) then
-      write(iunit,'(9x,53(":"))')
-      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
-      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
-      if (mol%npbc > 0) &
-      write(iunit,outfmt) "gradlatt norm     ", norm2(lattice_gradient),  "Eh/α"
-      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
-      write(iunit,'(9x,53(":"))')
-   endif
-
-end subroutine gfn0_calculation
-
-! ========================================================================
-!> GFN2-xTB calculation
-subroutine gfn2_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
-   use iso_fortran_env, wp => real64
-
-   use mctc_systools
-
-   use tbdef_options
-   use tbdef_molecule
-   use tbdef_wavefunction
-   use tbdef_basisset
-   use tbdef_param
-   use tbdef_data
-   use tbdef_pcem
-
-   use setparam, only : gfn_method, ngrida
-   use aoparam,  only : use_parameterset
-
-   use xbasis
-   use eeq_model
-   use ncoord
-   use scc_core
-   use scf_module
-   use gbobc
-   use embedding
-
-   implicit none
-
-   integer, intent(in) :: iunit
-
-   type(tb_molecule),    intent(inout) :: mol
-   type(tb_wavefunction),intent(inout) :: wfn
-   type(gfn_parameter),  intent(in)    :: gfn
-   type(scc_options),    intent(in)    :: opt
-   type(tb_environment), intent(in)    :: env
-   type(tb_pcem),        intent(inout) :: pcem
-
-   real(wp), intent(out) :: energy
-   real(wp), intent(out) :: hl_gap
-   real(wp), intent(out) :: gradient(3,mol%n)
-
-   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
-
-   type(tb_basisset)     :: basis
-   type(scc_parameter)   :: param
-   type(scc_results)     :: res
-   type(chrg_parameter)  :: chrgeq
-
-   real(wp), allocatable :: cn(:)
-
-   character(len=*),parameter :: outfmt = &
-      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
-   character(len=*), parameter   :: p_fnv_gfn2 = '.param_gfn2.xtb'
-   character(len=:), allocatable :: fnv
-   real(wp) :: globpar(25)
-   integer  :: ipar
-   logical  :: exist
-
-   logical  :: okbas
-
-   gfn_method = 2
-   call init_pcem
-
-   ! ====================================================================
-   !  STEP 1: prepare geometry input
-   ! ====================================================================
-   ! we assume that the user provides a resonable molecule input
-   ! -> all atoms are inside the unit cell, all data is set and consistent
-
-   wfn%nel = nint(sum(mol%z) - mol%chrg)
-   wfn%nopen = mol%uhf
-   ! at this point, don't complain about odd multiplicities for even electron
-   ! systems and just fix it silently, the API is supposed catch this
-   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
-   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
-
-   ! give an optional summary on the geometry used
-   if (opt%prlevel > 2) then
-      call main_geometry(iunit,mol)
-   endif
-
-   ! ====================================================================
-   !  STEP 2: get the parametrisation
-   ! ====================================================================
-   ! we could require our user to perform this step, but if we want
-   ! to be sure about getting the correct parameters, we should do it here
-
-   ! we will try an internal parameter file first to avoid IO
-   call use_parameterset(p_fnv_gfn2,globpar,exist)
-   ! no luck, we have to fire up some IO to get our parameters
-   if (.not.exist) then
-      ! let's check if we can find the parameter file
-      call rdpath(env%xtbpath,p_fnv_gfn2,fnv,exist)
-      ! maybe the user provides a local parameter file, this was always
-      ! an option in `xtb', so we will give it a try
-      if (.not.exist) fnv = p_fnv_gfn2
-      call open_file(ipar,fnv,'r')
-      if (ipar.eq.-1) then
-         ! at this point there is no chance to recover from this error
-         ! THEREFORE, we have to kill the program
-         call raise('E',"Parameter file '"//fnv//"' not found!",1)
-         return
-      endif
-      call read_gfn_param(ipar,globpar,.true.)
-      call close_file(ipar)
-   endif
-   call set_gfn2_parameter(param,globpar,mol%n,mol%at)
-   if (opt%prlevel > 1) then
-      call gfn2_header(iunit)
-      call gfn2_prparam(iunit,mol%n,mol%at,param)
-   endif
-
-   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none"
-   if (lgbsa) then
-      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
-   endif
-
-   ! ====================================================================
-   !  STEP 3: expand our Slater basis set in contracted Gaussians
-   ! ====================================================================
-
-   call xbasis0(mol%n,mol%at,basis)
-   call xbasis_gfn2(mol%n,mol%at,basis,okbas)
-   call xbasis_cao2sao(mol%n,mol%at,basis)
-
-   ! ====================================================================
-   !  STEP 4: setup the initial wavefunction
-   ! ====================================================================
-
-   call wfn%allocate(mol%n,basis%nshell,basis%nao)
-
-   ! do an EEQ guess
-   allocate( cn(mol%n), source = 0.0_wp )
-   call new_charge_model_2019(chrgeq,mol%n,mol%at)
-   call ncoord_erf(mol%n,mol%at,mol%xyz,cn)
-   call eeq_chrgeq(mol,chrgeq,cn,wfn%q)
-   deallocate(cn)
-
-   call iniqshell(mol%n,mol%at,mol%z,basis%nshell,wfn%q,wfn%qsh,gfn_method)
-
-   if (opt%restart) &
-      call read_restart(wfn,'xtbrestart',mol%n,mol%at,gfn_method,exist,.false.)
-
-   ! ====================================================================
-   !  STEP 5: do the calculation
-   ! ====================================================================
-   call scf(iunit,mol,wfn,basis,param,pcem,hl_gap, &
-      &     opt%etemp,opt%maxiter,opt%prlevel,.false.,opt%grad,opt%acc, &
-      &     energy,gradient,res)
-
-   if (opt%restart) then
-      call write_restart(wfn,'xtbrestart',gfn_method)
-   endif 
-
-   if (opt%prlevel > 0) then
-      write(iunit,'(9x,53(":"))')
-      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
-      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
-      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
-      write(iunit,'(9x,53(":"))')
-   endif
-
-end subroutine gfn2_calculation
-
-! ========================================================================
-!> GFN1-xTB calculation
-subroutine gfn1_calculation &
-      (iunit,env,opt,mol,gfn,pcem,wfn,hl_gap,energy,gradient)
-   use iso_fortran_env, wp => real64
-
-   use mctc_systools
-
-   use tbdef_options
-   use tbdef_molecule
-   use tbdef_wavefunction
-   use tbdef_basisset
-   use tbdef_param
-   use tbdef_data
-   use tbdef_pcem
-
-   use setparam, only : gfn_method, ngrida
-   use aoparam,  only : use_parameterset
-
-   use xbasis
-   use eeq_model
-   use ncoord
-   use scc_core
-   use scf_module
-   use gbobc
-   use embedding
-
-   implicit none
-
-   integer, intent(in) :: iunit
-
-   type(tb_molecule),    intent(inout) :: mol
-   type(gfn_parameter),  intent(in)    :: gfn
-   type(scc_options),    intent(in)    :: opt
-   type(tb_environment), intent(in)    :: env
-   type(tb_pcem),        intent(inout) :: pcem
-   type(tb_wavefunction),intent(inout) :: wfn
-
-   real(wp), intent(out) :: energy
-   real(wp), intent(out) :: hl_gap
-   real(wp), intent(out) :: gradient(3,mol%n)
-
-   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
-
-   type(tb_basisset)     :: basis
-   type(scc_parameter)   :: param
-   type(scc_results)     :: res
-   type(chrg_parameter)  :: chrgeq
-
-   real(wp), allocatable :: cn(:)
-
-   character(len=*),parameter :: outfmt = &
-      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
-   character(len=*), parameter   :: p_fnv_gfn1 = '.param_gfn.xtb'
-   character(len=:), allocatable :: fnv
-   real(wp) :: globpar(25)
-   integer  :: ipar
-   logical  :: exist
-
-   logical  :: okbas,diff
-
-   gfn_method = 1
-   call init_pcem
-
-   ! ====================================================================
-   !  STEP 1: prepare geometry input
-   ! ====================================================================
-   ! we assume that the user provides a resonable molecule input
-   ! -> all atoms are inside the unit cell, all data is set and consistent
-
-   wfn%nel = nint(sum(mol%z) - mol%chrg)
-   wfn%nopen = mol%uhf
-   ! at this point, don't complain about odd multiplicities for even electron
-   ! systems and just fix it silently, the API is supposed catch this
-   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
-   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
-
-   ! give an optional summary on the geometry used
-   if (opt%prlevel > 2) then
-      call main_geometry(iunit,mol)
-   endif
-
-   ! ====================================================================
-   !  STEP 2: get the parametrisation
-   ! ====================================================================
-   ! we could require our user to perform this step, but if we want
-   ! to be sure about getting the correct parameters, we should do it here
-
-   ! we will try an internal parameter file first to avoid IO
-   call use_parameterset(p_fnv_gfn1,globpar,exist)
-   ! no luck, we have to fire up some IO to get our parameters
-   if (.not.exist) then
-      ! let's check if we can find the parameter file
-      call rdpath(env%xtbpath,p_fnv_gfn1,fnv,exist)
-      ! maybe the user provides a local parameter file, this was always
-      ! an option in `xtb', so we will give it a try
-      if (.not.exist) fnv = p_fnv_gfn1
-      call open_file(ipar,fnv,'r')
-      if (ipar.eq.-1) then
-         ! at this point there is no chance to recover from this error
-         ! THEREFORE, we have to kill the program
-         call raise('E',"Parameter file '"//fnv//"' not found!",1)
-         return
-      endif
-      call read_gfn_param(ipar,globpar,.true.)
-      call close_file(ipar)
-   endif
-   call set_gfn1_parameter(param,globpar,mol%n,mol%at)
-   if (opt%prlevel > 1) then
-      call gfn1_header(iunit)
-      call gfn1_prparam(iunit,mol%n,mol%at,param)
-   endif
-
-   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none"
-   if (lgbsa) then
-      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
-   endif
-
-   ! ====================================================================
-   !  STEP 3: expand our Slater basis set in contracted Gaussians
-   ! ====================================================================
-
-   call xbasis0(mol%n,mol%at,basis)
-   call xbasis_gfn1(mol%n,mol%at,basis,okbas,diff)
-   call xbasis_cao2sao(mol%n,mol%at,basis)
-
-   ! ====================================================================
-   !  STEP 4: setup the initial wavefunction
-   ! ====================================================================
-
-   call wfn%allocate(mol%n,basis%nshell,basis%nao)
-
-   ! do a EEQ guess
-   allocate( cn(mol%n), source = 0.0_wp )
-   call new_charge_model_2019(chrgeq,mol%n,mol%at)
-   call ncoord_erf(mol%n,mol%at,mol%xyz,cn)
-   call eeq_chrgeq(mol,chrgeq,cn,wfn%q)
-   deallocate(cn)
-
-   call iniqshell(mol%n,mol%at,mol%z,basis%nshell,wfn%q,wfn%qsh,gfn_method)
-
-   ! ====================================================================
-   !  STEP 5: do the calculation
-   ! ====================================================================
-   call scf(iunit,mol,wfn,basis,param,pcem,hl_gap, &
-      &     opt%etemp,opt%maxiter,opt%prlevel,.false.,opt%grad,opt%acc, &
-      &     energy,gradient,res)
-
-   if (opt%prlevel > 0) then
-      write(iunit,'(9x,53(":"))')
-      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
-      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
-      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
-      write(iunit,'(9x,53(":"))')
-   endif
-
-end subroutine gfn1_calculation
 
 !> interface to the DFT-D4 module
 subroutine d4_calculation(iunit,opt,mol,dparam,energy,gradient)

--- a/xtb/gfn0_calculator.f90
+++ b/xtb/gfn0_calculator.f90
@@ -1,0 +1,180 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+submodule(tb_calculators) gfn0_calc_implementation
+   implicit none
+contains
+! ========================================================================
+!> periodic GFN0-xTB (PEEQ) calculation
+module subroutine gfn0_calculation &
+      (iunit,env,opt,mol,hl_gap,energy,gradient,stress,lattice_gradient)
+   use iso_fortran_env, wp => real64
+
+   use mctc_systools
+
+   use tbdef_options
+   use tbdef_molecule
+   use tbdef_wavefunction
+   use tbdef_basisset
+   use tbdef_param
+   use tbdef_data
+
+   use setparam, only : gfn_method, ngrida
+   use aoparam,  only : use_parameterset
+
+   use pbc_tools
+   use xbasis
+   use peeq_module
+   use gbobc
+
+   implicit none
+
+   integer, intent(in) :: iunit
+
+   type(tb_molecule),    intent(inout) :: mol
+   type(peeq_options),   intent(in)    :: opt
+   type(tb_environment), intent(in)    :: env
+
+   real(wp), intent(out) :: energy
+   real(wp), intent(out) :: hl_gap
+   real(wp), intent(out) :: gradient(3,mol%n)
+   real(wp), intent(out) :: stress(3,3)
+   real(wp), intent(out) :: lattice_gradient(3,3)
+   real(wp)              :: sigma(3,3)
+   real(wp)              :: inv_lat(3,3)
+
+   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
+
+   type(tb_wavefunction) :: wfn
+   type(tb_basisset)     :: basis
+   type(scc_parameter)   :: param
+   type(scc_results)     :: res
+
+   character(len=*),parameter :: outfmt = &
+      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
+   character(len=*), parameter   :: p_fnv_gfn0 = '.param_gfn0.xtb'
+   character(len=:), allocatable :: fnv
+   real(wp) :: globpar(25)
+   integer  :: ipar,i
+   logical  :: exist
+
+   logical  :: okbas,diff
+
+   gfn_method = 0
+   sigma = 0.0_wp
+
+   ! ====================================================================
+   !  STEP 1: prepare geometry input
+   ! ====================================================================
+   ! we assume that the user provides a resonable molecule input
+   ! -> all atoms are inside the unit cell, all data is set and consistent
+
+   wfn%nel = nint(sum(mol%z) - mol%chrg)
+   wfn%nopen = mol%uhf
+   ! at this point, don't complain about odd multiplicities for even electron
+   ! systems and just fix it silently, the API is supposed catch this
+   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
+   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
+
+   if (mol%npbc > 0) then
+      ! get Wigner-Seitz cell if necessary
+      ! -> this modifies the molecule, since the WSC is bound to a molecule
+      call generate_wsc(mol,mol%wsc,wsc_rep)
+   endif
+
+   ! give an optional summary on the geometry used
+   if (opt%prlevel > 2) then
+      call print_pbcsum(iunit,mol)
+   endif
+
+   ! ====================================================================
+   !  STEP 2: get the parametrisation
+   ! ====================================================================
+   ! we could require our user to perform this step, but if we want
+   ! to be sure about getting the correct parameters, we should do it here
+
+   ! we will try an internal parameter file first to avoid IO
+   call use_parameterset(p_fnv_gfn0,globpar,exist)
+   ! no luck, we have to fire up some IO to get our parameters
+   if (.not.exist) then
+      ! let's check if we can find the parameter file
+      call rdpath(env%xtbpath,p_fnv_gfn0,fnv,exist)
+      ! maybe the user provides a local parameter file, this was always
+      ! an option in `xtb', so we will give it a try
+      if (.not.exist) fnv = p_fnv_gfn0
+      call open_file(ipar,fnv,'r')
+      if (ipar.eq.-1) then
+         ! at this point there is no chance to recover from this error
+         ! THEREFORE, we have to kill the program
+         call raise('E',"Parameter file '"//fnv//"' not found!",1)
+         return
+      endif
+      call read_gfn_param(ipar,globpar,.true.)
+      call close_file(ipar)
+   endif
+   call set_gfn0_parameter(param,globpar,mol%n,mol%at)
+   if (opt%prlevel > 1) then
+      call gfn0_header(iunit)
+      call gfn0_prparam(iunit,mol%n,mol%at,param)
+   endif
+
+   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none" &
+      &    .and. mol%npbc == 0 ! GBSA is not yet periodic
+   if (lgbsa) then
+      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
+   endif
+
+   ! ====================================================================
+   !  STEP 3: expand our Slater basis set in contracted Gaussians
+   ! ====================================================================
+
+   call xbasis0(mol%n,mol%at,basis)
+   call xbasis_gfn0(mol%n,mol%at,basis,okbas,diff)
+   call xbasis_cao2sao(mol%n,mol%at,basis)
+
+   ! ====================================================================
+   !  STEP 4: setup the initial wavefunction
+   ! ====================================================================
+
+   call wfn%allocate(mol%n,basis%nshell,basis%nao)
+   ! do a SAD guess since we are not need any of this information later
+   wfn%q = mol%chrg / real(mol%n,wp)
+
+   ! ====================================================================
+   !  STEP 5: do the calculation
+   ! ====================================================================
+
+   call peeq(iunit,mol,wfn,basis,param,hl_gap,opt%etemp,opt%prlevel,opt%grad, &
+      &      opt%ccm,opt%acc,energy,gradient,sigma,res)
+
+   if (mol%npbc > 0) then
+      inv_lat = mat_inv_3x3(mol%lattice)
+      call sigma_to_latgrad(sigma,inv_lat,lattice_gradient)
+      stress = sigma/mol%volume
+   endif
+
+   if (opt%prlevel > 0) then
+      write(iunit,'(9x,53(":"))')
+      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
+      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
+      if (mol%npbc > 0) &
+      write(iunit,outfmt) "gradlatt norm     ", norm2(lattice_gradient),  "Eh/α"
+      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
+      write(iunit,'(9x,53(":"))')
+   endif
+
+end subroutine gfn0_calculation
+end submodule gfn0_calc_implementation

--- a/xtb/gfn1_calculator.f90
+++ b/xtb/gfn1_calculator.f90
@@ -1,0 +1,176 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+submodule(tb_calculators) gfn1_calc_implementation
+   implicit none
+contains
+! ========================================================================
+!> GFN1-xTB calculation
+module subroutine gfn1_calculation &
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
+   use iso_fortran_env, wp => real64
+
+   use mctc_systools
+
+   use tbdef_options
+   use tbdef_molecule
+   use tbdef_wavefunction
+   use tbdef_basisset
+   use tbdef_param
+   use tbdef_data
+   use tbdef_pcem
+
+   use setparam, only : gfn_method, ngrida
+   use aoparam,  only : use_parameterset
+
+   use xbasis
+   use eeq_model
+   use ncoord
+   use scc_core
+   use scf_module
+   use gbobc
+   use embedding
+
+   implicit none
+
+   integer, intent(in) :: iunit
+
+   type(tb_molecule),    intent(inout) :: mol
+   type(scc_options),    intent(in)    :: opt
+   type(tb_environment), intent(in)    :: env
+   type(tb_pcem),        intent(inout) :: pcem
+   type(tb_wavefunction),intent(inout) :: wfn
+
+   real(wp), intent(out) :: energy
+   real(wp), intent(out) :: hl_gap
+   real(wp), intent(out) :: gradient(3,mol%n)
+
+   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
+
+   type(tb_basisset)     :: basis
+   type(scc_parameter)   :: param
+   type(scc_results)     :: res
+   type(chrg_parameter)  :: chrgeq
+
+   real(wp), allocatable :: cn(:)
+
+   character(len=*),parameter :: outfmt = &
+      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
+   character(len=*), parameter   :: p_fnv_gfn1 = '.param_gfn.xtb'
+   character(len=:), allocatable :: fnv
+   real(wp) :: globpar(25)
+   integer  :: ipar
+   logical  :: exist
+
+   logical  :: okbas,diff
+
+   gfn_method = 1
+   call init_pcem
+
+   ! ====================================================================
+   !  STEP 1: prepare geometry input
+   ! ====================================================================
+   ! we assume that the user provides a resonable molecule input
+   ! -> all atoms are inside the unit cell, all data is set and consistent
+
+   wfn%nel = nint(sum(mol%z) - mol%chrg)
+   wfn%nopen = mol%uhf
+   ! at this point, don't complain about odd multiplicities for even electron
+   ! systems and just fix it silently, the API is supposed catch this
+   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
+   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
+
+   ! give an optional summary on the geometry used
+   if (opt%prlevel > 2) then
+      call main_geometry(iunit,mol)
+   endif
+
+   ! ====================================================================
+   !  STEP 2: get the parametrisation
+   ! ====================================================================
+   ! we could require our user to perform this step, but if we want
+   ! to be sure about getting the correct parameters, we should do it here
+
+   ! we will try an internal parameter file first to avoid IO
+   call use_parameterset(p_fnv_gfn1,globpar,exist)
+   ! no luck, we have to fire up some IO to get our parameters
+   if (.not.exist) then
+      ! let's check if we can find the parameter file
+      call rdpath(env%xtbpath,p_fnv_gfn1,fnv,exist)
+      ! maybe the user provides a local parameter file, this was always
+      ! an option in `xtb', so we will give it a try
+      if (.not.exist) fnv = p_fnv_gfn1
+      call open_file(ipar,fnv,'r')
+      if (ipar.eq.-1) then
+         ! at this point there is no chance to recover from this error
+         ! THEREFORE, we have to kill the program
+         call raise('E',"Parameter file '"//fnv//"' not found!",1)
+         return
+      endif
+      call read_gfn_param(ipar,globpar,.true.)
+      call close_file(ipar)
+   endif
+   call set_gfn1_parameter(param,globpar,mol%n,mol%at)
+   if (opt%prlevel > 1) then
+      call gfn1_header(iunit)
+      call gfn1_prparam(iunit,mol%n,mol%at,param)
+   endif
+
+   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none"
+   if (lgbsa) then
+      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
+   endif
+
+   ! ====================================================================
+   !  STEP 3: expand our Slater basis set in contracted Gaussians
+   ! ====================================================================
+
+   call xbasis0(mol%n,mol%at,basis)
+   call xbasis_gfn1(mol%n,mol%at,basis,okbas,diff)
+   call xbasis_cao2sao(mol%n,mol%at,basis)
+
+   ! ====================================================================
+   !  STEP 4: setup the initial wavefunction
+   ! ====================================================================
+
+   call wfn%allocate(mol%n,basis%nshell,basis%nao)
+
+   ! do a EEQ guess
+   allocate( cn(mol%n), source = 0.0_wp )
+   call new_charge_model_2019(chrgeq,mol%n,mol%at)
+   call ncoord_erf(mol%n,mol%at,mol%xyz,cn)
+   call eeq_chrgeq(mol,chrgeq,cn,wfn%q)
+   deallocate(cn)
+
+   call iniqshell(mol%n,mol%at,mol%z,basis%nshell,wfn%q,wfn%qsh,gfn_method)
+
+   ! ====================================================================
+   !  STEP 5: do the calculation
+   ! ====================================================================
+   call scf(iunit,mol,wfn,basis,param,pcem,hl_gap, &
+      &     opt%etemp,opt%maxiter,opt%prlevel,.false.,opt%grad,opt%acc, &
+      &     energy,gradient,res)
+
+   if (opt%prlevel > 0) then
+      write(iunit,'(9x,53(":"))')
+      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
+      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
+      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
+      write(iunit,'(9x,53(":"))')
+   endif
+
+end subroutine gfn1_calculation
+end submodule gfn1_calc_implementation

--- a/xtb/gfn2_calculator.f90
+++ b/xtb/gfn2_calculator.f90
@@ -1,0 +1,183 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2019 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+submodule(tb_calculators) gfn2_calc_implementation
+   implicit none
+contains
+! ========================================================================
+!> GFN2-xTB calculation
+module subroutine gfn2_calculation &
+      (iunit,env,opt,mol,pcem,wfn,hl_gap,energy,gradient)
+   use iso_fortran_env, wp => real64
+
+   use mctc_systools
+
+   use tbdef_options
+   use tbdef_molecule
+   use tbdef_wavefunction
+   use tbdef_basisset
+   use tbdef_param
+   use tbdef_data
+   use tbdef_pcem
+
+   use setparam, only : gfn_method, ngrida
+   use aoparam,  only : use_parameterset
+
+   use xbasis
+   use eeq_model
+   use ncoord
+   use scc_core
+   use scf_module
+   use gbobc
+   use embedding
+
+   implicit none
+
+   integer, intent(in) :: iunit
+
+   type(tb_molecule),    intent(inout) :: mol
+   type(tb_wavefunction),intent(inout) :: wfn
+   type(scc_options),    intent(in)    :: opt
+   type(tb_environment), intent(in)    :: env
+   type(tb_pcem),        intent(inout) :: pcem
+
+   real(wp), intent(out) :: energy
+   real(wp), intent(out) :: hl_gap
+   real(wp), intent(out) :: gradient(3,mol%n)
+
+   integer, parameter    :: wsc_rep(3) = [1,1,1] ! FIXME
+
+   type(tb_basisset)     :: basis
+   type(scc_parameter)   :: param
+   type(scc_results)     :: res
+   type(chrg_parameter)  :: chrgeq
+
+   real(wp), allocatable :: cn(:)
+
+   character(len=*),parameter :: outfmt = &
+      '(9x,"::",1x,a,f24.12,1x,a,1x,"::")'
+   character(len=*), parameter   :: p_fnv_gfn2 = '.param_gfn2.xtb'
+   character(len=:), allocatable :: fnv
+   real(wp) :: globpar(25)
+   integer  :: ipar
+   logical  :: exist
+
+   logical  :: okbas
+
+   gfn_method = 2
+   call init_pcem
+
+   ! ====================================================================
+   !  STEP 1: prepare geometry input
+   ! ====================================================================
+   ! we assume that the user provides a resonable molecule input
+   ! -> all atoms are inside the unit cell, all data is set and consistent
+
+   wfn%nel = nint(sum(mol%z) - mol%chrg)
+   wfn%nopen = mol%uhf
+   ! at this point, don't complain about odd multiplicities for even electron
+   ! systems and just fix it silently, the API is supposed catch this
+   if (mod(wfn%nopen,2) == 0.and.mod(wfn%nel,2) /= 0) wfn%nopen = 1
+   if (mod(wfn%nopen,2) /= 0.and.mod(wfn%nel,2) == 0) wfn%nopen = 0
+
+   ! give an optional summary on the geometry used
+   if (opt%prlevel > 2) then
+      call main_geometry(iunit,mol)
+   endif
+
+   ! ====================================================================
+   !  STEP 2: get the parametrisation
+   ! ====================================================================
+   ! we could require our user to perform this step, but if we want
+   ! to be sure about getting the correct parameters, we should do it here
+
+   ! we will try an internal parameter file first to avoid IO
+   call use_parameterset(p_fnv_gfn2,globpar,exist)
+   ! no luck, we have to fire up some IO to get our parameters
+   if (.not.exist) then
+      ! let's check if we can find the parameter file
+      call rdpath(env%xtbpath,p_fnv_gfn2,fnv,exist)
+      ! maybe the user provides a local parameter file, this was always
+      ! an option in `xtb', so we will give it a try
+      if (.not.exist) fnv = p_fnv_gfn2
+      call open_file(ipar,fnv,'r')
+      if (ipar.eq.-1) then
+         ! at this point there is no chance to recover from this error
+         ! THEREFORE, we have to kill the program
+         call raise('E',"Parameter file '"//fnv//"' not found!",1)
+         return
+      endif
+      call read_gfn_param(ipar,globpar,.true.)
+      call close_file(ipar)
+   endif
+   call set_gfn2_parameter(param,globpar,mol%n,mol%at)
+   if (opt%prlevel > 1) then
+      call gfn2_header(iunit)
+      call gfn2_prparam(iunit,mol%n,mol%at,param)
+   endif
+
+   lgbsa = len_trim(opt%solvent).gt.0 .and. opt%solvent.ne."none"
+   if (lgbsa) then
+      call init_gbsa(iunit,trim(opt%solvent),0,opt%etemp,gfn_method,ngrida)
+   endif
+
+   ! ====================================================================
+   !  STEP 3: expand our Slater basis set in contracted Gaussians
+   ! ====================================================================
+
+   call xbasis0(mol%n,mol%at,basis)
+   call xbasis_gfn2(mol%n,mol%at,basis,okbas)
+   call xbasis_cao2sao(mol%n,mol%at,basis)
+
+   ! ====================================================================
+   !  STEP 4: setup the initial wavefunction
+   ! ====================================================================
+
+   call wfn%allocate(mol%n,basis%nshell,basis%nao)
+
+   ! do an EEQ guess
+   allocate( cn(mol%n), source = 0.0_wp )
+   call new_charge_model_2019(chrgeq,mol%n,mol%at)
+   call ncoord_erf(mol%n,mol%at,mol%xyz,cn)
+   call eeq_chrgeq(mol,chrgeq,cn,wfn%q)
+   deallocate(cn)
+
+   call iniqshell(mol%n,mol%at,mol%z,basis%nshell,wfn%q,wfn%qsh,gfn_method)
+
+   if (opt%restart) &
+      call read_restart(wfn,'xtbrestart',mol%n,mol%at,gfn_method,exist,.false.)
+
+   ! ====================================================================
+   !  STEP 5: do the calculation
+   ! ====================================================================
+   call scf(iunit,mol,wfn,basis,param,pcem,hl_gap, &
+      &     opt%etemp,opt%maxiter,opt%prlevel,.false.,opt%grad,opt%acc, &
+      &     energy,gradient,res)
+
+   if (opt%restart) then
+      call write_restart(wfn,'xtbrestart',gfn_method)
+   endif 
+
+   if (opt%prlevel > 0) then
+      write(iunit,'(9x,53(":"))')
+      write(iunit,outfmt) "total energy      ", res%e_total,"Eh  "
+      write(iunit,outfmt) "gradient norm     ", res%gnorm,  "Eh/α"
+      write(iunit,outfmt) "HOMO-LUMO gap     ", res%hl_gap, "eV  "
+      write(iunit,'(9x,53(":"))')
+   endif
+
+end subroutine gfn2_calculation
+end submodule gfn2_calc_implementation

--- a/xtb/grad_core.f90
+++ b/xtb/grad_core.f90
@@ -28,6 +28,7 @@ module grad_core
 
    implicit none
 
+   integer, private, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
 
 contains
 

--- a/xtb/hessian.F90
+++ b/xtb/hessian.F90
@@ -167,7 +167,9 @@ subroutine numhess( &
       !$omp&         private(ia,ic,ii,ja,jc,jj,eel,gr,gl,egap,sccr,sccl,sr,sl,wfx,tmol) &
       !$omp&         shared (h,dipd,pold,step,step2,t1,t0,w1,w0,indx,nonfrozh)
       !$ call omp_set_num_threads(1)
+#ifdef WITH_MKL
       !$ call mkl_set_num_threads(1)
+#endif
       !$omp do schedule(dynamic)
       do a = 1, nonfrozh
          ia=indx(a)
@@ -210,7 +212,9 @@ subroutine numhess( &
       !$omp end do
       !$omp end parallel
       !$ call omp_set_num_threads(nproc)
+#ifdef WITH_MKL
       !$ call mkl_set_num_threads(nproc)
+#endif
 
    else
 !! ------------------------------------------------------------------------
@@ -222,7 +226,9 @@ subroutine numhess( &
       !$omp&         private(ia,ic,ii,ja,jc,jj,eel,gr,gl,egap,sccr,sccl,wfx,tmol) &
       !$omp&         shared (h,dipd,pold,step,step2,t1,t0,w1,w0,xyzsave)
       !$ call omp_set_num_threads(1)
+#ifdef WITH_MKL
       !$ call mkl_set_num_threads(1)
+#endif
       !$omp do schedule(dynamic)
       do ia = 1, mol%n
          do ic = 1, 3
@@ -276,7 +282,9 @@ subroutine numhess( &
       !$omp end do
       !$omp end parallel
       !$ call omp_set_num_threads(nproc)
+#ifdef WITH_MKL
       !$ call mkl_set_num_threads(nproc)
+#endif
 
    endif
 

--- a/xtb/modef.f90
+++ b/xtb/modef.f90
@@ -49,13 +49,6 @@ subroutine modefollow(mol,wfn,calc,egap,et,maxiter,epot,grd,sigma)
    real(wp), intent(inout) :: grd(3,mol%n)
    real(wp), intent(inout) :: sigma(3,3)
    type(scc_results) :: res
-   interface
-      function rename(oldpath, newpath) bind(c) result(stat)
-         use iso_c_binding
-         character(len=*,kind=c_char), intent(in) :: oldpath, newpath
-         integer(c_int) :: stat
-      end function rename
-   end interface
 
    real(wp),allocatable:: freq(:), u(:,:), uu(:,:)
    real(wp),allocatable:: xyza (:,:,:), rmass(:), e(:), e2(:), geo(:,:)
@@ -123,8 +116,6 @@ subroutine modefollow(mol,wfn,calc,egap,et,maxiter,epot,grd,sigma)
    if(mode.lt.6.and.(.not.intermol)) call raise('E','mode <7(6) makes no sense!',1)
    if(mode_follow.gt.3*mol%n) call raise('E','mode >3N makes no sense!',1)
 
-   !call system('mv hessian hessian.xtbtmp 2>/dev/null') ! don't use hessian in ancopt
-   i = rename('hessian'//c_null_char,'hessian.xtbtmp'//c_null_char)              ! don't use hessian in ancopt
 
    n3=3*mol%n
    allocate(freq(n3),u(n3,n3),uu(n3,nprj),xyzmin(3,mol%n), &
@@ -512,8 +503,6 @@ subroutine modefollow(mol,wfn,calc,egap,et,maxiter,epot,grd,sigma)
    endif
 
    999  continue
-   !call system('mv hessian.xtbtmp hessian 2>/dev/null') ! restore
-   i = rename('hessian.xtbtmp'//c_null_char,'hessian'//c_null_char)              ! restore
    !call system('touch xtbmodefok')                     ! for parallel runs
    call touch_file('xtbmodefok')                    ! for parallel runs
 

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -689,7 +689,7 @@ subroutine read_molecule_gen(mol, unit, status, iomsg)
 
    call next_line(unit, line, error)
    read(line, *, iostat=error) natoms, variant
-   if (any(species == 0)) then
+   if (error /= 0 .or. natoms < 1) then
       iomsg = 'could not read number of atoms'
       return
    endif

--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -263,6 +263,7 @@ program XTBprog
    if (coffee) then ! it's coffee time
       fname = 'caffeine'
       call get_coffee(mol)
+      call file_generate_meta_info(fname, extension, basename, directory)
    else
       call file_generate_meta_info(fname, extension, basename, directory)
       call file_figure_out_ftype(ftype, extension, basename)

--- a/xtb/scc_core.f90
+++ b/xtb/scc_core.f90
@@ -28,7 +28,7 @@ module scc_core
    use mctc_la, only : sygvd,gemm,symm
    implicit none
 
-   integer, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
+   integer, private, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
  
 contains
 

--- a/xtb/scf_module.f90
+++ b/xtb/scf_module.f90
@@ -22,6 +22,8 @@ module scf_module
 
    logical,private,parameter :: profile = .true.
 
+   integer, private, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
+
 contains
 
 subroutine scf(iunit,mol,wfn,basis,param,pcem, &

--- a/xtb/screening.f90
+++ b/xtb/screening.f90
@@ -270,13 +270,6 @@ subroutine qmdfftoscreen(n,at,xyz,nall,xyzall)
    integer  :: nall
    real(wp) :: xyzall(3,n,nall)
    real(wp) :: xyz   (3,n)
-   interface
-      function rename(oldpath, newpath) bind(c) result(stat)
-         use iso_c_binding
-         character(len=*,kind=c_char), intent(in) :: oldpath, newpath
-         integer(c_int) :: stat
-      end function rename
-   end interface
 
    character(80) :: atmp
    character(2)  :: a2
@@ -287,8 +280,6 @@ subroutine qmdfftoscreen(n,at,xyz,nall,xyzall)
    !call wrcoord(16,n,xyz,at,0.0d0,'coord')  ! qmdff needs a coord file
    call wrc('coord',n,xyz,at)
    write(*,*) 'moving hessian to hessian.save'
-   !call execute_command_line('mv hessian hessian.save')
-   i = rename('hessian'//c_null_char,'hessian.save'//c_null_char)
 
    temp  =Tend_siman
    tstart=temp_md

--- a/xtb/tbdef_atomlist.f90
+++ b/xtb/tbdef_atomlist.f90
@@ -35,7 +35,7 @@ module tbdef_atomlist
       logical :: error = .false.
    contains
       generic :: new => from_integers, from_logicals, from_string, from_defaults
-      procedure, private :: from_defaults => atomlist_defaults
+      procedure, private, non_overridable :: from_defaults => atomlist_defaults
       procedure, private :: from_integers => atomlist_assign_integers
       procedure, private :: from_logicals => atomlist_assign_logicals
       procedure, private :: from_string => atomlist_assign_string
@@ -131,7 +131,7 @@ pure function atomlist_from_string(list, truth, delimiter, skip) result(self)
    call self%new(list)
 end function atomlist_from_string
 
-pure elemental subroutine atomlist_defaults(self)
+subroutine atomlist_defaults(self)
    class(tb_atomlist), intent(out) :: self
 end subroutine atomlist_defaults
 

--- a/xtb/tbdef_fragments.f90
+++ b/xtb/tbdef_fragments.f90
@@ -18,7 +18,7 @@
 module tbdef_fragments
    implicit none
    public :: tb_fragments
-   public :: len, size
+   public :: len
    private
 
 
@@ -43,13 +43,13 @@ contains
 
 
 subroutine frag_new_default(self, number_of_atoms)
-   class(tb_fragments), intent(out) :: self
+   class(tb_fragments), intent(inout) :: self
    integer, intent(in) :: number_of_atoms
    allocate(self%list(number_of_atoms), source=0)
 end subroutine frag_new_default
 
 subroutine frag_new_from_list(self, list)
-   class(tb_fragments), intent(out) :: self
+   class(tb_fragments), intent(inout) :: self
    integer, intent(in) :: list(:)
    if (all(list > 0)) then
       self%list = list
@@ -73,7 +73,7 @@ subroutine frag_get_list(self, fragment, list)
    integer, intent(in) :: fragment
    integer, allocatable, intent(out) :: list(:)
    integer :: i
-   list = pack([(i, i=1, size(self%list))], mask=self%list.eq.fragment)
+   list = pack([(i, i=1, size(self%list, 1))], mask=self%list.eq.fragment)
 end subroutine frag_get_list
 
 

--- a/xtb/tbdef_param.f90
+++ b/xtb/tbdef_param.f90
@@ -27,8 +27,6 @@ module tbdef_param
    public :: gfn2_param_from_globpar
 
    public :: chrg_parameter
-
-   public :: gfn_parameter
    private
 
    type :: dftd_parameter
@@ -73,38 +71,6 @@ module tbdef_param
       real(wp) :: g_c
       real(wp) :: wf
    end type scc_parameter
-
-   integer, private, parameter :: max_elem  = 94
-   integer, private, parameter :: max_shell = 10
-   type gfn_parameter(nelem,nshell)
-      integer, len :: nelem  = max_elem
-      integer, len :: nshell = max_shell
-      integer  :: method = -1
-      real(wp) :: en(nelem)
-      real(wp) :: mc(nelem)
-      real(wp) :: gam(nelem)
-      real(wp) :: gam3(nelem)
-      real(wp) :: rad(nelem)
-      real(wp) :: wll(nelem,nshell)
-      real(wp) :: rep(2,nelem)
-      real(wp) :: polyr(4,nelem)
-      real(wp) :: cxb(nelem)
-      real(wp) :: ao_exp(nshell,nelem)
-      real(wp) :: ao_lev(nshell,nelem)
-      real(wp) :: lpar(0:2,nelem)
-      real(wp) :: kpair(nelem,nelem)
-      real(wp) :: kcnat(0:2,nelem)
-      real(wp) :: radaes(nelem)
-      real(wp) :: dpolc(nelem)
-      real(wp) :: qpolc(nelem)
-      integer  :: ao_pqn(nshell,nelem)
-      integer  :: ao_l(nshell,nelem)
-      integer  :: ao_n(nelem)
-      integer  :: ao_typ(nshell,nelem)
-      integer  :: metal(nelem)
-      integer  :: cnval(nelem)
-      character(len=30) :: timestp(nelem)
-   end type gfn_parameter
 
    type chrg_parameter
       integer  :: n

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -42,11 +42,18 @@ subroutine file_generate_meta_info(fname, extension, basename, directory)
       extension = fname(idot+1:)
    else ! means point is somewhere in the path or absent
       idot = len(fname)+1
+      extension = ''
    endif
    if (idot > islash .and. islash > 0) then
       basename = fname(islash+1:idot-1)
+   else
+      basename = ''
    endif
-   if (islash > 0) directory = fname(:islash)
+   if (islash > 0) then
+      directory = fname(:islash)
+   else
+      directory = ''
+   endif
 end subroutine file_generate_meta_info
 
 subroutine file_generate_name(fname, basename, extension, ftype)


### PR DESCRIPTION
hopefully fixes #11
also fixes #12 when we are running the CI on OSX!
[![Build Status](https://github.com/awvwgk/xtb/workflows/CI/badge.svg)](https://github.com/awvwgk/xtb/actions)
- [x] remove all offending statements such that it compiles with GCC
- [x] check dependencies to allow linking a binary with GCC
- [x] make sure no Intel extensions are used in the code... this gonna be hard :)
  - [x] mostly effects by `-r8` flag (GCC equivalent?)
- [x] make openmp usage compatible with GCC restrictions
  - [x] GCC version >= 8 works
- [x] figure out what is wrong with deferred-length characters and GCC
- [x] get the testsuite running with GCC (for Travis-CI and GH actions)
  - [x] basic GH actions CI :tada:
  - [x] WSC generation is failing (0D always, 3D erratically)
  - [x] xTB Hamiltonians fail erratically
  - [x] atomlist class is somewhat problematic (derived type IO to internal unit)
- [x] have a working binary

This is work in progress and not my highest priority. If you think you can help out here, feel free to open a PR on this PR :)