### PR TITLE
Support more file formats for input/output

### DIFF
--- a/cmake/Files.cmake
+++ b/cmake/Files.cmake
@@ -55,6 +55,7 @@ set(XTB_SOURCES
   "${XTB_ROOT}/xtb/setparam.f90"
 
   # Header and I/O
+  "${XTB_ROOT}/xtb/symbols.f90"
   "${XTB_ROOT}/xtb/readin.f90"
   "${XTB_ROOT}/xtb/filetools.f90"
   "${XTB_ROOT}/xtb/set_module.f90"

--- a/cmake/Files.cmake
+++ b/cmake/Files.cmake
@@ -56,6 +56,7 @@ set(XTB_SOURCES
 
   # Header and I/O
   "${XTB_ROOT}/xtb/symbols.f90"
+  "${XTB_ROOT}/xtb/output_writer.f90"
   "${XTB_ROOT}/xtb/readin.f90"
   "${XTB_ROOT}/xtb/filetools.f90"
   "${XTB_ROOT}/xtb/set_module.f90"

--- a/meson.build
+++ b/meson.build
@@ -180,6 +180,7 @@ xtb_srcs += 'xtb/aoparam.f90'
 xtb_srcs += 'xtb/setparam.f90'
 
 # header and I/O
+xtb_srcs += 'xtb/symbols.f90'
 xtb_srcs += 'xtb/readin.f90'
 xtb_srcs += 'xtb/filetools.f90'
 xtb_srcs += 'xtb/set_module.f90'

--- a/meson.build
+++ b/meson.build
@@ -181,6 +181,7 @@ xtb_srcs += 'xtb/setparam.f90'
 
 # header and I/O
 xtb_srcs += 'xtb/symbols.f90'
+xtb_srcs += 'xtb/output_writer.f90'
 xtb_srcs += 'xtb/readin.f90'
 xtb_srcs += 'xtb/filetools.f90'
 xtb_srcs += 'xtb/set_module.f90'

--- a/scripts/xtb-gaussian
+++ b/scripts/xtb-gaussian
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+2&>1 exec xtb $2 --grad > $4

--- a/scripts/xtb-gaussian
+++ b/scripts/xtb-gaussian
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-2&>1 exec xtb $2 --grad > $4
+2>&1 exec xtb $2 --grad > $4

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -17,7 +17,13 @@
 
 submodule(tbdef_molecule) molecule_reader
    use tbdef_molecule
+   use tbmod_symbols
    implicit none
+
+   interface assignment(=)
+      module procedure :: symbol_to_number
+      module procedure :: number_to_symbol
+   end interface assignment(=)
 
 contains
 

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -957,6 +957,7 @@ subroutine read_molecule_gaussian(mol, unit, status, iomsg)
          return
       endif
       if (iat > 0) then
+         n = n+1
          mol%at(n) = iat
          mol%sym(n) = iat
          mol%xyz(:, n) = xyz

--- a/xtb/molecule_reader.f90
+++ b/xtb/molecule_reader.f90
@@ -977,5 +977,4 @@ subroutine read_molecule_gaussian(mol, unit, status, iomsg)
 end subroutine read_molecule_gaussian
 
 
-
 end submodule molecule_reader

--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -17,7 +17,13 @@
 
 submodule(tbdef_molecule) molecule_writer
    use tbdef_molecule
+   use tbmod_symbols
    implicit none
+
+   interface assignment(=)
+      module procedure :: symbol_to_number
+      module procedure :: number_to_symbol
+   end interface assignment(=)
 
 contains
 

--- a/xtb/output_writer.f90
+++ b/xtb/output_writer.f90
@@ -1,0 +1,137 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2020 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+module tbmod_output_writer
+   use iso_fortran_env, only: wp => real64
+   implicit none
+
+contains
+
+subroutine write_turbomole(mol, unit, energy, gradient, sigma)
+   use tbdef_molecule
+   type(tb_molecule), intent(in) :: mol
+   integer, intent(in), optional :: unit
+   real(wp), intent(in), optional :: energy
+   real(wp), intent(in), optional :: gradient(:, :)
+   real(wp), intent(in), optional :: sigma(:, :)
+   integer :: ien, igr, igl
+   real(wp) :: en
+
+   if (present(unit)) then
+      ien = unit
+      igr = unit
+      igl = unit
+   else
+      if (present(energy)) then
+         call open_file(ien, "energy", "w")
+      end if
+      if (present(gradient)) then
+         call open_file(igr, "gradient", "w")
+      end if
+      if (present(sigma) .and. mol%npbc > 0) then
+         call open_file(igl, "gradlatt", "w")
+      end if
+   end if
+
+   if (present(energy)) then
+      en = energy
+      call write_turbomole_energy(ien, en)
+   else
+      en = 0.0_wp
+   end if
+
+   if (present(gradient)) then
+      call write_turbomole_gradient(igr, mol%xyz, mol%sym, en, gradient)
+   end if
+
+   if (present(sigma) .and. mol%npbc > 0) then
+      call write_turbomole_gradlatt(igl, mol%lattice, en, sigma)
+   end if
+
+   if (present(unit)) then
+      if (present(energy) .or. present(gradient) &
+         & .or. (present(sigma) .and. mol%npbc > 0)) then
+         write(unit, '("$end")')
+      end if
+   else
+      if (present(energy)) then
+         write(ien, '("$end")')
+         call close_file(ien)
+      end if
+      if (present(gradient)) then
+         write(igr, '("$end")')
+         call close_file(igr)
+      end if
+      if (present(sigma) .and. mol%npbc > 0) then
+         write(igl, '("$end")')
+         call close_file(igl)
+      end if
+   end if
+
+end subroutine write_turbomole
+
+subroutine write_turbomole_energy(unit, energy)
+   integer, intent(in) :: unit
+   real(wp), intent(in) :: energy
+   write(unit, '("$energy")')
+   write(unit, '(i6,F18.11)') 1, energy
+end subroutine write_turbomole_energy
+
+subroutine write_turbomole_gradient(unit, xyz, sym, energy, gradient)
+   integer, intent(in) :: unit
+   real(wp), intent(in) :: xyz(:, :)
+   character(len=*), intent(in) :: sym(:)
+   real(wp), intent(in) :: energy
+   real(wp), intent(in) :: gradient(:, :)
+   integer :: i
+
+   write(unit, '("$gradient")')
+   write(unit, '(2x,"cycle =",1x,i6,4x,"SCF energy =",f18.11,3x,'//&
+      &        '"|dE/dxyz| =",f10.6)') 1, energy, norm2(gradient)
+   do i = 1, size(xyz, dim=2)
+      write(unit, '(3(F20.14,2x),4x,a2)') xyz(1,i), xyz(2,i), xyz(3,i), sym(i)
+   end do
+   do i = 1, size(gradient, dim=2)
+      write(unit, '(3ES22.13)') gradient(1,i), gradient(2,i), gradient(3,i)
+   end do
+
+end subroutine write_turbomole_gradient
+
+subroutine write_turbomole_gradlatt(unit, lattice, energy, sigma)
+   use pbc_tools
+   integer, intent(in) :: unit
+   real(wp), intent(in) :: lattice(:, :)
+   real(wp), intent(in) :: energy
+   real(wp), intent(in) :: sigma(:, :)
+   real(wp) :: gradlatt(3, 3), inv_lat(3, 3)
+   integer :: i
+
+   inv_lat = mat_inv_3x3(lattice)
+   call sigma_to_latgrad(sigma, inv_lat, gradlatt)
+
+   write(unit, '("$gradlatt")')
+   write(unit, '(2x,"cycle =",1x,i6,4x,"SCF energy =",f18.11,3x,'//&
+      &        '"|dE/dlatt| =",f10.6)') 1, energy, norm2(gradlatt)
+   do i = 1, size(lattice, dim=2)
+      write(unit, '(3(F20.14,2x))') lattice(1, i), lattice(2, i), lattice(3, i)
+   end do
+   do i = 1, size(gradlatt, dim=2)
+      write(unit, '(3ES22.13)') gradlatt(1, i), gradlatt(2, i), gradlatt(3, i)
+   end do
+end subroutine write_turbomole_gradlatt
+
+end module tbmod_output_writer

--- a/xtb/output_writer.f90
+++ b/xtb/output_writer.f90
@@ -21,6 +21,27 @@ module tbmod_output_writer
 
 contains
 
+subroutine write_orca_engrad(unit, mol, energy, gradient)
+   use tbdef_molecule
+   type(tb_molecule), intent(in) :: mol
+   integer, intent(in) :: unit
+   real(wp), intent(in) :: energy
+   real(wp), intent(in) :: gradient(:, :)
+   integer :: i
+
+   write(unit, '(a)') "#", "# Number of atoms", "#"
+   write(unit, '(i10)') mol%n
+   write(unit, '(a)') "#", "# The current total energy in Eh", "#"
+   write(unit, '(f20.12)') energy
+   write(unit, '(a)') "#", "# The current gradient in Eh/bohr", "#"
+   write(unit, '(1x,f20.12)') gradient
+   write(unit, '(a)') "#", "# The atomic numbers and current coordinates in Bohr", "#"
+   do i = 1, mol%n
+      write(unit, '(1x,i3,1x,3(1x,f12.7))') mol%at(i), mol%xyz(:, i)
+   end do
+
+end subroutine write_orca_engrad
+
 subroutine write_gaussian_eou(unit, energy, dipole, gradient)
    integer, intent(in) :: unit
    real(wp), intent(in) :: energy

--- a/xtb/output_writer.f90
+++ b/xtb/output_writer.f90
@@ -21,6 +21,17 @@ module tbmod_output_writer
 
 contains
 
+subroutine write_gaussian_eou(unit, energy, dipole, gradient)
+   integer, intent(in) :: unit
+   real(wp), intent(in) :: energy
+   real(wp), intent(in) :: dipole(:)
+   real(wp), intent(in) :: gradient(:, :)
+
+   write(unit, '(4D20.12)') energy, dipole
+   write(unit, '(3D20.12)') gradient
+
+end subroutine write_gaussian_eou
+
 subroutine write_turbomole(mol, unit, energy, gradient, sigma)
    use tbdef_molecule
    type(tb_molecule), intent(in) :: mol

--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -786,6 +786,16 @@ program XTBprog
    if (lgrad) then
       call write_turbomole(mol, energy=etot, gradient=g, sigma=sigma)
    end if
+   if (mol%ftype .eq. p_ftype%gaussian) then
+      if (allocated(basename)) then
+         cdum = basename // '.EOu'
+      else
+         cdum = 'xtb-gaussian.EOu'
+      end if
+      call open_file(ich, cdum, 'w')
+      call write_gaussian_eou(ich, etot, res%dipole, g)
+      call close_file(ich)
+   end if
 
    if(periodic)then
       write(*,*)'Periodic properties'

--- a/xtb/program_main.f90
+++ b/xtb/program_main.f90
@@ -63,6 +63,7 @@ program XTBprog
    use set_module
    use property_output
    use tbmod_file_utils
+   use tbmod_output_writer
 
 !! ========================================================================
 !  get interfaces for methods used in this part
@@ -782,7 +783,9 @@ program XTBprog
    endif
 
    call generic_header(iprop,'Property Printout',49,10)
-   if (lgrad) call tmgrad(mol%n,mol%at,mol%xyz,g,etot)
+   if (lgrad) then
+      call write_turbomole(mol, energy=etot, gradient=g, sigma=sigma)
+   end if
 
    if(periodic)then
       write(*,*)'Periodic properties'

--- a/xtb/symbols.f90
+++ b/xtb/symbols.f90
@@ -1,0 +1,114 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2017-2020 Stefan Grimme
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+module tbmod_symbols
+   implicit none
+
+contains
+
+
+elemental subroutine symbol_to_number(number, symbol)
+   character(len=2), parameter :: pse(118) = [ &
+      & 'h ','he', &
+      & 'li','be','b ','c ','n ','o ','f ','ne', &
+      & 'na','mg','al','si','p ','s ','cl','ar', &
+      & 'k ','ca', &
+      & 'sc','ti','v ','cr','mn','fe','co','ni','cu','zn', &
+      &           'ga','ge','as','se','br','kr', &
+      & 'rb','sr', &
+      & 'y ','zr','nb','mo','tc','ru','rh','pd','ag','cd', &
+      &           'in','sn','sb','te','i ','xe', &
+      & 'cs','ba','la', &
+      & 'ce','pr','nd','pm','sm','eu','gd','tb','dy','ho','er','tm','yb', &
+      & 'lu','hf','ta','w ','re','os','ir','pt','au','hg', &
+      &           'tl','pb','bi','po','at','rn', &
+      & 'fr','ra','ac', &
+      & 'th','pa','u ','np','pu','am','cm','bk','cf','es','fm','md','no', &
+      & 'lr','rf','db','sg','bh','hs','mt','ds','rg','cn', &
+      &           'nh','fl','mc','lv','ts','og' ]
+   character(len=*), intent(in) :: symbol
+   integer, intent(out) :: number
+   character(len=2) :: lc_symbol
+   integer :: i, j, k, l
+   integer, parameter :: offset = iachar('a')-iachar('A')
+
+   number = 0
+   lc_symbol = '  '
+
+   k = 0
+   do j = 1, len_trim(symbol)
+      if (k > 2) exit
+      l = iachar(symbol(j:j))
+      if (k >= 1 .and. l == iachar(' ')) exit
+      if (k >= 1 .and. l == 9) exit
+      if (l >= iachar('A') .and. l <= iachar('Z')) l = l + offset
+      if (l >= iachar('a') .and. l <= iachar('z')) then
+         k = k+1
+         lc_symbol(k:k) = achar(l)
+      endif
+   enddo
+
+   do i = 1, size(pse)
+      if (lc_symbol == pse(i)) then
+         number = i
+         exit
+      endif
+   enddo
+
+end subroutine symbol_to_number
+
+elemental subroutine number_to_symbol(symbol, number)
+   integer,intent(in) :: number
+   character(len=2), intent(out) :: symbol
+   character(len=2), parameter :: pse(118) = [ &
+   & 'H ','He', &
+   & 'Li','Be','B ','C ','N ','O ','F ','Ne', &
+   & 'Na','Mg','Al','Si','P ','S ','Cl','Ar', &
+   & 'K ','Ca', &
+   & 'Sc','Ti','V ','Cr','Mn','Fe','Co','Ni','Cu','Zn', &
+   &           'Ga','Ge','As','Se','Br','Kr', &
+   & 'Rb','Sr', &
+   & 'Y ','Zr','Nb','Mo','Tc','Ru','Rh','Pd','Ag','Cd', &
+   &           'In','Sn','Sb','Te','I ','Xe', &
+   & 'Cs','Ba', &
+   & 'La','Ce','Pr','Nd','Pm','Sm','Eu','Gd','Tb','Dy','Ho','Er','Tm','Yb', &
+   & 'Lu','Hf','Ta','W ','Re','Os','Ir','Pt','Au','Hg', &
+   &           'Tl','Pb','Bi','Po','At','Rn', &
+   & 'Fr','Ra', &
+   & 'Ac','Th','Pa','U ','Np','Pu','Am','Cm','Bk','Cf','Es','Fm','Md','No', &
+   & 'Lr','Rf','Db','Sg','Bh','Hs','Mt','Ds','Rg','Cn', &
+   &           'Nh','Fl','Mc','Lv','Ts','Og' ]
+   if (number.gt.118) then
+      symbol = 'XX'
+   else
+      symbol = pse(number)
+   endif
+end subroutine number_to_symbol
+
+elemental function to_number(symbol) result(number)
+   character(len=*), intent(in) :: symbol
+   integer :: number
+   call symbol_to_number(number, symbol)
+end function to_number
+
+elemental function to_symbol(number) result(symbol)
+   integer,intent(in) :: number
+   character(len=2) :: symbol
+   call number_to_symbol(symbol, number)
+end function to_symbol
+
+end module tbmod_symbols

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -174,11 +174,6 @@ module tbdef_molecule
       module procedure :: mol_length
    end interface
 
-   interface assignment(=)
-      module procedure :: symbol_to_number
-      module procedure :: number_to_symbol
-   end interface assignment(=)
-
 
 contains
 
@@ -495,85 +490,6 @@ pure subroutine align_to_principal_axes(self,break_symmetry)
    call coord_trafo(self%n,axes,self%xyz)
 
 end subroutine align_to_principal_axes
-
-
-elemental subroutine symbol_to_number(number, symbol)
-   character(len=2), parameter :: pse(118) = [ &
-      & 'h ','he', &
-      & 'li','be','b ','c ','n ','o ','f ','ne', &
-      & 'na','mg','al','si','p ','s ','cl','ar', &
-      & 'k ','ca', &
-      & 'sc','ti','v ','cr','mn','fe','co','ni','cu','zn', &
-      &           'ga','ge','as','se','br','kr', &
-      & 'rb','sr', &
-      & 'y ','zr','nb','mo','tc','ru','rh','pd','ag','cd', &
-      &           'in','sn','sb','te','i ','xe', &
-      & 'cs','ba','la', &
-      & 'ce','pr','nd','pm','sm','eu','gd','tb','dy','ho','er','tm','yb', &
-      & 'lu','hf','ta','w ','re','os','ir','pt','au','hg', &
-      &           'tl','pb','bi','po','at','rn', &
-      & 'fr','ra','ac', &
-      & 'th','pa','u ','np','pu','am','cm','bk','cf','es','fm','md','no', &
-      & 'lr','rf','db','sg','bh','hs','mt','ds','rg','cn', &
-      &           'nh','fl','mc','lv','ts','og' ]
-   character(len=*), intent(in) :: symbol
-   integer, intent(out) :: number
-   character(len=2) :: lc_symbol
-   integer :: i, j, k, l
-   integer, parameter :: offset = iachar('a')-iachar('A')
-
-   number = 0
-   lc_symbol = '  '
-
-   k = 0
-   do j = 1, len_trim(symbol)
-      if (k > 2) exit
-      l = iachar(symbol(j:j))
-      if (k >= 1 .and. l == iachar(' ')) exit
-      if (k >= 1 .and. l == 9) exit
-      if (l >= iachar('A') .and. l <= iachar('Z')) l = l + offset
-      if (l >= iachar('a') .and. l <= iachar('z')) then
-         k = k+1
-         lc_symbol(k:k) = achar(l)
-      endif
-   enddo
-
-   do i = 1, size(pse)
-      if (lc_symbol == pse(i)) then
-         number = i
-         exit
-      endif
-   enddo
-
-end subroutine symbol_to_number
-
-elemental subroutine number_to_symbol(symbol, number)
-   integer,intent(in) :: number
-   character(len=2), intent(out) :: symbol
-   character(len=2), parameter :: pse(118) = [ &
-   & 'H ','He', &
-   & 'Li','Be','B ','C ','N ','O ','F ','Ne', &
-   & 'Na','Mg','Al','Si','P ','S ','Cl','Ar', &
-   & 'K ','Ca', &
-   & 'Sc','Ti','V ','Cr','Mn','Fe','Co','Ni','Cu','Zn', &
-   &           'Ga','Ge','As','Se','Br','Kr', &
-   & 'Rb','Sr', &
-   & 'Y ','Zr','Nb','Mo','Tc','Ru','Rh','Pd','Ag','Cd', &
-   &           'In','Sn','Sb','Te','I ','Xe', &
-   & 'Cs','Ba', &
-   & 'La','Ce','Pr','Nd','Pm','Sm','Eu','Gd','Tb','Dy','Ho','Er','Tm','Yb', &
-   & 'Lu','Hf','Ta','W ','Re','Os','Ir','Pt','Au','Hg', &
-   &           'Tl','Pb','Bi','Po','At','Rn', &
-   & 'Fr','Ra', &
-   & 'Ac','Th','Pa','U ','Np','Pu','Am','Cm','Bk','Cf','Es','Fm','Md','No', &
-   & 'Lr','Rf','Db','Sg','Bh','Hs','Mt','Ds','Rg','Cn', &
-   &           'Nh','Fl','Mc','Lv','Ts','Og' ]
-   if (number.gt.118) then
-      symbol = 'XX'
-   else
-      symbol = pse(number)
-   endif
-end subroutine number_to_symbol
 
 
 end module tbdef_molecule

--- a/xtb/tbdef_molecule.f90
+++ b/xtb/tbdef_molecule.f90
@@ -174,6 +174,11 @@ module tbdef_molecule
       module procedure :: mol_length
    end interface
 
+   interface assignment(=)
+      module procedure :: symbol_to_number
+      module procedure :: number_to_symbol
+   end interface assignment(=)
+
 
 contains
 
@@ -490,5 +495,85 @@ pure subroutine align_to_principal_axes(self,break_symmetry)
    call coord_trafo(self%n,axes,self%xyz)
 
 end subroutine align_to_principal_axes
+
+
+elemental subroutine symbol_to_number(number, symbol)
+   character(len=2), parameter :: pse(118) = [ &
+      & 'h ','he', &
+      & 'li','be','b ','c ','n ','o ','f ','ne', &
+      & 'na','mg','al','si','p ','s ','cl','ar', &
+      & 'k ','ca', &
+      & 'sc','ti','v ','cr','mn','fe','co','ni','cu','zn', &
+      &           'ga','ge','as','se','br','kr', &
+      & 'rb','sr', &
+      & 'y ','zr','nb','mo','tc','ru','rh','pd','ag','cd', &
+      &           'in','sn','sb','te','i ','xe', &
+      & 'cs','ba','la', &
+      & 'ce','pr','nd','pm','sm','eu','gd','tb','dy','ho','er','tm','yb', &
+      & 'lu','hf','ta','w ','re','os','ir','pt','au','hg', &
+      &           'tl','pb','bi','po','at','rn', &
+      & 'fr','ra','ac', &
+      & 'th','pa','u ','np','pu','am','cm','bk','cf','es','fm','md','no', &
+      & 'lr','rf','db','sg','bh','hs','mt','ds','rg','cn', &
+      &           'nh','fl','mc','lv','ts','og' ]
+   character(len=*), intent(in) :: symbol
+   integer, intent(out) :: number
+   character(len=2) :: lc_symbol
+   integer :: i, j, k, l
+   integer, parameter :: offset = iachar('a')-iachar('A')
+
+   number = 0
+   lc_symbol = '  '
+
+   k = 0
+   do j = 1, len_trim(symbol)
+      if (k > 2) exit
+      l = iachar(symbol(j:j))
+      if (k >= 1 .and. l == iachar(' ')) exit
+      if (k >= 1 .and. l == 9) exit
+      if (l >= iachar('A') .and. l <= iachar('Z')) l = l + offset
+      if (l >= iachar('a') .and. l <= iachar('z')) then
+         k = k+1
+         lc_symbol(k:k) = achar(l)
+      endif
+   enddo
+
+   do i = 1, size(pse)
+      if (lc_symbol == pse(i)) then
+         number = i
+         exit
+      endif
+   enddo
+
+end subroutine symbol_to_number
+
+elemental subroutine number_to_symbol(symbol, number)
+   integer,intent(in) :: number
+   character(len=2), intent(out) :: symbol
+   character(len=2), parameter :: pse(118) = [ &
+   & 'H ','He', &
+   & 'Li','Be','B ','C ','N ','O ','F ','Ne', &
+   & 'Na','Mg','Al','Si','P ','S ','Cl','Ar', &
+   & 'K ','Ca', &
+   & 'Sc','Ti','V ','Cr','Mn','Fe','Co','Ni','Cu','Zn', &
+   &           'Ga','Ge','As','Se','Br','Kr', &
+   & 'Rb','Sr', &
+   & 'Y ','Zr','Nb','Mo','Tc','Ru','Rh','Pd','Ag','Cd', &
+   &           'In','Sn','Sb','Te','I ','Xe', &
+   & 'Cs','Ba', &
+   & 'La','Ce','Pr','Nd','Pm','Sm','Eu','Gd','Tb','Dy','Ho','Er','Tm','Yb', &
+   & 'Lu','Hf','Ta','W ','Re','Os','Ir','Pt','Au','Hg', &
+   &           'Tl','Pb','Bi','Po','At','Rn', &
+   & 'Fr','Ra', &
+   & 'Ac','Th','Pa','U ','Np','Pu','Am','Cm','Bk','Cf','Es','Fm','Md','No', &
+   & 'Lr','Rf','Db','Sg','Bh','Hs','Mt','Ds','Rg','Cn', &
+   &           'Nh','Fl','Mc','Lv','Ts','Og' ]
+   if (number.gt.118) then
+      symbol = 'XX'
+   else
+      symbol = pse(number)
+   endif
+end subroutine number_to_symbol
+
 
 end module tbdef_molecule

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -88,6 +88,8 @@ subroutine file_generate_name(fname, basename, extension, ftype)
          fname = fname//'.pdb'
       case(p_ftype%gen)
          fname = fname//'.gen'
+      case(p_ftype%gaussian)
+         fname = fname//'.ein'
       end select
    endif
 end subroutine file_generate_name
@@ -116,6 +118,8 @@ subroutine file_figure_out_ftype(ftype, extension, basename)
          ftype = p_ftype%pdb
       case('gen')
          ftype = p_ftype%gen
+      case('ein')
+         ftype = p_ftype%gaussian
       case default
          if (len(basename) > 0) then
             select case(lowercase(basename))

--- a/xtb/tbmod_file_utils.f90
+++ b/xtb/tbmod_file_utils.f90
@@ -27,6 +27,7 @@ module tbmod_file_utils
       integer :: pdb = 5
       integer :: sdf = 6
       integer :: gen = 7
+      integer :: gaussian = 8
    end type tb_enum_molecule
    type(tb_enum_molecule), public, parameter :: p_ftype = tb_enum_molecule()
 


### PR DESCRIPTION
Allows `xtb` to read new file formats. Solves #95 on the `xtb` level.

- [x] read and write Gaussian external input files as documented [here](https://gaussian.com/external/)
  - [x] find out default file ending to activate automatic detection (@pierre-24 can I get some input?)
- [x] write Turbomole `lattgrad` file
- [x] write energy/gradient to Orca `engrad` format
- [x] write energy/gradient to Gaussian external format