### PR TITLE
Fix PDB writer to not overflow the charge record

### DIFF
--- a/xtb/molecule_writer.f90
+++ b/xtb/molecule_writer.f90
@@ -365,9 +365,9 @@ subroutine write_pdb(mol, unit, number)
 
       xyz = mol%xyz(:,iatom) * autoaa
       if (mol%pdb(iatom)%charge < 0) then
-         write(a_charge, '(i1,"-")') mol%pdb(iatom)%charge
+         write(a_charge, '(i1,"-")') abs(mol%pdb(iatom)%charge)
       else if (mol%pdb(iatom)%charge > 0) then
-         write(a_charge, '(i1,"+")') mol%pdb(iatom)%charge
+         write(a_charge, '(i1,"+")') abs(mol%pdb(iatom)%charge)
       else
          a_charge = '  '
       endif


### PR DESCRIPTION
Fix overflow introduced in #124 for negative charges.