### PR TITLE
Implement comparison between topologies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,7 @@ list(APPEND srcs
   "${dir}/thermo.f90"
   "${dir}/timing.f90"
   "${dir}/tmgrad.f90"
+  "${dir}/topology.f90"
   "${dir}/wrbas.f90"
   "${dir}/wrgbw.f90"
   "${dir}/wrmodef.f90"

--- a/src/main/property.f90
+++ b/src/main/property.f90
@@ -20,6 +20,7 @@ module xtb_propertyoutput
    use xtb_mctc_io, only : stdout
    use xtb_mctc_symbols, only : toSymbol
    use xtb_cube
+   use xtb_topology
 
 contains
 
@@ -158,6 +159,8 @@ subroutine main_property &
       call print_wbofile(ifile,mol%n,wfx%wbo,0.1_wp)
       call close_file(ifile)
       call print_wiberg(iunit,mol%n,mol%at,wfx%wbo,0.1_wp)
+
+      call checkTopology(iunit, mol, wfx%wbo, 1)
    endif
 
    if (pr_wbofrag) &

--- a/src/meson.build
+++ b/src/meson.build
@@ -145,6 +145,7 @@ srcs += files(
   'thermo.f90',
   'timing.f90',
   'tmgrad.f90',
+  'topology.f90',
   'wrbas.f90',
   'wrgbw.f90',
   'wrmodef.f90',

--- a/src/topology.f90
+++ b/src/topology.f90
@@ -216,6 +216,8 @@ subroutine topologyToNeighbourList(topo, neighList, mol)
       neighList%weight(neighList%neighs(iat), iat) = iBond(3)
    end do
 
+   call neighList%sort
+
 end subroutine topologyToNeighbourList
 
 

--- a/src/topology.f90
+++ b/src/topology.f90
@@ -93,7 +93,7 @@ subroutine makeBondTopology(topo, mol, wbo)
    do iat = 1, len(mol)
       do jat = 1, iat-1
          associate(w => wbo(jat, iat))
-            if (mol%at(iat) == 6 .and. mol%at(jat) == 6) then
+            if (any(mol%at(iat) == [6, 7, 8]) .and. any(mol%at(jat) == [6, 7, 8])) then
                if (w > wbothr .and. w <= 1.2_wp) then
                   call topo%push_back([jat, iat, 1])
                else if (w > 1.5_wp .and. w <= 2.3_wp) then

--- a/src/topology.f90
+++ b/src/topology.f90
@@ -1,0 +1,222 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2019-2020 Sebastian Ehlert
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+!> Compare and generate topological information from wavefunctions
+module xtb_topology
+   use xtb_mctc_accuracy, only : wp
+   use xtb_mctc_filetypes, only : fileType, generateFileName
+   use xtb_io_writer, only : writeMolecule
+   use xtb_type_molecule, only : TMolecule, len
+   use xtb_type_neighbourlist, only : TNeighbourList, init, resizeNeigh
+   use xtb_type_topology, only : TTopology, len
+   implicit none
+   private
+
+   public :: checkTopology
+   public :: makeBondTopology, compareBondTopology
+
+
+contains
+
+
+subroutine checkTopology(unit, mol, wbo, verbosity)
+
+   integer, intent(in) :: unit
+
+   type(TMolecule), intent(in) :: mol
+
+   real(wp), intent(in) :: wbo(:, :)
+
+   integer, intent(in) :: verbosity
+
+   character(len=:), allocatable :: fname
+   type(TMolecule) :: copy
+   integer :: ich, ftype
+   logical :: match
+
+   ! CT files have some limits:
+   ! bail out if we encounter a structure not suitable for this format
+   if (mol%npbc /= 0 .or. mol%n > 999) return
+
+   copy = mol
+   call makeBondTopology(copy%bonds, mol, wbo)
+
+   call compareBondTopology(unit, mol%bonds, copy%bonds, mol, verbosity, match)
+
+   if (.not.match .and. len(copy%bonds) > 0) then
+      ! prefer molfiles, except the input has been SDF
+      if (mol%ftype /= fileType%sdf) then
+         ftype = fileType%molfile
+      else
+         ftype = mol%ftype
+      end if
+      call generateFileName(fname, 'xtbtopo', '', ftype)
+      call open_file(ich, fname, 'w')
+      if (verbosity > 0 .and. len(mol%bonds) > 0) then
+         write(unit, '("Writing corrected topology to", 1x, a)') fname
+      else
+         write(unit, '("Writing topology from bond orders to", 1x, a)') fname
+      end if
+      call writeMolecule(copy, ich, format=ftype)
+      call close_file(ich)
+   end if
+
+end subroutine checkTopology
+
+
+subroutine makeBondTopology(topo, mol, wbo)
+
+   type(TTopology), intent(out) :: topo
+
+   type(TMolecule), intent(in) :: mol
+
+   real(wp), intent(in) :: wbo(:, :)
+
+   real(wp), parameter :: wbothr = 0.3_wp
+   integer :: iat, jat
+
+   call topo%allocate(size=len(mol), order=3)
+   do iat = 1, len(mol)
+      do jat = 1, iat-1
+         associate(w => wbo(jat, iat))
+            if (mol%at(iat) == 6 .and. mol%at(jat) == 6) then
+               if (w > wbothr .and. w <= 1.2_wp) then
+                  call topo%push_back([jat, iat, 1])
+               else if (w > 1.5_wp .and. w <= 2.3_wp) then
+                  call topo%push_back([jat, iat, 2])
+               else if (w > 2.3_wp) then
+                  call topo%push_back([jat, iat, 3])
+               else if (w > 1.2_wp .and. w <= 1.5_wp) then
+                  call topo%push_back([jat, iat, 4])
+               end if
+            else
+               if (w > wbothr .and. w <= 1.3_wp) then
+                  call topo%push_back([jat, iat, 1])
+               else if (w > 1.3_wp .and. w <= 2.3_wp) then
+                  call topo%push_back([jat, iat, 2])
+               else if (w > 2.3_wp) then
+                  call topo%push_back([jat, iat, 3])
+               end if
+            end if
+         end associate
+      end do
+   end do
+end subroutine makeBondTopology
+
+
+subroutine compareBondTopology(unit, topo1, topo2, mol, verbosity, match)
+
+   integer, intent(in) :: unit
+
+   type(TTopology), intent(in) :: topo1
+
+   type(TTopology), intent(in) :: topo2
+
+   type(TMolecule), intent(in) :: mol
+
+   integer, intent(in) :: verbosity
+
+   logical, intent(out) :: match
+
+   type(TNeighbourList) :: neighList1, neighList2
+   integer :: iat, neigh
+
+   match = len(topo1) == len(topo2)
+
+   if (.not.match .and. verbosity > 0) then
+      write(unit, '("Topologies differ in total number of bonds")')
+   end if
+
+   if (match .or. verbosity > 1) then
+      call topologyToNeighbourList(topo1, neighList1, mol)
+      call topologyToNeighbourList(topo2, neighList2, mol)
+
+      match = match .and. all(neighList1%neighs == neighList2%neighs)
+      if (.not.match .and. verbosity > 0) then
+         write(unit, '("Topologies differ in number of bonds")')
+      end if
+
+      if (match .or. verbosity > 1) then
+         neigh = min(ubound(neighList1%iNeigh, 1), ubound(neighList2%iNeigh, 1))
+         match = match .and. all(neighList1%iNeigh(:neigh, :) &
+            & == neighList2%iNeigh(:neigh, :))
+         if (.not.match .and. verbosity > 0) then
+            write(unit, '("Topologies differ in connectivity")')
+         end if
+
+         if (match .or. verbosity > 1) then
+            match = match .and. all(nint(neighList1%weight(:neigh, :)) &
+               & == nint(neighList2%weight(:neigh, :)))
+            if (.not.match .and. verbosity > 0) then
+               write(unit, '("Topologies differ in bond orders")')
+            end if
+         end if
+      end if
+   end if
+
+end subroutine compareBondTopology
+
+
+subroutine topologyToNeighbourList(topo, neighList, mol)
+
+   type(TTopology), intent(in) :: topo
+
+   type(TMolecule), intent(in) :: mol
+
+   type(TNeighbourList), intent(out) :: neighList
+
+   integer :: iBond(3)
+   integer :: mNeigh
+   integer :: ii, iat, jat
+   real(wp) :: r2
+
+   call init(neighList, len(mol))
+
+   mNeigh = ubound(neighList%iNeigh, dim=1)
+
+   neighList%neighs(:) = 0
+   neighList%iNeigh(:, :) = 0
+   neighList%dist2(:, :) = 0.0_wp
+   neighList%weight(:, :) = 0.0_wp
+   do iat = 1, len(mol)
+      neighList%iNeigh(0, iat) = iat
+      neighList%weight(0, iat) = 1.0_wp
+      neighList%coords(:, iat) = mol%xyz(:, iat)
+      neighList%image(iat) = iat
+      neighList%trans(iat) = 1
+   end do
+
+   do ii = 1, len(topo)
+      call topo%get_item(ii, iBond)
+      iat = min(iBond(1), iBond(2))
+      jat = max(iBond(1), iBond(2))
+      r2 = norm2(neighList%coords(:, iat) - neighList%coords(:, jat))
+      neighList%neighs(iat) = neighList%neighs(iat) + 1
+      if (neighList%neighs(iat) > mNeigh) then
+         mNeigh = 2*mNeigh
+         call resizeNeigh(mNeigh, neighList%iNeigh, neighList%dist2, &
+            & neighList%weight)
+      end if
+      neighList%iNeigh(neighList%neighs(iat), iat) = jat
+      neighList%dist2(neighList%neighs(iat), iat) = r2
+      neighList%weight(neighList%neighs(iat), iat) = iBond(3)
+   end do
+
+end subroutine topologyToNeighbourList
+
+
+end module xtb_topology


### PR DESCRIPTION
discussed in #158
closes #34

For this algorithm we

1. generate a bond topology from the Wiberg bond orders
2. translate the WBO topology to a sorted neighbourlist
3. translate the input topology to a sorted neighbourlist as well
4. compare those neighbourlists w.r.t. length, number of neighbours, actual neighbours and bond orders (stored somewhat hacky in the Wigner–Seitz weight)

This allows to work even on differently sorted bond topologies. In case we fail, or we do not have an input topology (xyz or coord input), we write the new topology as connection table to `xtbtopo.mol` or `xtbtopo.sdf`. The input topology will not be amended by this check.


order | WBO | C-N-O
--- | --- | ---
1 | 0.3 to 1.3 | 0.3 to 1.2
2 | 1.3 to 2.3 | 1.4 to 2.3
3 | greater 2.3 | greater 2.3
4 | | 1.2 to 1.4

@tobigithub @ghutchis Any additional suggestions?