### PR TITLE
Change configuration of version number with commit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -27,11 +27,13 @@ project(
   ],
 )
 
-git_commit = run_command(find_program('git'),'show','-s','--format=%h')
-if git_commit.returncode() == 0
-  commit = git_commit.stdout().strip()
-else
-  commit = get_option('build_name')
+commit = get_option('build_name')
+git = find_program('git', required: false)
+if git.found()
+  git_commit = run_command(git, 'show', '-s', '--format=%h')
+  if git_commit.returncode() == 0
+    commit = git_commit.stdout().strip()
+  endif
 endif
 
 # build a configuration data containing all the important data to propagate

--- a/meson.build
+++ b/meson.build
@@ -27,13 +27,20 @@ project(
   ],
 )
 
+git_commit = run_command(find_program('git'),'show','-s','--format=%h')
+if git_commit.returncode() == 0
+  commit = git_commit.stdout().strip()
+else
+  commit = get_option('build_name')
+endif
+
 # build a configuration data containing all the important data to propagate
 # it to the automatically generated files
 config = configuration_data({
   'name': meson.project_name(),
   'description': 'Semiempirical Extended Tight-Binding Program Package',
   'version': meson.project_version(),
-  'commit': run_command(find_program('git'),'show','-s','--format=%h').stdout().strip(),
+  'commit': commit,
   'date': run_command(find_program('date'),'-I').stdout().strip(),
   'author': run_command(find_program('whoami')).stdout().strip(),
   'origin': run_command(find_program('hostname')).stdout().strip(),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,3 +28,5 @@ option('static', type: 'boolean', value: true,
        description: 'Produce statically linked executables.')
 option('python', type: 'boolean', value: true,
        description: 'Enable the python wrapper.')
+option('build_name', type: 'string', value: 'unknown',
+       description: 'Name of the build, will be overwritten automatically by git')


### PR DESCRIPTION
Rescue build configuration if build is not in a git repo, i.e. downloaded as archive. `-Dbuild_name` option can be used to override the default value in case of specific recognizable builds like AUR, conda and so on.