### PR TITLE
OpenSUSE specific fix for C-source code

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,9 @@ elif cc.get_id() == 'intel'
   add_project_arguments('-std=c11', language: 'c')
 endif
 
+# fix compiliation problems with of symmetry/symmetry_i.c
+add_project_arguments('-D_Float128=__float128', language: 'c')
+
 ## ========================================== ##
 ## LIBRARIES
 ## ========================================== ##


### PR DESCRIPTION
Adding  `-D_Float128=__float128` fixes compilation issues with `symmetry/symmetry_i.c` on OpenSUSE.

Thanks to @jens-vasp for pointing this out.