### PR TITLE
Fix: save bond orders from ctfiles

### DIFF
--- a/src/io/reader/ctfile.f90
+++ b/src/io/reader/ctfile.f90
@@ -134,7 +134,7 @@ subroutine readMoleculeMolfile(mol, unit, status, iomsg)
    call move_alloc(sdf, mol%sdf)
    if (len(name) > 0) mol%name = name
 
-   call mol%bonds%allocate(size=number_of_bonds)
+   call mol%bonds%allocate(size=number_of_bonds, order=3)
    do ibond = 1, number_of_bonds
       call getline(unit, line, error)
       read(line, '(7i3)', iostat=error) &
@@ -143,7 +143,7 @@ subroutine readMoleculeMolfile(mol, unit, status, iomsg)
          iomsg = "could not topology from connection table"
          return
       endif
-      call mol%bonds%push_back([iatom, jatom])
+      call mol%bonds%push_back([iatom, jatom, btype])
    enddo
 
    do while(error == 0)

--- a/src/io/writer/ctfile.f90
+++ b/src/io/writer/ctfile.f90
@@ -68,7 +68,7 @@ subroutine writeMoleculeMolfile(mol, unit, comment_line)
    integer, intent(in) :: unit
    character(len=*), intent(in) :: comment_line
    integer, parameter :: list4(4) = 0
-   integer :: iatom, ibond, iatoms(2), list12(12)
+   integer :: iatom, ibond, iatoms(3), list12(12)
    logical :: has_sdf_data
    integer, parameter :: charge_to_ccc(-3:3) = [7, 6, 5, 0, 3, 2, 1]
    character(len=8)  :: date
@@ -99,7 +99,7 @@ subroutine writeMoleculeMolfile(mol, unit, comment_line)
    do ibond = 1, len(mol%bonds)
       call mol%bonds%get_item(ibond, iatoms)
       write(unit, '(7i3)') &
-         & iatoms, 1, list4
+         & iatoms, list4
    enddo
 
    if (nint(mol%chrg) /= 0) then


### PR DESCRIPTION
Quick fix for #158

Saves the input bond order from the connection table and echos it when writing mol or sdf output.