### PR TITLE
Allow strict mode for new environment

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name="xtb",
-      version="6.2.2",
+      version="6.2.3",
       author="Sebastian Ehlert",
       author_email="ehlert@thch.uni-bonn.de",
       description="Wrapper for the extended tight binding program",

--- a/src/prog/main.f90
+++ b/src/prog/main.f90
@@ -404,6 +404,7 @@ program XTBprog
 
 !  You had it coming!
    if (strict) call mctc_strict
+   env%strict = strict
 
    call check_cold_fusion(mol)
 

--- a/src/type/environment.f90
+++ b/src/type/environment.f90
@@ -44,6 +44,9 @@ module xtb_type_environment
 
       !> Message log
       type(TMessage), allocatable :: log(:)
+      
+      !> Handle warnings as errors
+      logical :: strict
 
       !> Actual executable name
       character(len=:),allocatable :: whoami
@@ -106,10 +109,13 @@ contains
 
 
 !> Construct the calculation environment
-subroutine initEnvironment(self)
+subroutine initEnvironment(self, strict)
 
    !> Calculation environment
    type(TEnvironment), intent(out) :: self
+   
+   !> Handle warnings as errors
+   logical, intent(in), optional :: strict
 
    integer :: err
 
@@ -128,6 +134,12 @@ subroutine initEnvironment(self)
    call rdvar('XTBPATH', self%xtbpath, err)
    if (err /= 0 .or. len(self%xtbpath) <= 0) then
       self%xtbpath = self%xtbhome
+   end if
+   
+   if (present(strict)) then
+      self%strict = strict
+   else
+      self%strict = .false.
    end if
 
 end subroutine initEnvironment
@@ -274,9 +286,9 @@ subroutine warning(self, message, source)
 
    self%nLog = self%nLog + 1
    if (present(source)) then
-      self%log(self%nLog) = TMessage(.false., source // ": " // message)
+      self%log(self%nLog) = TMessage(self%strict, source // ": " // message)
    else
-      self%log(self%nLog) = TMessage(.false., message)
+      self%log(self%nLog) = TMessage(self%strict, message)
    end if
 
 end subroutine warning


### PR DESCRIPTION
This PR enables the strict mode (`--strict`) for the new error handling environment.

In case a warning occurs it is raised as error, but the environment will only return at the next higher level or a checkpoint.