### PR TITLE
Hessian read-in mode for RF optimizer

### DIFF
--- a/xtb/set_module.f90
+++ b/xtb/set_module.f90
@@ -193,6 +193,7 @@ subroutine write_set_opt(ictrl)
    write(ictrl,'(3x,"hessian=")',advance='no')
    select case(mhset%model)
    case default;          write(ictrl,'("lindh-d2")')
+   case(p_modh_read);     write(ictrl,'("read")')
    case(p_modh_unit);     write(ictrl,'("unit")')
    case(p_modh_old);      write(ictrl,'("old")')
    case(p_modh_lindh);    write(ictrl,'("lindh")')
@@ -1407,6 +1408,7 @@ subroutine set_opt(key,val)
          case("swart");    mhset%model = p_modh_swart
          case("old");      mhset%model = p_modh_old
          case("unit");     mhset%model = p_modh_unit
+         case("read");     mhset%model = p_modh_read
          end select
       endif
       set14 = .false.

--- a/xtb/setparam.f90
+++ b/xtb/setparam.f90
@@ -110,6 +110,7 @@ module setparam
       maxdispl_opt = 1.000_wp, &
 !  lowest force constant in ANC generation (should be > 0.005)
       hlow_opt = 0.010_wp )
+   integer, parameter :: p_modh_read     = -2
    integer, parameter :: p_modh_unit     = -1
    integer, parameter :: p_modh_lindh    =  1
    integer, parameter :: p_modh_lindh_d2 =  2


### PR DESCRIPTION
Read-in of previous calculated hessians is somewhat annoying and shouldn't be the default.