### PR TITLE
Preparation for release of xtb version 6.2.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 # extended tight binding program package
 project('xtb',
         'fortran', 'c', 'cpp',
-        version: '6.2.1',
+        version: '6.2.2',
         license: 'LGPL3',
         meson_version: '>=0.49')
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="xtb",
-      version="6.2.1",
+      version="6.2.2",
       author="Sebastian Ehlert",
       author_email="ehlert@thch.uni-bonn.de",
       description="Wrapper for the extended tight binding program",


### PR DESCRIPTION
Staging for release v6.2.2, requires https://github.com/grimme-lab/xtb/milestone/1 to be finished.