### PR TITLE
Introduce chemical identity

### DIFF
--- a/cmake/Files.cmake
+++ b/cmake/Files.cmake
@@ -55,6 +55,7 @@ set(XTB_SOURCES
   "${XTB_ROOT}/src/type/environment.f90"
   "${XTB_ROOT}/src/type/vendordata.f90"
   "${XTB_ROOT}/src/type/reader.f90"
+  "${XTB_ROOT}/src/type/identitymap.f90"
   "${XTB_ROOT}/src/type/buffer.f90"
 
   # Global data

--- a/src/constrain_param.f90
+++ b/src/constrain_param.f90
@@ -55,11 +55,11 @@
 !! ========================================================================
 module xtb_constrain_param
    use xtb_mctc_accuracy, only : wp
-
    use xtb_mctc_strings, only : parse
    use xtb_readin, only : getline => strip_line,getValue,getListValue
    use xtb_setparam, only : verbose
    use xtb_type_environment, only : TEnvironment
+   use xtb_type_identitymap, only : TIdentityMap, init
    use xtb_type_molecule, only : TMolecule
 
    implicit none
@@ -86,12 +86,13 @@ module xtb_constrain_param
    public
 
    abstract interface
-      subroutine handlerInterface(env,key,val,nat,at,xyz)
-         import :: wp, TEnvironment
+      subroutine handlerInterface(env,key,val,nat,at,idMap,xyz)
+         import :: wp, TEnvironment, TIdentityMap
          type(TEnvironment), intent(inout) :: env
          character(len=*),intent(in) :: key
          character(len=*),intent(in) :: val
          integer, intent(in) :: nat
+         type(TIdentityMap), intent(in) :: idMap
          integer, intent(in) :: at(nat)
          real(wp),intent(in) :: xyz(3,nat)
       end subroutine handlerInterface
@@ -111,6 +112,7 @@ subroutine read_userdata(fname,env,mol)
    character(len=:),allocatable :: key
    character(len=:),allocatable :: val
    character(len=:),allocatable :: newname
+   type(TIdentityMap) :: idMap
    integer :: i
    integer :: id
    integer :: ic
@@ -131,6 +133,10 @@ subroutine read_userdata(fname,env,mol)
    endif
    rewind(id) ! not sure if this is necessary
 
+   call init(idMap, mol)
+
+   call idMap%writeInfo(env%unit)
+
 !  read first line before the readloop starts, I have to do this
 !  to avoid using backspace on id (dammit Turbomole format)
    call getline(id,line,err)
@@ -140,36 +146,36 @@ subroutine read_userdata(fname,env,mol)
          select case(line(2:))
          case('fix'      )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_fix,    line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_fix,    line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('split'    )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_split,  line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_split,  line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('constrain')
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
             if (allocated(potset%xyz)) then
-               call rdblock(env,set_constr, line,id,mol%n,mol%at,potset%xyz,err)
+               call rdblock(env,set_constr, line,id,mol%n,mol%at,idMap,potset%xyz,err)
             else
-               call rdblock(env,set_constr, line,id,mol%n,mol%at,mol%xyz,err)
+               call rdblock(env,set_constr, line,id,mol%n,mol%at,idMap,mol%xyz,err)
             endif
          case('scan'     )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_scan,   line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_scan,   line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('wall'     )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_wall,   line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_wall,   line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('metadyn'  )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_metadyn,line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_metadyn,line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('hess'     )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_hess,   line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_hess,   line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('path'     )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_path,   line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_path,   line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case('reactor'  )
             if (verbose) write(env%unit,'(">",1x,a)') line(2:)
-            call rdblock(env,set_reactor,line,id,mol%n,mol%at,mol%xyz,err)
-         case('set'      ); call rdsetbl(env,set_legacy,line,id,mol%n,mol%at,mol%xyz,err)
+            call rdblock(env,set_reactor,line,id,mol%n,mol%at,idMap,mol%xyz,err)
+         case('set'      ); call rdsetbl(env,set_legacy,line,id,mol%n,mol%at,idMap,mol%xyz,err)
          case default ! unknown keyword -> ignore, we don't raise them
             call getline(id,line,err)
          end select
@@ -185,7 +191,7 @@ subroutine read_userdata(fname,env,mol)
    call close_file(id)
 end subroutine read_userdata
 
-subroutine rdsetbl(env,handler,line,id,nat,at,xyz,err)
+subroutine rdsetbl(env,handler,line,id,nat,at,idMap,xyz,err)
    implicit none
    character(len=*), parameter :: source = 'userdata_rdsetbl'
    type(TEnvironment), intent(inout) :: env
@@ -193,6 +199,7 @@ subroutine rdsetbl(env,handler,line,id,nat,at,xyz,err)
    procedure(handlerInterface) :: handler
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
    integer,intent(out) :: err
    character(len=:),allocatable,intent(out) :: line
@@ -211,7 +218,7 @@ subroutine rdsetbl(env,handler,line,id,nat,at,xyz,err)
       if ((line.eq.'').or.(ie.eq.0)) cycle
       key = trim(line(:ie-1))
       val = trim(adjustl(line(ie+1:)))
-      call handler(env,key,val,nat,at,xyz)
+      call handler(env,key,val,nat,at,idMap,xyz)
       call env%check(exitRun)
       if (exitRun) then
          call env%error("handler could not process input", source)
@@ -221,7 +228,7 @@ subroutine rdsetbl(env,handler,line,id,nat,at,xyz,err)
 
 end subroutine rdsetbl
 
-subroutine rdblock(env,handler,line,id,nat,at,xyz,err)
+subroutine rdblock(env,handler,line,id,nat,at,idMap,xyz,err)
    implicit none
    character(len=*), parameter :: source = 'userdata_rdblock'
    type(TEnvironment), intent(inout) :: env
@@ -229,6 +236,7 @@ subroutine rdblock(env,handler,line,id,nat,at,xyz,err)
    procedure(handlerInterface) :: handler
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
    integer,intent(out) :: err
    character(len=:),allocatable,intent(out) :: line
@@ -247,7 +255,7 @@ subroutine rdblock(env,handler,line,id,nat,at,xyz,err)
       if ((line.eq.'').or.(ie.eq.0)) cycle
       key = trim(line(:ie-1))
       val = trim(adjustl(line(ie+1:)))
-      call handler(env,key,val,nat,at,xyz)
+      call handler(env,key,val,nat,at,idMap,xyz)
       call env%check(exitRun)
       if (exitRun) then
          call env%error("handler could not process input", source)
@@ -257,7 +265,7 @@ subroutine rdblock(env,handler,line,id,nat,at,xyz,err)
 
 end subroutine rdblock
 
-subroutine set_fix(env,key,val,nat,at,xyz)
+subroutine set_fix(env,key,val,nat,at,idMap,xyz)
    use xtb_type_atomlist
    use xtb_fixparam
    use xtb_setparam
@@ -268,6 +276,7 @@ subroutine set_fix(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    type(TAtomList) :: atl
@@ -364,7 +373,7 @@ subroutine set_fix(env,key,val,nat,at,xyz)
 
 end subroutine set_fix
 
-subroutine set_constr(env,key,val,nat,at,xyz)
+subroutine set_constr(env,key,val,nat,at,idMap,xyz)
    use xtb_mctc_constants
    use xtb_mctc_convert
    use xtb_type_atomlist
@@ -377,6 +386,7 @@ subroutine set_constr(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    type(TAtomList) :: atl
@@ -756,7 +766,7 @@ end subroutine set_constr
 
 !! --------------------------------------------------------------[SAW1809]-
 !  this is the new version of the scan routine exploiting all features
-subroutine set_scan(env,key,val,nat,at,xyz)
+subroutine set_scan(env,key,val,nat,at,idMap,xyz)
    use xtb_scanparam
    use xtb_mctc_convert, only : aatoau
    use xtb_mctc_constants, only : pi
@@ -767,6 +777,7 @@ subroutine set_scan(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    integer  :: idum
@@ -785,7 +796,7 @@ subroutine set_scan(env,key,val,nat,at,xyz)
    if (ie.ne.0) then
       temp = val(:ie-1)
       idum = nconstr
-      call set_constr(env,key,temp,nat,at,xyz) ! generate a new constraint
+      call set_constr(env,key,temp,nat,at,idMap,xyz) ! generate a new constraint
       scan_list(nscan)%iconstr = nconstr ! new generated
       if (idum.eq.nconstr) then
          call env%error('Failed to generate constraint',source)
@@ -860,7 +871,7 @@ subroutine set_scan(env,key,val,nat,at,xyz)
 
 end subroutine set_scan
 
-subroutine set_wall(env,key,val,nat,at,xyz)
+subroutine set_wall(env,key,val,nat,at,idMap,xyz)
    use xtb_mctc_convert, only : autoaa
    use xtb_sphereparam
    implicit none
@@ -870,6 +881,7 @@ subroutine set_wall(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    integer  :: idum
@@ -997,7 +1009,7 @@ subroutine set_wall(env,key,val,nat,at,xyz)
 
 end subroutine set_wall
 
-subroutine set_split(env,key,val,nat,at,xyz)
+subroutine set_split(env,key,val,nat,at,idMap,xyz)
    use xtb_splitparam
    implicit none
    character(len=*), parameter :: source = 'userdata_split'
@@ -1006,6 +1018,7 @@ subroutine set_split(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    integer  :: idum
@@ -1074,7 +1087,7 @@ subroutine set_split(env,key,val,nat,at,xyz)
    end select
 end subroutine set_split
 
-subroutine set_hess(env,key,val,nat,at,xyz)
+subroutine set_hess(env,key,val,nat,at,idMap,xyz)
    use xtb_splitparam
    implicit none
    character(len=*), parameter :: source = 'userdata_hess'
@@ -1083,6 +1096,7 @@ subroutine set_hess(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    integer  :: idum
@@ -1152,7 +1166,7 @@ subroutine set_hess(env,key,val,nat,at,xyz)
 
 end subroutine set_hess
 
-subroutine set_reactor(env,key,val,nat,at,xyz)
+subroutine set_reactor(env,key,val,nat,at,idMap,xyz)
    use xtb_type_atomlist
    use xtb_setparam
    implicit none
@@ -1162,6 +1176,7 @@ subroutine set_reactor(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    type(TAtomList) :: atl
@@ -1198,7 +1213,7 @@ subroutine set_reactor(env,key,val,nat,at,xyz)
 
 end subroutine set_reactor
 
-subroutine set_path(env,key,val,nat,at,xyz)
+subroutine set_path(env,key,val,nat,at,idMap,xyz)
    use xtb_type_atomlist
    use xtb_setparam
    implicit none
@@ -1208,6 +1223,7 @@ subroutine set_path(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    type(TAtomList) :: atl
@@ -1244,7 +1260,7 @@ subroutine set_path(env,key,val,nat,at,xyz)
 
 end subroutine set_path
 
-subroutine set_metadyn(env,key,val,nat,at,xyz)
+subroutine set_metadyn(env,key,val,nat,at,idMap,xyz)
    use xtb_type_atomlist
    use xtb_fixparam
    implicit none
@@ -1254,6 +1270,7 @@ subroutine set_metadyn(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    type(TAtomList) :: atl
@@ -1320,7 +1337,7 @@ subroutine set_metadyn(env,key,val,nat,at,xyz)
 
 end subroutine set_metadyn
 
-subroutine set_freeze(env,key,val,nat,at,xyz)
+subroutine set_freeze(env,key,val,nat,at,idMap,xyz)
    implicit none
    character(len=*), parameter :: source = 'userdata_freeze'
    type(TEnvironment), intent(inout) :: env
@@ -1328,6 +1345,7 @@ subroutine set_freeze(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
 
    integer  :: idum
@@ -1353,7 +1371,7 @@ subroutine set_freeze(env,key,val,nat,at,xyz)
 
 end subroutine set_freeze
 
-subroutine set_legacy(env,key,val,nat,at,xyz)
+subroutine set_legacy(env,key,val,nat,at,idMap,xyz)
    implicit none
    character(len=*), parameter :: source = 'userdata_legacy'
    type(TEnvironment), intent(inout) :: env
@@ -1361,6 +1379,7 @@ subroutine set_legacy(env,key,val,nat,at,xyz)
    character(len=*),intent(in) :: val
    integer, intent(in) :: nat
    integer, intent(in) :: at(nat)
+   type(TIdentityMap), intent(in) :: idMap
    real(wp),intent(in) :: xyz(3,nat)
    integer  :: err
    integer  :: idum
@@ -1369,18 +1388,18 @@ subroutine set_legacy(env,key,val,nat,at,xyz)
    select case(key)
    case default ! complaining about unknown keywords should already be done
       continue  ! so we do nothing here
-   case('hessf');       call set_fix(env,'freeze',val,nat,at,xyz)
+   case('hessf');       call set_fix(env,'freeze',val,nat,at,idMap,xyz)
 !   case('hessa');       call set_frozh('hessa',val)
-   case('fragment1'); call set_split(env,'fragment1',val,nat,at,xyz)
-   case('fragment2'); call set_split(env,'fragment1',val,nat,at,xyz)
-   case('constrxyz'); call set_fix(env,'atoms',val,nat,at,xyz)
+   case('fragment1'); call set_split(env,'fragment1',val,nat,at,idMap,xyz)
+   case('fragment2'); call set_split(env,'fragment1',val,nat,at,idMap,xyz)
+   case('constrxyz'); call set_fix(env,'atoms',val,nat,at,idMap,xyz)
 !   case('constrainel')
 !   case('constrain')
 !   case('scan')
-   case('ellips'); call set_wall(env,'ellipsoid',val,nat,at,xyz)
-   case('sphere'); call set_wall(env,'sphere',val,nat,at,xyz)
-   case('fix'); call set_fix(env,'atoms',val,nat,at,xyz)
-   case('atomlist+'); call set_metadyn(env,'atoms',val,nat,at,xyz)
+   case('ellips'); call set_wall(env,'ellipsoid',val,nat,at,idMap,xyz)
+   case('sphere'); call set_wall(env,'sphere',val,nat,at,idMap,xyz)
+   case('fix'); call set_fix(env,'atoms',val,nat,at,idMap,xyz)
+   case('atomlist+'); call set_metadyn(env,'atoms',val,nat,at,idMap,xyz)
    end select
 
 end subroutine set_legacy

--- a/src/mctc/symbols.f90
+++ b/src/mctc/symbols.f90
@@ -23,8 +23,14 @@ module xtb_mctc_symbols
 
    public :: symbolLength
    public :: symbolToNumber, numberToSymbol, numberToLcSymbol
-   public :: toNumber, toSymbol, toLcSymbol
-   public :: findSymbol, findNumber, appendSymbol, appendNumber
+   public :: toNumber, toSymbol, toLcSymbol, getIdentity
+
+
+   !> Get chemical identity
+   interface getIdentity
+      module procedure :: getIdentityNumber
+      module procedure :: getIdentitySymbol
+   end interface getIdentity
 
 
    !> Maximum allowed length of element symbols
@@ -201,6 +207,66 @@ elemental function toLcSymbol(number) result(symbol)
    call numberToLcSymbol(symbol, number)
 
 end function toLcSymbol
+
+
+!> Get chemical identity from a list of atomic numbers
+subroutine getIdentityNumber(nId, identity, number)
+
+   !> Number of unique species
+   integer, intent(out) :: nId
+
+   !> Ordinal numbers
+   integer, intent(in) :: number(:)
+
+   !> Chemical identity
+   integer, intent(out) :: identity(:)
+
+   integer, allocatable :: iTmp(:)
+   integer :: nAt, iAt, iId
+
+   nAt = size(identity)
+   allocate(iTmp(nAt))
+   nId = 0
+   do iAt = 1, nAt
+      iId = findNumber(iTmp(:nId), number(iAt))
+      if (iId == 0) then
+         call appendNumber(iTmp, nId, number(iAt))
+         iId = nId
+      end if
+      identity(iAt) = iId
+   end do
+
+end subroutine getIdentityNumber
+
+
+!> Get chemical identity from a list of element symbols
+subroutine getIdentitySymbol(nId, identity, symbol)
+
+   !> Number of unique species
+   integer, intent(out) :: nId
+
+   !> Element symbols
+   character(len=symbolLength), intent(in) :: symbol(:)
+
+   !> Chemical identity
+   integer, intent(out) :: identity(:)
+
+   character(len=symbolLength), allocatable :: sTmp(:)
+   integer :: nAt, iAt, iId
+
+   nAt = size(identity)
+   allocate(sTmp(nAt))
+   nId = 0
+   do iAt = 1, nAt
+      iId = findSymbol(sTmp(:nId), symbol(iAt))
+      if (iId == 0) then
+         call appendSymbol(sTmp, nId, symbol(iAt))
+         iId = nId
+      end if
+      identity(iAt) = iId
+   end do
+
+end subroutine getIdentitySymbol
 
 
 !> Find element symbol in an unordered list, all entries are required to be unique

--- a/src/type/identitymap.f90
+++ b/src/type/identitymap.f90
@@ -1,0 +1,406 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2019-2020 Sebastian Ehlert
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+!> Implementation of a map from element symbols/atomic numbers to ids
+module xtb_type_identitymap
+   use xtb_mctc_accuracy, only : wp
+   use xtb_mctc_resize, only : resize
+   use xtb_mctc_symbols, only : symbolLength
+   use xtb_type_molecule, only : TMolecule
+   implicit none
+   private
+
+   public :: TIdentityMap, init
+
+
+   !> Maps an identity to all its atoms
+   type :: TAtomicMap
+
+      !> Positions in the atomic array
+      integer, allocatable :: pos(:)
+
+   end type TAtomicMap
+
+
+   !> Map from element symbols to identity
+   type :: TIdentityMap
+      private
+
+      !> Atomic numbers for each id
+      integer, allocatable :: num(:)
+
+      !> Element symbols for each id
+      character(len=symbolLength), allocatable :: sym(:)
+
+      !> Maps from id to its atoms
+      type(TAtomicMap), allocatable :: map(:)
+
+   contains
+
+      !> Write informative printout for the map
+      procedure :: writeInfo
+
+      !> Check if symbol or number maps to atoms
+      generic :: has => hasSymbol, hasNumber
+
+      !> Check if element symbol maps to atoms
+      procedure, private :: hasSymbol
+
+      !> Check if atomic number maps to atoms
+      procedure, private :: hasNumber
+
+      !> Get indices
+      generic :: get => getSymbol, getNumber
+
+      !> Get indices for an unique element symbol
+      procedure, private :: getSymbol
+
+      !> Get indices for a certain atomic number
+      procedure, private :: getNumber
+
+      !> Setter functions in atomic arrays
+      generic :: set => setRealWithSymbol, setRealWithNumber
+
+      !> Set value in an array using an unique element symbol
+      procedure, private :: setRealWithSymbol
+
+      !> Set value in an array using the atomic number
+      procedure, private :: setRealWithNumber
+
+   end type TIdentityMap
+
+
+   !> Initialize identity map
+   interface init
+      module procedure :: initIdentityMapFromMolecule
+      module procedure :: initIdentityMapFromArrays
+   end interface init
+
+
+contains
+
+
+!> Initialize identity map from molecular structure data
+subroutine initIdentityMapFromMolecule(self, mol)
+
+   !> Instance of the map
+   type(TIdentityMap), intent(out) :: self
+
+   !> Molecular structure data
+   type(TMolecule), intent(in) :: mol
+
+   call init(self, mol%id, mol%sym, mol%at)
+
+end subroutine initIdentityMapFromMolecule
+
+
+!> Initialize identity map from at atomic numbers and element symbols
+subroutine initIdentityMapFromArrays(self, id, sym, num)
+
+   !> Instance of the map
+   type(TIdentityMap), intent(out) :: self
+
+   !> Atomic numbers for each id
+   integer, intent(in) :: id(:)
+
+   !> Atomic numbers for each atom
+   integer, intent(in) :: num(:)
+
+   !> Element symbols for each atom
+   character(len=symbolLength), intent(in) :: sym(:)
+
+   integer :: nAt, nId
+   integer :: iId, iAt, thisAt, initialSize, nMp
+   integer, allocatable :: pos(:)
+
+   nAt = size(id)
+   nId = maxval(id)
+
+   allocate(self%map(nId))
+   allocate(self%num(nId))
+   allocate(self%sym(nId))
+
+   initialSize = nAt / nId + 1
+   allocate(pos(initialSize))
+
+   do iId = 1, nId
+      pos = 0
+      nMp = 0
+      thisAt = 0
+      do iAt = 1, nAt
+         if (id(iAt) == iId) then
+            if (thisAt == 0) thisAt = iAt
+            if (nMp >= size(pos)) then
+               call resize(pos)
+            end if
+            nMp = nMp + 1
+            pos(nMp) = iAt
+         end if
+      end do
+      self%num(iId) = num(thisAt)
+      self%sym(iId) = sym(thisAt)
+      allocate(self%map(iId)%pos(nMp))
+      self%map(iId)%pos(:) = pos(:nMp)
+   end do
+
+end subroutine initIdentityMapFromArrays
+
+
+subroutine writeInfo(self, unit)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Unit for I/O
+   integer, intent(in) :: unit
+
+   integer :: iId, iStart, iEnd, iDel
+   character(len=:), allocatable :: list
+
+   write(unit, '(a5,1x,a4,1x,a4,3x,a5)') "ID", "Z", "sym.", "atoms"
+   do iId = 1, size(self%sym)
+      write(unit, '(i5,1x,i4,1x,a4,3x)', advance='no') &
+         & iId, self%num(iId), self%sym(iId)
+      call serializeAtomicMap(self%map(iId)%pos, list, '-', ', ')
+      iStart = 1
+      iEnd = min(60, len(list))
+      do while(iStart < len(list))
+         if (iEnd >= len(list)) then
+            iDel = iEnd
+         else
+            iDel = index(list(iStart:iEnd), ' ', back=.true.) + iStart - 2
+            if (iDel < iStart) then
+               iDel = index(list(iEnd:), ' ') + iEnd - 2
+            end if
+         end if
+         write(unit, '(a)') list(iStart:iDel)
+         iStart = iDel+1
+         iEnd = min(iStart+60, len(list))
+         if (iStart < len(list)) then
+            write(unit, '(17x)', advance='no')
+         end if
+      end do
+   end do
+
+end subroutine writeInfo
+
+
+subroutine serializeAtomicMap(list, string, separator, delimiter)
+
+   !> Instance of an atomic map
+   integer, intent(in) :: list(:)
+
+   !> Serialized form of the atomic map
+   character(len=:), allocatable, intent(out) :: string
+
+   !> Separator for list
+   character(len=*), intent(in), optional :: separator
+
+   !> Separator for list
+   character(len=*), intent(in), optional :: delimiter
+
+   integer :: ii, jj, kk
+   character(len=64) :: buffer
+   character(len=:), allocatable :: sep, del
+
+   if (present(separator)) then
+      sep = separator
+   else
+      sep = ', '
+   end if
+
+   if (present(delimiter)) then
+      del = delimiter
+   else
+      del = '-'
+   end if
+
+   string = ''
+   jj = list(1)
+   kk = jj
+   do ii = 2, size(list)
+      if (jj+1 == list(ii)) then
+         jj = jj+1
+      else
+         if (jj-kk == 0) then
+            write(buffer, '(i0)') jj
+         else if (jj-kk == 1) then
+            write(buffer, '(i0,a,i0)') kk, del, jj
+         else
+            write(buffer, '(i0,a,i0)') kk, sep, jj
+         end if
+         string = string // trim(buffer) // del
+         jj = list(ii)
+         kk = jj
+      end if
+   end do
+   if (jj-kk == 0) then
+      write(buffer, '(i0)') jj
+   else if (jj-kk == 1) then
+      write(buffer, '(i0,a,i0)') kk, del, jj
+   else
+      write(buffer, '(i0,a,i0)') kk, sep, jj
+   end if
+   string = string // trim(buffer)
+
+end subroutine serializeAtomicMap
+
+
+!> Check if element symbol maps to atoms
+pure function hasSymbol(self, sym) result(exist)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Element symbol
+   character(len=*), intent(in) :: sym
+
+   !> Symbol is present
+   logical :: exist
+
+   exist = any(self%sym == sym)
+
+end function hasSymbol
+
+
+!> Check if atomic number maps to atoms
+pure function hasNumber(self, num) result(exist)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Atomic number
+   integer, intent(in) :: num
+
+   !> Number is present
+   logical :: exist
+
+   exist = any(self%num == num)
+
+end function hasNumber
+
+
+!> Get indices for an unique element symbol
+subroutine getSymbol(self, indx, sym)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Indices for all selected atoms
+   integer, allocatable, intent(out) :: indx(:)
+
+   !> Element symbol
+   character(len=*), intent(in) :: sym
+
+   integer :: iId
+
+   do iId = 1, size(self%sym)
+      if (self%sym(iId) == sym) then
+         indx = self%map(iId)%pos
+         exit
+      end if
+   end do
+
+end subroutine getSymbol
+
+
+!> Get indices for a certain atomic number
+subroutine getNumber(self, indx, num)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Indices for all selected atoms
+   integer, allocatable, intent(out) :: indx(:)
+
+   !> Atomic number
+   integer, intent(in) :: num
+
+   integer :: nAt, iId, newSize
+   integer, allocatable :: pos(:)
+
+   nAt = 0
+   do iId = 1, size(self%num)
+      if (self%num(iId) == num) then
+         newSize = nAt + size(self%map(iId)%pos)
+         if (newSize >= size(pos)) then
+            call resize(pos, newSize)
+         end if
+         pos(nAt+1:newSize) = self%map(iId)%pos
+      end if
+   end do
+
+   if (nAt > 0) then
+      call move_alloc(pos, indx)
+   end if
+
+end subroutine getNumber
+
+
+!> Set value in an array using an unique element symbol
+subroutine setRealWithSymbol(self, array, sym, val)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Instance of the array
+   real(wp), intent(inout) :: array(:)
+
+   !> Element symbol
+   character(len=*), intent(in) :: sym
+
+   !> Value to set
+   real(wp), intent(in) :: val
+
+   integer :: iId
+
+   do iId = 1, size(self%sym)
+      if (self%sym(iId) == sym) then
+         array(self%map(iId)%pos) = val
+      end if
+   end do
+
+end subroutine setRealWithSymbol
+
+
+!> Set value in an array using the atomic number
+subroutine setRealWithNumber(self, array, num, val)
+
+   !> Instance of the map
+   class(TIdentityMap), intent(in) :: self
+
+   !> Instance of the array
+   real(wp), intent(inout) :: array(:)
+
+   !> Atomic number
+   integer, intent(in) :: num
+
+   !> Value to set
+   real(wp), intent(in) :: val
+
+   integer :: iId
+
+   do iId = 1, size(self%num)
+      if (self%num(iId) == num) then
+         array(self%map(iId)%pos) = val
+      end if
+   end do
+
+end subroutine setRealWithNumber
+
+
+end module xtb_type_identitymap

--- a/src/type/identitymap.f90
+++ b/src/type/identitymap.f90
@@ -64,13 +64,13 @@ module xtb_type_identitymap
       procedure, private :: hasNumber
 
       !> Get indices
-      generic :: get => getSymbol, getNumber
+      generic :: get => getIndexSymbol, getIndexNumber
 
       !> Get indices for an unique element symbol
-      procedure, private :: getSymbol
+      procedure, private :: getIndexSymbol
 
       !> Get indices for a certain atomic number
-      procedure, private :: getNumber
+      procedure, private :: getIndexNumber
 
       !> Setter functions in atomic arrays
       generic :: set => setRealWithSymbol, setRealWithNumber
@@ -178,13 +178,14 @@ subroutine writeInfo(self, unit)
       call serializeAtomicMap(self%map(iId)%pos, list, '-', ', ')
       iStart = 1
       iEnd = min(60, len(list))
-      do while(iStart < len(list))
+      do while(iStart <= len(list))
          if (iEnd >= len(list)) then
             iDel = iEnd
          else
             iDel = index(list(iStart:iEnd), ' ', back=.true.) + iStart - 2
             if (iDel < iStart) then
                iDel = index(list(iEnd:), ' ') + iEnd - 2
+               if (iDel == iEnd - 2) iDel = len(list)
             end if
          end if
          write(unit, '(a)') list(iStart:iDel)
@@ -295,7 +296,7 @@ end function hasNumber
 
 
 !> Get indices for an unique element symbol
-subroutine getSymbol(self, indx, sym)
+subroutine getIndexSymbol(self, indx, sym)
 
    !> Instance of the map
    class(TIdentityMap), intent(in) :: self
@@ -315,11 +316,11 @@ subroutine getSymbol(self, indx, sym)
       end if
    end do
 
-end subroutine getSymbol
+end subroutine getIndexSymbol
 
 
 !> Get indices for a certain atomic number
-subroutine getNumber(self, indx, num)
+subroutine getIndexNumber(self, indx, num)
 
    !> Instance of the map
    class(TIdentityMap), intent(in) :: self
@@ -348,7 +349,7 @@ subroutine getNumber(self, indx, num)
       call move_alloc(pos, indx)
    end if
 
-end subroutine getNumber
+end subroutine getIndexNumber
 
 
 !> Set value in an array using an unique element symbol

--- a/src/type/meson.build
+++ b/src/type/meson.build
@@ -25,6 +25,7 @@ srcs += files(
   'dispersion_model.f90',
   'environment.f90',
   'fragments.f90',
+  'identitymap.f90',
   'molecule.f90',
   'options.f90',
   'param.f90',


### PR DESCRIPTION
This PR introduces an unique id for each species in the molecular structure. This enables:

1. storing element specific data in a dense way

2. convenient setting of values for whole groups of atoms with the same id

With the definition here the identity is defined by unique element symbols, so the user can produce additional identities by using slightly mangled symbols, *i.e.* `C`, `c` and `C_` are different species in w.r.t. the id, but all map to the atomic number 6. All internal initialization will use the atomic number, but user initialization can make use of the id by specifying the respective symbol.