### PR TITLE
Fix Orca 4.2.1 incompatible energy printout

### DIFF
--- a/scripts/otool_xtb
+++ b/scripts/otool_xtb
@@ -5,5 +5,5 @@ namespace=$(printf '%s\n' "${args[@]}" | awk 'namespace {print $0; namespace=0};
 if [ -f "$namespace.energy" ]
 then
    energy=$(cat "$namespace.energy")
-   echo "$energy" | awk 'BEGIN {print "$energy"}; END {print "$end"}; NF == 2 {print $1, $2, $2, $2}; $NF == 4 {print $0}' > "$namespace.energy"
+   echo "$energy" | awk 'BEGIN {print "$energy"}; END {print "$end"}; NF == 2 {print $1, $2, $2, $2}; NF == 4 {print $0}' > "$namespace.energy"
 fi

--- a/scripts/otool_xtb
+++ b/scripts/otool_xtb
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+args=("$@")
+namespace=$(printf '%s\n' "${args[@]}" | awk 'namespace {print $0; namespace=0}; /--namespace/ {namespace=1}')
+./build_refactor/xtb "$@"
+if [ -f "$namespace.energy" ]
+then
+   energy=$(cat "$namespace.energy")
+   echo "$energy" | awk 'BEGIN {print "$energy"}; END {print "$end"}; NF == 2 {print $1, $2, $2, $2}; $NF == 4 {print $0}' > "$namespace.energy"
+fi

--- a/scripts/otool_xtb
+++ b/scripts/otool_xtb
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 args=("$@")
 namespace=$(printf '%s\n' "${args[@]}" | awk 'namespace {print $0; namespace=0}; /--namespace/ {namespace=1}')
-./build_refactor/xtb "$@"
+xtb "$@"
 if [ -f "$namespace.energy" ]
 then
    energy=$(cat "$namespace.energy")

--- a/src/io/writer/turbomole.f90
+++ b/src/io/writer/turbomole.f90
@@ -115,7 +115,7 @@ subroutine writeEnergyTurbomole(unit, energy)
    integer, intent(in) :: unit
    real(wp), intent(in) :: energy
    write(unit, '("$energy")')
-   write(unit, '(i6,F18.11)') 1, energy
+   write(unit, '(i6,3F18.11)') 1, spread(energy, 1, 3)
 end subroutine writeEnergyTurbomole
 
 


### PR DESCRIPTION
Fixes #153

- adds a script to wrap `xtb` 6.2.3 binary (also added to the v6.2.3 release tag)
- fixes the printout in `xtb` so it matches the expectation of the reader in Orca