### PR TITLE
Fix PDB output writer for partial charges on atom sides

### DIFF
--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -364,8 +364,10 @@ subroutine write_pdb(mol, unit, number)
 
 
       xyz = mol%xyz(:,iatom) * autoaa
-      if (mol%pdb(iatom)%charge /= 0) then
-         write(a_charge, '(i2)') mol%pdb(iatom)%charge
+      if (mol%pdb(iatom)%charge < 0) then
+         write(a_charge, '(i1,"-")') mol%pdb(iatom)%charge
+      else if (mol%pdb(iatom)%charge > 0) then
+         write(a_charge, '(i1,"+")') mol%pdb(iatom)%charge
       else
          a_charge = '  '
       endif


### PR DESCRIPTION
Order of sign and number was wrong in output PDB