### PR TITLE
Update GitHub actions/checkout to v2

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -5,7 +5,7 @@ jobs:
   osx-build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'


### PR DESCRIPTION
Should fix the increasingly encountered CI errors with GitHub actions. This PR will not revert the migration to Travis-CI for the Ubuntu build.

See https://github.com/actions/checkout/issues/23 for details.