### PR TITLE
Fix Wiberg bond order calculation

### DIFF
--- a/xtb/local.f90
+++ b/xtb/local.f90
@@ -21,7 +21,7 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis)
    use mctc_econv, only : autoev,autoaa
    use tbdef_basisset
    use setparam
-   use scc_core, only : wiberg_nosort
+   use scc_core, only : get_wiberg
    use dtrafo
    implicit none
    type(tb_basisset), intent(in) :: basis
@@ -417,7 +417,7 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis)
 
       allocate(wbo(nat,nat))
       wbo=0.0d0
-      call wiberg_nosort(nat,nao,at,xyz,p,s,wbo,.false.,basis%fila2)
+      call get_wiberg(nat,nao,at,xyz,p,s,wbo,basis%fila2)
 
       !     now create new LMO
       k=0

--- a/xtb/main_property.f90
+++ b/xtb/main_property.f90
@@ -148,8 +148,12 @@ subroutine main_property &
 
 
 !! wiberg bond orders
-   if (pr_wiberg) &
-   call print_wiberg(iunit,mol%n,mol%at,wfx%wbo,0.1_wp)
+   if (pr_wiberg) then
+      call open_file(ifile,'wbo','w')
+      call print_wbofile(ifile,mol%n,wfx%wbo,0.1_wp)
+      call close_file(ifile)
+      call print_wiberg(iunit,mol%n,mol%at,wfx%wbo,0.1_wp)
+   endif
 
    if (pr_wbofrag) &
    call print_wbo_fragment(iunit,mol%n,mol%at,wfx%wbo,0.1_wp)
@@ -502,6 +506,21 @@ subroutine print_mulliken(iunit,ifile,n,at,xyz,z,nao,S,P,aoat2,lao2)
       enddo
    endif
 end subroutine print_mulliken
+
+subroutine print_wbofile(iunit,n,wbo,thr)
+   use iso_fortran_env, wp => real64
+   implicit none
+   integer, intent(in) :: iunit
+   integer, intent(in) :: n
+   real(wp),intent(in) :: wbo(n,n)
+   real(wp),intent(in) :: thr
+   integer :: i, j
+   do i = 1, n
+      do j = 1, i-1
+         if (wbo(j, i) > thr) write(iunit, *) j, i, wbo(j, i)
+      end do
+   end do
+end subroutine print_wbofile
 
 subroutine print_wiberg(iunit,n,at,wbo,thr)
    use iso_fortran_env, wp => real64

--- a/xtb/main_property.f90
+++ b/xtb/main_property.f90
@@ -64,7 +64,6 @@ subroutine main_property &
    use gbobc
 
 !! ------------------------------------------------------------------------
-   use scc_core, only : wiberg
    use aespot
    use dtrafo
 
@@ -149,8 +148,6 @@ subroutine main_property &
 
 
 !! wiberg bond orders
-   if (pr_wiberg.and.gfn_method.eq.0) &
-   call wiberg(mol%n,basis%nao,mol%at,mol%xyz,wfx%P,S,wfx%wbo,.false.,.false.,basis%fila2)
    if (pr_wiberg) &
    call print_wiberg(iunit,mol%n,mol%at,wfx%wbo,0.1_wp)
 
@@ -508,7 +505,6 @@ end subroutine print_mulliken
 
 subroutine print_wiberg(iunit,n,at,wbo,thr)
    use iso_fortran_env, wp => real64
-   use scc_core, only : wibsort
    implicit none
    integer, intent(in) :: iunit
    integer, intent(in) :: n
@@ -550,6 +546,38 @@ subroutine print_wiberg(iunit,n,at,wbo,thr)
    enddo
 
    deallocate(wbr,imem)
+
+contains
+
+SUBROUTINE wibsort(ncent,imo,imem,qmo)
+   use iso_fortran_env, only : wp => real64
+   implicit none
+   integer  :: ncent
+   integer  :: imo
+   real(wp) :: qmo(ncent,ncent)
+   integer  :: imem(ncent)
+   integer  :: ii,i,j,k,ihilf
+   real(wp) :: pp
+
+   do ii = 2,ncent
+      i = ii - 1
+      k = i
+      pp= qmo(imo,i)
+      do j = ii, ncent
+         if (qmo(imo,j) .lt. pp) cycle
+         k = j
+         pp=qmo(imo,j)
+      enddo
+      if (k .eq. i) cycle
+      qmo(imo,k) = qmo(imo,i)
+      qmo(imo,i) = pp
+
+      ihilf=imem(i)
+      imem(i)=imem(k)
+      imem(k)=ihilf
+   enddo
+
+end SUBROUTINE wibsort
 
 end subroutine print_wiberg
 

--- a/xtb/peeq_module.f90
+++ b/xtb/peeq_module.f90
@@ -574,6 +574,10 @@ subroutine peeq &
 
    endif printing
 
+! ------------------------------------------------------------------------
+!  get Wiberg bond orders
+   call get_wiberg(mol%n,basis%nao,mol%at,mol%xyz,wfn%P,S,wfn%wbo,basis%fila2)
+
    sigma = sigma + sum(sigma_tmp, dim=3)
    if (debug) then
       write(iunit,'("ij",2x,6a12)') "total", "EEQ", "D4", "rep", "SRB", "H0"

--- a/xtb/scf_module.f90
+++ b/xtb/scf_module.f90
@@ -690,11 +690,6 @@ subroutine scf(iunit,mol,wfn,basis,param,pcem, &
       endif
 
 ! ------------------------------------------------------------------------
-!     get Wiberg bond orders
-      call wiberg(mol%n,basis%nao,mol%at,mol%xyz,wfn%P,S,wfn%wbo,.false.,.false., &
-         &        basis%fila2)
-
-! ------------------------------------------------------------------------
 !     HOMO-LUMO excitation properties if  UHF=2        
       if (wfn%nopen.eq.2) then
          call hlex(mol%n,mol%at,basis%nbf,basis%nao,wfn%ihomoa,mol%xyz,wfn%focc,S,wfn%C,wfn%emo,basis)
@@ -717,6 +712,10 @@ subroutine scf(iunit,mol,wfn,basis,param,pcem, &
       endif
 
    endif printing
+
+! ------------------------------------------------------------------------
+!  get Wiberg bond orders
+   call get_wiberg(mol%n,basis%nao,mol%at,mol%xyz,wfn%P,S,wfn%wbo,basis%fila2)
 
 ! ------------------------------------------------------------------------
 !  dipole calculation (always done because its free)


### PR DESCRIPTION
makes Wiberg bond order calculation finally independent from the printlevel.
Resolves 1. and 2. point of #98.