### PR TITLE
add cold fusion check to xtb

### DIFF
--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -376,6 +376,8 @@ program XTBprog
 !  You had it coming!
    if (strict) call mctc_strict
 
+   call check_cold_fusion(mol)
+
 !! ------------------------------------------------------------------------
 !  PARAMETER
 !! ------------------------------------------------------------------------
@@ -1026,5 +1028,30 @@ program XTBprog
       call terminate(0)
    endif
 
+contains
+subroutine check_cold_fusion(mol)
+   type(tb_molecule), intent(in) :: mol
+   integer :: iat, jat
+   character(len=10) :: a10
+   character(len=20) :: a20
+   logical :: cold_fusion
+   cold_fusion = .false.
+   do iat = 1, len(mol)
+      do jat = 1, iat-1
+         if (mol%dist(jat, iat) < 1.0e-9_wp) then
+            cold_fusion = .true.
+            write(a20, '(a,i0,"-",a,i0)') &
+               &  trim(mol%sym(jat)), jat, trim(mol%sym(iat)), iat
+            write(a10, '(es10.3)') mol%dist(jat, iat)
+            call raise('S', "Found *very* short distance of "//a10//" for "//&
+               &            trim(a20), 1)
+         endif
+      enddo
+   enddo
+   if (cold_fusion) then
+      call raise('F', "Some atoms in the start geometry are *very* close", 1)
+      call raise('E', "XTB REFUSES TO CONTINUE WITH THIS CALCULATION!", 1)
+   endif
+end subroutine check_cold_fusion
 end program XTBprog
 


### PR DESCRIPTION
fixes #74

- [x] checks all atompairs for very small distances
- [x] lists all offending distances except for strict jobs
- [x] kills the job because it is going to break anyway

Distance threshold is set to 1.0e-9, which should be far beyond reasonable for any geometry.

```
########################################################################
# WARNING! Some atoms in the start geometry are *very* close
#  - Found *very* short distance of  0.000E+00 for S1-Ar2
#  - Found *very* short distance of  0.000E+00 for S1-Ca3
#  - Found *very* short distance of  0.000E+00 for Ar2-Ca3
#  - Found *very* short distance of  0.000E+00 for S1-Sm4
#  - Found *very* short distance of  0.000E+00 for Ar2-Sm4
#  - Found *very* short distance of  0.000E+00 for Ca3-Sm4
########################################################################

#ERROR! XTB REFUSES TO CONTINUE WITH THIS CALCULATION!
abnormal termination of xtb
```

With `--strict` the run is killed immediately at:
```
#ERROR! Found *very* short distance of  0.000E+00 for S1-Ar2
abnormal termination of xtb
```

Note: The API does not perform such checks... hopefully they are not necessary there.