### PR TITLE
Compile xtb with the PGI compiler

### DIFF
--- a/TESTSUITE/coordinationnumber.f90
+++ b/TESTSUITE/coordinationnumber.f90
@@ -10,7 +10,8 @@ subroutine test_ncoord_pbc3d_latticepoints
    implicit none
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -128,7 +129,8 @@ subroutine test_ncoord_pbc3d_neighbourlist
    implicit none
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/coulomb.f90
+++ b/TESTSUITE/coulomb.f90
@@ -160,7 +160,8 @@ subroutine test_coulomb_point_pbc3d
 
    real(wp),parameter :: thr = 1.0e-9_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -595,7 +596,8 @@ subroutine test_coulomb_gfn1_pbc3d
 
    real(wp),parameter :: thr = 1.0e-9_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -1056,7 +1058,8 @@ subroutine test_coulomb_gfn2_pbc3d
    real(wp),parameter :: thr = 1.0e-9_wp
    integer, parameter :: nat = 32
    integer, parameter :: nsh = 48
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -1411,7 +1414,8 @@ subroutine test_coulomb_gaussian_pbc3d
 
    real(wp),parameter :: thr = 1.0e-9_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/dftd3.f90
+++ b/TESTSUITE/dftd3.f90
@@ -18,7 +18,8 @@ subroutine test_dftd3_pbc3d_neighbourlist
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -205,7 +206,8 @@ subroutine test_dftd3_pbc3d_latticepoints
    real(wp),parameter :: thr = 1.0e-10_wp
    real(wp),parameter :: thr2 = 1.0e-9_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -397,7 +399,8 @@ subroutine test_dftd3_pbc3d_threebody_neighs
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -574,7 +577,8 @@ subroutine test_dftd3_pbc3d_threebody_latp
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/dftd4.f90
+++ b/TESTSUITE/dftd4.f90
@@ -559,7 +559,8 @@ subroutine test_dftd4_pbc3d_neighbourlist
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -773,7 +774,8 @@ subroutine test_dftd4_pbc3d_latticepoints
    real(wp),parameter :: thr = 1.0e-10_wp
    real(wp),parameter :: thr2 = 1.0e-9_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -987,7 +989,8 @@ subroutine test_dftd4_pbc3d_threebody_neighs
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &
@@ -1169,7 +1172,8 @@ subroutine test_dftd4_pbc3d_threebody_latp
 
    real(wp),parameter :: thr = 1.0e-10_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -37,11 +37,11 @@ xtb_test += files('symmetry.f90')
 xtb_test += files('thermo.f90')
 xtb_test += files('tbdef_atomlist.f90')
 
-xtb_test = executable('xtb_test',
-                      xtb_test,
-                      dependencies: dependencies_exe,
-                      include_directories: incdir,
-                      link_with: xtb_lib_static)
+xtb_test = executable(
+  'xtb_test',
+  xtb_test,
+  dependencies: xtb_dep_static,
+)
 
 # some very basic checks to see if the executable reacts at all
 test('Argparser: print version', xtb_exe, args: '--version', env: xtbenv)
@@ -150,8 +150,7 @@ test('GFN2-xTB: API (PCEM)', xtb_test, args: ['gfn2', 'pcem'], env: xtbenv)
 if cc.get_id() == 'intel'
    test('GFN2-xTB: C', executable('xtb_c_test', files('c_api_example.c'),
                                   include_directories: incdir,
-                                  link_with: xtb_lib_static,
-                                  dependencies: dependencies_exe),
+                                  dependencies: xtb_dep_static),
                                   env: xtbenv)
 endif
 

--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -41,6 +41,7 @@ xtb_test = executable(
   'xtb_test',
   xtb_test,
   dependencies: xtb_dep_static,
+  link_language: 'fortran'
 )
 
 # some very basic checks to see if the executable reacts at all

--- a/TESTSUITE/peeq.f90
+++ b/TESTSUITE/peeq.f90
@@ -247,7 +247,8 @@ subroutine test_peeq_api_srb
    real(wp),parameter :: thr = 1.0e-9_wp
    ! CaF2
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/repulsion.f90
+++ b/TESTSUITE/repulsion.f90
@@ -131,7 +131,8 @@ subroutine test_repulsion_pbc3d
    real(wp),parameter :: thr = 1.0e-10_wp
    real(wp),parameter :: thr2 = 1.0e-8_wp
    integer, parameter :: nat = 32
-   integer, parameter :: at(nat) = [spread(8, 1, 4), spread(6, 1, 12),  spread(1, 1, 16)]
+   integer, parameter :: at(nat) = [8, 8, 8, 8, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, &
+      & 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
    real(wp),parameter :: xyz(3,nat) = reshape(&
       &[4.5853168464880421_wp,  4.9392326929575878_wp,  4.1894081210748118_wp,  &
       & 5.8862267152491423_wp,  1.1425258978245871_wp,  6.5015058204768126_wp,  &

--- a/TESTSUITE/tbdef_atomlist.f90
+++ b/TESTSUITE/tbdef_atomlist.f90
@@ -58,8 +58,6 @@ subroutine test_atomlist
    call atl%to_string(string)
    call assert_eq(string, '2 6:7 9')
    call atl%switch_truth
-   write(string, *) atl
-   call assert_eq(string, '1 3:5 8')
    call atl%to_list(list)
    call atl%switch_truth
    call atl%add(list)

--- a/TESTSUITE/tbdef_atomlist.f90
+++ b/TESTSUITE/tbdef_atomlist.f90
@@ -7,10 +7,10 @@ subroutine test_atomlist
    type(TAtomList) :: atl
    character(len=:), allocatable :: string
    integer, allocatable :: list(:)
-   integer, parameter :: atoms(*) = [3,1,1,5,8,1,1,2,5]
-   logical, parameter :: lpar(*) = [.true., .false., .true., .true., .true., &
+   integer, parameter :: atoms(9) = [3,1,1,5,8,1,1,2,5]
+   logical, parameter :: lpar(9) = [.true., .false., .true., .true., .true., &
       &                             .false., .false., .true., .false.]
-   integer, parameter :: ipar(*) = [1, 3, 4, 5, 8]
+   integer, parameter :: ipar(5) = [1, 3, 4, 5, 8]
    character(len=*), parameter :: cpar = '1,3-5,8'
 
    write(stderr,'(a)') " * Testing defaults"

--- a/TESTSUITE/thermo.f90
+++ b/TESTSUITE/thermo.f90
@@ -136,8 +136,7 @@ subroutine test_thermo_calc
    real(wp), parameter :: rotational_constants(3) = &
       & 0.5_wp*autorcm/[moments(3), moments(2), moments(1)]
    real(wp), parameter :: averaged_moment = &
-      & sum(moments)/3 /(kgtome*aatoau**2*1.0e+20_wp)
-   real(wp), parameter :: molecular_mass = sum(ams)
+      & (moments(1)+moments(2)+moments(3))/3 /(kgtome*aatoau**2*1.0e+20_wp)
    logical, parameter :: atom = .false.
    logical, parameter :: linear = .false.
    real(wp), parameter :: symmetry_number = 1
@@ -145,13 +144,12 @@ subroutine test_thermo_calc
    real(wp), parameter :: temperature = 298.15_wp
    real(wp), parameter :: rotor_cutoff = 100.0_wp
    logical, parameter :: pr = .true.
-   real(wp), parameter :: zero_point_energy = 0.5_wp * sum(vibs)
    real(wp) :: et, ht, g, ts
 
    call thermodyn(stdout,rotational_constants(1),rotational_constants(2), &
       &           rotational_constants(3),averaged_moment,linear,atom, &
-      &           symmetry_number,molecular_mass,vibs,nvibs,energy,temperature, &
-      &           rotor_cutoff,et,ht,g,ts,zero_point_energy,pr)
+      &           symmetry_number,sum(ams),vibs,nvibs,energy,temperature, &
+      &           rotor_cutoff,et,ht,g,ts,0.5_wp*sum(vibs),pr)
 
    call assert_close(et, 0.50275771916811E-01_wp, thr)
    call assert_close(ht, 0.67528241233247E-02_wp, thr)

--- a/meson.build
+++ b/meson.build
@@ -24,8 +24,10 @@ project(
   meson_version: '>=0.51',
   default_options: [
     'includedir=include/xtb',
+    'default_library=both',
   ],
 )
+message(get_option('default_library'))
 
 commit = get_option('build_name')
 git = find_program('git', required: false)
@@ -86,46 +88,38 @@ incdir = include_directories('include')
 # Build target
 
 # create a static library from all sources
-xtb_lib_static = static_library(
+xtb_lib = library(
   meson.project_name(),
   srcs,
-  include_directories: incdir,
-  install: true,
-  pic: true,
-)
-
-xtb_exe = executable(
-  meson.project_name(),
-  prog,
-  dependencies: dependencies_exe,
-  include_directories: incdir,
-  link_with: xtb_lib_static,
-  link_language: 'fortran',
-  install: true,
-)
-
-xtb_lib_shared = shared_library(
-  meson.project_name(),
   version: meson.project_version(),
   dependencies: dependencies_sha,
   include_directories: incdir,
-  link_whole: xtb_lib_static,
-  install: true
+  install: true,
 )
 
 xtb_dep_static = [
   declare_dependency(
-    link_whole: xtb_lib_static,
-    ),
+    link_with: xtb_lib.get_static_lib(),
+    include_directories: xtb_lib.private_dir_include(),
+  ),
   dependencies_exe,
 ]
-
 xtb_dep = [
   declare_dependency(
-    link_with: xtb_lib_shared,
+    link_with: xtb_lib.get_shared_lib(),
+    include_directories: xtb_lib.private_dir_include(),
   ),
   dependencies_sha,
 ]
+
+xtb_exe = executable(
+  meson.project_name(),
+  prog,
+  dependencies: xtb_dep_static,
+  include_directories: incdir,
+  link_language: 'fortran',
+  install: true,
+)
 
 ## ========================================== ##
 ## INSTALL

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -41,6 +41,11 @@ elif fc.get_id() == 'intel'
     add_project_link_arguments('-static', language: 'fortran')
     add_project_link_arguments('-static', language: 'c') # icc will do linking
   endif
+elif fc.get_id() == 'pgi'
+  add_project_arguments(
+    '-Mbackslash', '-Mallocatable=03', '-traceback',
+    language: 'fortran'
+  )
 endif
 
 if cc.get_id() == 'gcc'

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -43,7 +43,7 @@ elif fc.get_id() == 'intel'
   endif
 elif fc.get_id() == 'pgi'
   add_project_arguments(
-    '-Mbackslash', '-Mallocatable=03', '-traceback',
+    '-Mbackslash', '-Mallocatable=03', '-traceback', '-r8',
     language: 'fortran'
   )
 endif
@@ -73,6 +73,9 @@ if get_option('la_backend') == 'mkl'
     elif fc.get_id() == 'intel'
       libmkl_exe = [fc.find_library('mkl_intel_lp64')]
       libmkl_exe += fc.find_library('mkl_intel_thread')
+    elif fc.get_id() == 'pgi'
+      libmkl_exe = [fc.find_library('mkl_intel_lp64')]
+      libmkl_exe += fc.find_library('mkl_pgi_thread')
     endif
     libmkl_exe += fc.find_library('mkl_core')
     libmkl_sha = [fc.find_library('mkl_rt')]

--- a/src/constr.f90
+++ b/src/constr.f90
@@ -139,7 +139,7 @@ subroutine constrallbonds(nat,at,xyz)
    do i = 1, nat
       do j =1, i
          if(i.eq.j) cycle
-         rij=norm2(xyz(:,i)-xyz(:,j))
+         rij=sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          rco=(atomicRad(at(j))+atomicRad(at(i)))*autoaa
          if(0.52917726*rij.lt.1.2*rco)then
             nconstr = nconstr + 1

--- a/src/constrain_param.f90
+++ b/src/constrain_param.f90
@@ -481,7 +481,7 @@ subroutine set_constr(env,key,val,nat,at,idMap,xyz)
    !  part 2: get the distance between those atoms
       i = potset%dist%atoms(ioffset+1)
       j = potset%dist%atoms(ioffset+2)
-      dist = norm2(xyz(:,i)-xyz(:,j))
+      dist = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
       if (trim(argv(narg)).eq.'auto') then
          potset%dist%val(potset%dist%n) = dist
       else
@@ -590,7 +590,7 @@ subroutine set_constr(env,key,val,nat,at,idMap,xyz)
    !  part 2: get the distance between those atoms
       i = atconstr(1,nconstr)
       j = atconstr(2,nconstr)
-      dist = norm2(xyz(:,i)-xyz(:,j))
+      dist = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
       if (trim(argv(narg)).eq.'auto') then
          valconstr(nconstr) = dist
       else

--- a/src/constrain_pot.f90
+++ b/src/constrain_pot.f90
@@ -44,7 +44,7 @@ subroutine constrain_zaxis(fix,n,at,xyz,g,e)
 end subroutine constrain_zaxis
 
 subroutine constrain_pos(fix,n,at,xyz,g,e)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    implicit none
    type(fix_setvar),intent(in) :: fix
@@ -86,7 +86,7 @@ end function lin
 end subroutine constrain_pos
 
 subroutine qpothess2(fix,n,at,xyz,h)
-   use iso_fortran_env, only : wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    implicit none
    type(fix_setvar),intent(in) :: fix
@@ -163,7 +163,7 @@ end function lin
 end subroutine qpothess2
 
 subroutine constrain_dist(fix,n,at,xyz,g,e)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    implicit none
    type(fix_setvar),intent(in) :: fix
@@ -206,7 +206,7 @@ subroutine constrain_dist(fix,n,at,xyz,g,e)
 end subroutine constrain_dist
 
 subroutine constrain_angle(fix,n,at,xyz,g,e)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    use xtb_basic_geo
    implicit none
@@ -263,7 +263,7 @@ subroutine constrain_angle(fix,n,at,xyz,g,e)
 end subroutine constrain_angle
 
 subroutine constrain_dihedral(fix,n,at,xyz,g,e)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_mctc_constants
    use xtb_type_setvar
    use xtb_basic_geo
@@ -309,7 +309,7 @@ subroutine constrain_dihedral(fix,n,at,xyz,g,e)
 end subroutine constrain_dihedral
 
 subroutine constrain_pot(fix,n,at,xyz,g,e)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    implicit none
    type(constr_setvar),intent(in) :: fix
@@ -327,7 +327,7 @@ subroutine constrain_pot(fix,n,at,xyz,g,e)
 end subroutine constrain_pot
 
 subroutine constrain_hess(fix,n,at,xyz0,Hess)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_type_setvar
    implicit none
    type(constr_setvar),intent(in) :: fix

--- a/src/coulomb/gaussian.f90
+++ b/src/coulomb/gaussian.f90
@@ -213,7 +213,7 @@ subroutine getCoulombMatrixCluster(mol, itbl, rad, jmat)
       do jat = 1, iat-1
          jj = itbl(1, jat)
          jid = mol%id(jat)
-         r1 = norm2(mol%xyz(:, jat) - mol%xyz(:, iat))
+         r1 = sqrt(sum((mol%xyz(:, jat) - mol%xyz(:, iat))**2))
          do ish = 1, itbl(2, iat)
             do jsh = 1, itbl(2, jat)
                gij = 1.0_wp/sqrt(rad(ish, iid)**2 + rad(jsh, jid)**2)
@@ -341,7 +341,7 @@ pure function getRTerm(vec, gam, rTrans, alpha, scale) result(rTerm)
    rTerm = 0.0_wp
    do itr = 1, size(rTrans, dim=2)
       rij = vec + rTrans(:, itr)
-      r1 = norm2(rij)
+      r1 = sqrt(sum(rij**2))
       ! self-interaction correction
       if(r1 < eps) then
          rTerm = rTerm - 2.0_wp*alpha/sqrtpi
@@ -571,7 +571,7 @@ pure subroutine getRDeriv(vec, gij, rTrans, alpha, scale, dG, dS)
    do itr = 1, size(rTrans, dim=2)
       ! real contributions
       rij = vec + rTrans(:, itr)
-      r1 = norm2(rij)
+      r1 = sqrt(sum(rij**2))
       if (r1 < eps) cycle
       arg = alpha**2*r1**2
       dd = + 2*gij*exp(-gij**2*r1**2)/(sqrtpi*r1**2) - erf(gij*r1)/(r1**3) &

--- a/src/coulomb/klopmanohno.f90
+++ b/src/coulomb/klopmanohno.f90
@@ -287,7 +287,7 @@ subroutine getCoulombMatrixCluster(mol, itbl, gamAverage, gExp, hardness, jmat)
       do jat = 1, iat-1
          jj = itbl(1, jat)
          jid = mol%id(jat)
-         r1 = norm2(mol%xyz(:, jat) - mol%xyz(:, iat))
+         r1 = sqrt(sum((mol%xyz(:, jat) - mol%xyz(:, iat))**2))
          rterm = 1.0_wp/r1
          do ish = 1, itbl(2, iat)
             do jsh = 1, itbl(2, jat)
@@ -422,7 +422,7 @@ pure function getRTerm(vec, gam, gExp, rTrans, alpha, scale) result(rTerm)
    rTerm = 0.0_wp
    do itr = 1, size(rTrans, dim=2)
       rij = vec + rTrans(:, itr)
-      r1 = norm2(rij)
+      r1 = sqrt(sum(rij**2))
       ! self-interaction correction
       if(r1 < eps) then
          rTerm = rTerm - 2.0_wp*alpha/sqrtpi
@@ -515,7 +515,7 @@ subroutine getCoulombDerivsCluster(mol, itbl, gamAverage, gExp, hardness, &
          jj = itbl(1, jat)
          jid = mol%id(jat)
          vec(:) = mol%xyz(:, jat) - mol%xyz(:, iat)
-         r1 = norm2(vec)
+         r1 = sqrt(sum(vec**2))
          do ish = 1, itbl(2, iat)
             do jsh = 1, itbl(2, jat)
                gij = gamAverage(hardness(ish, iid), hardness(jsh, jid))
@@ -668,7 +668,7 @@ pure subroutine getRDeriv(vec, gij, gExp, rTrans, alpha, scale, dG, dS)
    do itr = 1, size(rTrans, dim=2)
       ! real contributions
       rij = vec + rTrans(:, itr)
-      r1 = norm2(rij)
+      r1 = sqrt(sum(rij**2))
       if (r1 < eps) cycle
       arg = alpha**2*r1**2
       g1 = 1.0_wp / (r1**gExp + gij**(-gExp))

--- a/src/david2.f90
+++ b/src/david2.f90
@@ -221,7 +221,7 @@ end subroutine sdavid2
 subroutine solver_sdavidson(n,crite,Hp,C,e,fail,pr)
    use xtb_mctc_accuracy, only : wp => sp
    use xtb_mctc_lapack, only : lapack_syevd
-   use xtb_mctc_blas, only : blas_copy, blas_axpy, blas_dot, blas_spmv
+   use xtb_mctc_blas, only : blas_copy, blas_axpy, blas_dot, mctc_spmv
    implicit none
    logical, intent(in) :: pr
    logical,parameter :: ini = .false.
@@ -270,7 +270,7 @@ subroutine solver_sdavidson(n,crite,Hp,C,e,fail,pr)
 
    ! H * C for initialization
    call smwrite(n,lun1,C(1,1),1)
-   call blas_spmv('U',n,  1.0_wp,HP, C(:,1),1,0.0_wp,vecf2,1)
+   call mctc_spmv(HP, C(:,1), vecf2)
    call smwrite(n,lun2,vecf2,1)
 
    ! aufbau des iideks feldes
@@ -374,7 +374,7 @@ subroutine solver_sdavidson(n,crite,Hp,C,e,fail,pr)
       endif
 
       ! H * C
-      call blas_spmv('U',n,  1.0_wp,HP, vecf1,1,0.0_wp,vecf2,1)
+      call mctc_spmv(HP, vecf1, vecf2)
 
       call smwrite(n,lun2,vecf2,memlun2+1)
 

--- a/src/dipole.f90
+++ b/src/dipole.f90
@@ -92,7 +92,7 @@ subroutine Dints(n,nbf,xyz,S1,S2,S3,basis)
 end subroutine Dints
 
 subroutine calc_dipole(n,at,xyz,z,nao,P,dpint,dip,d)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    use xtb_mctc_convert
    implicit none
    integer, intent(in) :: n

--- a/src/disp/dftd4.f90
+++ b/src/disp/dftd4.f90
@@ -624,7 +624,7 @@ pure subroutine build_dispmat(nat,ndim,at,xyz,par,c6abns,dispmat)
       do j = 1, i-1
          ja = at(j)
          cutoff = par%a1*sqrt(3._wp*r4r2(at(i))*r4r2(at(j)))+par%a2
-         r = norm2(xyz(:,j)-xyz(:,i))
+         r = sqrt(sum((xyz(:,j)-xyz(:,i))**2))
          if (r.gt.rthr) cycle
 !        oor6  = 1.0_wp/(r**6  + cutoff**6 )
 !        oor8  = 1.0_wp/(r**8  + cutoff**8 )
@@ -688,7 +688,7 @@ subroutine build_wdispmat(nat,ndim,at,xyz,par,c6abns,gw,wdispmat)
 !        oor6  = 1.0_wp/(r2**3 + cutoff**6 )
 !        oor8  = 1.0_wp/(r2**4 + cutoff**8 )
 !        oor10 = 1.0_wp/(r2**5 + cutoff**10)
-         r = norm2(xyz(:,j)-xyz(:,i))
+         r = sqrt(sum((xyz(:,j)-xyz(:,i))**2))
          if (r.gt.rthr) cycle
          oor6  = fdmpr_bj( 6,r,cutoff)
          oor8  = fdmpr_bj( 8,r,cutoff)
@@ -870,7 +870,7 @@ subroutine edisp(nat,ndim,at,q,xyz,par,g_a,g_c, &
       do j = 1, i-1
          ja = at(j)
          ij = i*(i-1)/2 + j
-         r = norm2(xyz(:,i)-xyz(:,j))
+         r = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
 !        r2 = sum( (xyz(:,i)-xyz(:,j))**2 )
          cutoff = par%a1*sqrt(3._wp*r4r2(ia)*r4r2(ja))+par%a2
 !        oor6 = 1._wp/(r2**3 + cutoff**6)

--- a/src/eeq_model.f90
+++ b/src/eeq_model.f90
@@ -68,7 +68,7 @@ subroutine get_coulomb_matrix_0d(mol, chrgeq, amat)
    do iat = 1, len(mol)
       ! EN of atom i
       do jat = 1, iat-1
-         r1 = norm2(mol%xyz(:,jat) - mol%xyz(:,iat))
+         r1 = sqrt(sum((mol%xyz(:,jat) - mol%xyz(:,iat))**2))
          gamij = 1.0_wp/sqrt(chrgeq%alpha(iat)**2+chrgeq%alpha(jat)**2)
          Amat(jat, iat) = erf(gamij*r1)/r1
          Amat(iat, jat) = Amat(jat,iat)
@@ -237,7 +237,7 @@ pure function eeq_ewald_3d_dir(riw,rTrans,gamij,cf,scale) result(Amat)
    Amat = 0.0_wp
    do itr = 1, size(rTrans, dim=2)
       rij = riw + rTrans(:, itr)
-      distiw = norm2(rij)
+      distiw = sqrt(sum(rij**2))
       ! self-interaction correction
       if(distiw < eps) then
          Amat = Amat - cf/sqrtpi
@@ -269,7 +269,7 @@ pure subroutine eeq_ewald_dx_3d_dir(riw,rTrans,gamij,cf,scale,dAmat,sigma)
    do itr = 1, size(rTrans, dim=2)
       ! real contributions
       rij = riw + rTrans(:, itr)
-      distiw = norm2(rij)
+      distiw = sqrt(sum(rij**2))
       if(distiw < eps) cycle
       arga = cf**2   *distiw**2
       stmp = + exp(-arga)/sqrtpi * cf * 2.0_wp / 3.0_wp
@@ -444,7 +444,7 @@ subroutine goedecker_chrgeq(n,at,xyz,chrg,cn,dcndr,q,dqdr,energy,gradient,&
    do i = 1, n
       ! EN of atom i
       do j = 1, i-1
-         r = norm2(xyz(:,j) - xyz(:,i))
+         r = sqrt(sum((xyz(:,j) - xyz(:,i))**2))
          gamij = 1.0_wp/sqrt(alpha(i)+alpha(j))
          Amat(j,i) = erf(gamij*r)/r
          Amat(i,j) = Amat(j,i)

--- a/src/embedding.f90
+++ b/src/embedding.f90
@@ -207,7 +207,7 @@ subroutine jpot_pcem_gfn1(jData,n,pcem,nshell,at,xyz,alphaj,Vpc)
          eh1 = 0.0_wp
          do kk = 1, pcem%n
             gj = pcem%gam(kk)
-            rab = norm2(pcem%xyz(:,kk) - xyz(:,iat))
+            rab = sqrt(sum((pcem%xyz(:,kk) - xyz(:,iat))**2))
             xj = 2.0_wp/(1./gi+1./gj)
             dum = 1.0_wp/(rab**alphaj+1._wp/xj**alphaj)**(1._wp/alphaj)
             eh1 = eh1+pcem%q(kk)*dum

--- a/src/fixparam.f90
+++ b/src/fixparam.f90
@@ -112,7 +112,7 @@ subroutine fix_info(iunit,n,at,xyz)
       do m = 1, shakeset%n, 2
          i = shakeset%atoms(m)
          j = shakeset%atoms(m+1)
-         val = norm2(xyz(:,i)-xyz(:,j))
+         val = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          write(iunit,'(2(i6,1x,i3,1x,a2),1x,f14.7)') &
             i,at(i),toSymbol(at(i)), &
             j,at(j),toSymbol(at(j)), &

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -85,7 +85,7 @@ subroutine generate_wsc(mol,wsc)
                   c=c+1
                   lattr(:,c) = [aa,bb,cc]
                   rw = mol%xyz(:,jj) + matmul(mol%lattice,t)
-                  dist(c)=norm2(mol%xyz(:,ii)-rw)
+                  dist(c)=sqrt(sum((mol%xyz(:,ii)-rw)**2))
                end do
             end do
          end do

--- a/src/gfn0_calculator.f90
+++ b/src/gfn0_calculator.f90
@@ -15,6 +15,7 @@
 ! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 submodule(xtb_calculators) gfn0_calc_implementation
+   use xtb_type_environment, only : TEnvironment
    implicit none
 contains
 ! ========================================================================

--- a/src/grad_core.f90
+++ b/src/grad_core.f90
@@ -30,7 +30,7 @@ module xtb_grad_core
 
    implicit none
 
-   integer, private, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
+   integer, private, parameter :: mmm(20)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
 
 contains
 

--- a/src/intgrad.f90
+++ b/src/intgrad.f90
@@ -222,8 +222,7 @@ pure subroutine dtrf2(s,li,lj)
    real(wp),intent(inout) :: s(6,6)
    integer, intent(in)    :: li,lj
    ! CAO-AO transformation
-   real(wp) :: trafo(6,6)
-   parameter (trafo = reshape((/ & ! copied from scf.f, simplyfied
+   real(wp), parameter :: trafo(6,6) = reshape((/ & ! copied from scf.f, simplyfied
       ! --- dS
       & sqrt(1.0_wp/5.0_wp), &
       & sqrt(1.0_wp/5.0_wp), &
@@ -239,7 +238,7 @@ pure subroutine dtrf2(s,li,lj)
       ! --- rest
       & 0.0_wp,0.0_wp,0.0_wp,1.0_wp,0.0_wp,0.0_wp, &
       & 0.0_wp,0.0_wp,0.0_wp,0.0_wp,1.0_wp,0.0_wp, &
-      & 0.0_wp,0.0_wp,0.0_wp,0.0_wp,0.0_wp,1.0_wp /), shape(trafo)))
+      & 0.0_wp,0.0_wp,0.0_wp,0.0_wp,0.0_wp,1.0_wp /), shape(trafo))
 
    real(wp) s2(6,6),sspher,dum(6,6)
    integer ii,jj,m,n

--- a/src/local.f90
+++ b/src/local.f90
@@ -530,7 +530,7 @@ end subroutine local
 
 ! determine type of LMO
 subroutine lmotype(n,at,xyz,ex,ey,ez,ia1,ia2,xcen,modi,pithr,typ)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    implicit none
    integer, intent(in)    :: n,ia1,ia2,at(n)
    integer, intent(out)   :: typ
@@ -560,7 +560,7 @@ subroutine lmotype(n,at,xyz,ex,ey,ez,ia1,ia2,xcen,modi,pithr,typ)
       r1=sqrt((xyz(1,ia1)-ex)**2+(xyz(2,ia1)-ey)**2+(xyz(3,ia1)-ez)**2)
       r2=sqrt((xyz(1,ia2)-ex)**2+(xyz(2,ia2)-ey)**2+(xyz(3,ia2)-ez)**2)
       r=r1+r2
-      r0=norm2(xyz(:,ia1)-xyz(:,ia2))
+      r0=sqrt(sum((xyz(:,ia1)-xyz(:,ia2))**2))
       if(r/r0.gt.1.04)then
          typ=3  ! pi
          if(xcen.gt.pithr) typ=4
@@ -704,7 +704,7 @@ subroutine lmoneigh(n,rk,ecent,aneigh,neigh)
 end subroutine lmoneigh
 
 subroutine atomneigh(n,nat,xyz,ecent,neigh)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    implicit none
    integer, intent(in)    :: n,nat
    integer, intent(inout) :: neigh(2,n)
@@ -736,7 +736,7 @@ pure function bndcheck(nat,list,i1,i2) result(check)
 end function bndcheck
 
 subroutine irand3(n1,n2,n3)
-   use iso_fortran_env, sp => real32
+   use xtb_mctc_accuracy, only : sp
    integer,intent(out) :: n1,n2,n3
    integer  :: irand
    real(sp) :: x
@@ -801,7 +801,7 @@ pure subroutine threeoutfour(i1,i2,j1,j2,n1,n2,n3)
 end subroutine threeoutfour
 
 pure subroutine calcrotation(x,ori,vec,phi)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    implicit none
 
    integer i,j
@@ -836,7 +836,7 @@ pure subroutine calcrotation(x,ori,vec,phi)
 end subroutine calcrotation
 
 pure subroutine piorient(a,b,flip)
-   use iso_fortran_env, wp => real64
+   use xtb_mctc_accuracy, only : wp
    implicit none
    real(wp),intent(in)  :: a(3),b(3)
    logical, intent(out) :: flip

--- a/src/main/geometry.f90
+++ b/src/main/geometry.f90
@@ -374,7 +374,7 @@ subroutine calc_distances(n,at,xyz,bond,maxdist,ndist,dist,id, &
       iat = at(i)
       do j = 1, i-1
          jat = at(j)
-         r  = norm2(xyz(:,i)-xyz(:,j))
+         r  = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          if (bond(j,i).gt.0) then
             m = m+1
             if (m.ge.maxdist) exit get_dist
@@ -518,7 +518,7 @@ subroutine get_bonds(n,at,xyz,bond)
       k = 0
       do while(k.eq.0 .and. f.lt.1.5_wp)
          do j = 1, i-1
-            r = norm2(xyz(:,j)-xyz(:,i))
+            r = sqrt(sum((xyz(:,j)-xyz(:,i))**2))
             r0 = rad(at(i))+rad(at(j))
             if (r.lt.f*r0) then
                k = k+1

--- a/src/mctc/namegen.f90
+++ b/src/mctc/namegen.f90
@@ -26,7 +26,7 @@ module xtb_mctc_namegen
 
    character(len=1), parameter :: delimiter = '-'
 
-   character(len=11), parameter :: tWord(61) = [ &
+   character(len=*), parameter :: tWord(61) = [ &
       &"talkative  ", "tall       ", "tame       ", "tan        ", "tangible   ", &
       &"tart       ", "tasty      ", "tattered   ", "taut       ", "tedious    ", &
       &"teeming    ", "tempting   ", "tender     ", "tense      ", "tepid      ", &
@@ -41,7 +41,7 @@ module xtb_mctc_namegen
       &"trustworthy", "trusty     ", "truthful   ", "tubby      ", "turbulent  ", &
       &"twin       "]
 
-   character(len=9), parameter :: bWord(53) = [ &
+   character(len=*), parameter :: bWord(53) = [ &
       & "back      ", "backs     ", "bail      ", "balance   ", "balances  ", &
       & "balloon   ", "balloons  ", "ban       ", "bans      ", "bandage   ", &
       & "bandages  ", "bank      ", "bare      ", "bargain   ", "battle    ", &

--- a/src/model_hessian.f90
+++ b/src/model_hessian.f90
@@ -1875,7 +1875,7 @@ subroutine mh_eeq(n,at,xyz,chrg,chrgeq,kq,hess)
    do i = 1, n
       ! EN of atom i
       do j = 1, i-1
-         r = norm2(xyz(:,j) - xyz(:,i))
+         r = sqrt(sum((xyz(:,j) - xyz(:,i))**2))
          gamij = 1.0_wp/sqrt(alpha(i)+alpha(j))
          Amat(j,i) = erf(gamij*r)/r
          Amat(i,j) = Amat(j,i)

--- a/src/qmdff.f90
+++ b/src/qmdff.f90
@@ -610,7 +610,7 @@ subroutine ff_hb(n,at,xyz,eh,g)
 !     r  =sqrt((xyz(1,i1)-xyz(1,i2))**2 &
 !        &    +(xyz(2,i1)-xyz(2,i2))**2 &
 !        &    +(xyz(3,i1)-xyz(3,i2))**2)
-      r  = norm2(xyz(:,i1)-xyz(:,i2))
+      r  = sqrt(sum((xyz(:,i1)-xyz(:,i2))**2))
       if(r.gt.25.0d0)cycle
       i  =hb(3,k)
       if(at(i).eq.1)then

--- a/src/scanparam.f90
+++ b/src/scanparam.f90
@@ -134,7 +134,7 @@ subroutine setup_constrain_pot(n,at,xyz)
          do j = 1, i-1
             jj = potset%pos%atoms(j)
             ij = ij+1
-            rij = norm2(xyz(1:3,jj)-xyz(1:3,ii))
+            rij = sqrt(sum((xyz(1:3,jj)-xyz(1:3,ii))**2))
             potset%pos%val(ij) = rij
          enddo
       enddo
@@ -147,6 +147,7 @@ subroutine pot_info(iunit,n,at,xyz)
    use xtb_mctc_constants
    use xtb_mctc_convert
    use xtb_mctc_symbols, only : toSymbol
+   use xtb_mctc_blas, only : mctc_nrm2
    implicit none
    integer, intent(in)  :: iunit
    integer, intent(in)  :: n
@@ -186,7 +187,7 @@ subroutine pot_info(iunit,n,at,xyz)
          write(iunit,'(i6,1x,i3,1x,a2)',advance='no') ii,at(ii),toSymbol(at(ii))
          if (allocated(potset%xyz)) then
             write(iunit,'(4f14.7)') &
-               potset%xyz(:,ii)*autoaa, norm2(potset%xyz(:,ii)-xyz(:,ii))*autoaa
+               potset%xyz(:,ii)*autoaa, sqrt(sum((potset%xyz(:,ii)-xyz(:,ii))**2))*autoaa
          else
             write(iunit,'(4f14.7)') &
                xyz(:,ii)*autoaa, 0.0_wp
@@ -204,9 +205,9 @@ subroutine pot_info(iunit,n,at,xyz)
       e = 0.0_wp
       call constrain_pos(potset%pos,n,at,xyz,g,e)
       efix = efix+e
-      gfix = gfix+norm2(g)
+      gfix = gfix+mctc_nrm2(g)
       write(iunit,'(5x,a,2f14.7)')"    constraining energy/grad norm:", &
-         e,norm2(g)
+         e,mctc_nrm2(g)
 
       write(iunit,'(a)')
    endif
@@ -220,7 +221,7 @@ subroutine pot_info(iunit,n,at,xyz)
          i = potset%dist%atoms(mm)
          j = potset%dist%atoms(mm+1)
          val0 = potset%dist%val(m)
-         val = norm2(xyz(:,i)-xyz(:,j))
+         val = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          write(iunit,'(2(i6,1x,i3,1x,a2),26x,1x,2f14.7)') &
             i,at(i),toSymbol(at(i)), &
             j,at(j),toSymbol(at(j)), &
@@ -238,9 +239,9 @@ subroutine pot_info(iunit,n,at,xyz)
       e = 0.0_wp
       call constrain_dist(potset%dist,n,at,xyz,g,e)
       efix = efix+e
-      gfix = gfix+norm2(g)
+      gfix = gfix+mctc_nrm2(g)
       write(iunit,'(5x,a,2f14.7)')"    constraining energy/grad norm:", &
-         e,norm2(g)
+         e,mctc_nrm2(g)
 
       write(iunit,'(a)')
    endif
@@ -272,9 +273,9 @@ subroutine pot_info(iunit,n,at,xyz)
       e = 0.0_wp
       call constrain_angle(potset%angle,n,at,xyz,g,e)
       efix = efix+e
-      gfix = gfix+norm2(g)
+      gfix = gfix+mctc_nrm2(g)
       write(iunit,'(5x,a,2f14.7)')"    constraining energy/grad norm:", &
-         e,norm2(g)
+         e,mctc_nrm2(g)
 
       write(iunit,'(a)')
    endif
@@ -309,9 +310,9 @@ subroutine pot_info(iunit,n,at,xyz)
       e = 0.0_wp
       call constrain_dihedral(potset%dihedral,n,at,xyz,g,e)
       efix = efix+e
-      gfix = gfix+norm2(g)
+      gfix = gfix+mctc_nrm2(g)
       write(iunit,'(5x,a,2f14.7)')"    constraining energy/grad norm:", &
-         e,norm2(g)
+         e,mctc_nrm2(g)
 
       write(iunit,'(a)')
    endif
@@ -337,7 +338,7 @@ subroutine constrain_all_bonds(n,at,xyz)
 
    do i = 1, n
       do j = 1, i-1
-         r  = norm2(xyz(:,i)-xyz(:,j))
+         r  = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          r0 = rad(at(j))+rad(at(i))
          if (r.lt.f*r0) then
             ioffset = 2*potset%dist%n

--- a/src/scc_core.f90
+++ b/src/scc_core.f90
@@ -38,7 +38,7 @@ module xtb_scc_core
    public :: shellPoly, h0scal
 
 
-   integer, private, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
+   integer, private, parameter :: mmm(20)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
 
 
 contains

--- a/src/scf_module.f90
+++ b/src/scf_module.f90
@@ -55,7 +55,7 @@ module xtb_scf
 
    logical, parameter :: profile = .true.
 
-   integer, parameter :: mmm(*)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
+   integer, parameter :: mmm(20)=(/1,2,2,2,3,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4/)
 
    integer, parameter :: metal(1:86) = [&
       & 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, &

--- a/src/sphereparam.f90
+++ b/src/sphereparam.f90
@@ -221,7 +221,7 @@ subroutine get_sphere_radius_list(nat,at,xyz,nlist,list,center,radius,do_trafo)
    max_distance = 0.0_wp ! ~equals diameter of sphere
    do i = 1, nlist
       do j = 1, i-1
-         distance = norm2(coord(:,list(j))-coord(:,list(i)))
+         distance = sqrt(sum((coord(:,list(j))-coord(:,list(i)))**2))
          max_distance = max(max_distance,distance)
       enddo
    enddo
@@ -272,7 +272,7 @@ subroutine get_sphere_radius_fragment(nat,at,xyz,center,fragment,radius,do_trafo
    do i = 1, nat
       do j = 1, i-1
          if (splitlist(i).ne.fragment.or.fragment.ne.splitlist(j)) cycle
-         distance = norm2(coord(:,j)-coord(:,i))
+         distance = sqrt(sum((coord(:,j)-coord(:,i))**2))
          max_distance = max(max_distance,distance)
       enddo
    enddo
@@ -320,7 +320,7 @@ subroutine get_sphere_radius_all(nat,at,xyz,center,radius,do_trafo)
    max_distance = 0.0_wp ! ~equals diameter of sphere
    do i = 1, nat
       do j = 1, i-1
-         distance = norm2(coord(:,j)-coord(:,i))
+         distance = sqrt(sum((coord(:,j)-coord(:,i))**2))
          max_distance = max(max_distance,distance)
       enddo
    enddo
@@ -362,7 +362,7 @@ subroutine logfermi_cavity_list(nat,at,xyz,nlist,list,temp,alpha,center,radius,&
    do i = 1, nlist
       iat = list(i)
       r = w*(xyz(:,iat) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       expterm = exp(alpha*(dist-R0))
       fermi = 1.0_wp/(1.0_wp+expterm)
       efix = efix + kB*temp * log( 1.0_wp+expterm )
@@ -398,7 +398,7 @@ subroutine logfermi_cavity_frag(nat,at,xyz,fragment,temp,alpha,center,radius,&
    do i = 1, nat
       if (splitlist(i).ne.fragment) cycle
       r = w*(xyz(:,i) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       expterm = exp(alpha*(dist-R0))
       fermi = 1.0_wp/(1.0_wp+expterm)
       efix = efix + kB*temp * log( 1.0_wp+expterm )
@@ -431,7 +431,7 @@ subroutine logfermi_cavity_all(nat,at,xyz,temp,alpha,center,radius,&
 
    do i = 1, nat
       r = w*(xyz(:,i) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       expterm = exp(alpha*(dist-R0))
       fermi = 1.0_wp/(1.0_wp+expterm)
       efix = efix + kB*temp * log( 1.0_wp+expterm )
@@ -467,7 +467,7 @@ subroutine polynomial_cavity_list(nat,at,xyz,nlist,list,alpha,center,radius,&
    do i = 1, nlist
       iat = list(i)
       r = w*(xyz(:,iat) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       polyterm = (dist/R0)**alpha
       efix = efix + polyterm
       gfix(:,iat) = gfix(:,iat) + alpha*polyterm * (r*w)/(dist**2+1.0e-14_wp)
@@ -501,7 +501,7 @@ subroutine polynomial_cavity_frag(nat,at,xyz,fragment,alpha,center,radius,&
    do i = 1, nat
       if (splitlist(i).ne.fragment) cycle
       r = w*(xyz(:,i) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       polyterm = (dist/R0)**alpha
       efix = efix + polyterm
       gfix(:,i) = gfix(:,i) + alpha*polyterm * (r*w)/(dist**2+1.0e-14_wp)
@@ -532,7 +532,7 @@ subroutine polynomial_cavity_all(nat,at,xyz,alpha,center,radius,&
 
    do i = 1, nat
       r = w*(xyz(:,i) - center)
-      dist = norm2(r)
+      dist = sqrt(sum(r**2))
       polyterm = (dist/R0)**alpha
       efix = efix + polyterm
       gfix(:,i) = gfix(:,i) + alpha*polyterm * (r*w)/(dist**2+1.0e-14_wp)

--- a/src/splitparam.f90
+++ b/src/splitparam.f90
@@ -72,7 +72,7 @@ subroutine splitm(nat,at,xyz,cn)
    bond = 0
    do i=1,nat
       do j=1,nat
-         r=norm2(xyz(:,i)-xyz(:,j))
+         r=sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          rco=(atomicRad(at(i))+atomicRad(at(j)))*autoaa
          if(r.lt.2.5*rco) bond(j,i)=1
       enddo

--- a/src/topology.f90
+++ b/src/topology.f90
@@ -204,7 +204,7 @@ subroutine topologyToNeighbourList(topo, neighList, mol)
       call topo%get_item(ii, iBond)
       iat = min(iBond(1), iBond(2))
       jat = max(iBond(1), iBond(2))
-      r2 = norm2(neighList%coords(:, iat) - neighList%coords(:, jat))
+      r2 = sum((neighList%coords(:, iat) - neighList%coords(:, jat))**2)
       neighList%neighs(iat) = neighList%neighs(iat) + 1
       if (neighList%neighs(iat) > mNeigh) then
          mNeigh = 2*mNeigh

--- a/src/type/atomlist.f90
+++ b/src/type/atomlist.f90
@@ -20,14 +20,13 @@ module xtb_type_atomlist
    use xtb_mctc_accuracy, only : wp
    implicit none
    public :: TAtomList
-   public :: size, len, assignment(=), write(formatted), read(formatted)
+   public :: size, len, assignment(=)
    private
 
    character, parameter :: p_delimiter = ','
    character, parameter :: p_skip = '-'
 
    type :: TAtomList
-      private
       logical, allocatable :: list(:)
       logical :: default = .false.
       character :: delimiter = p_delimiter
@@ -35,7 +34,7 @@ module xtb_type_atomlist
       logical :: error = .false.
    contains
       generic :: new => from_integers, from_logicals, from_string, from_defaults
-      procedure, private, non_overridable :: from_defaults => atomlist_defaults
+      procedure, non_overridable :: from_defaults
       procedure, private :: from_integers => atomlist_assign_integers
       procedure, private :: from_logicals => atomlist_assign_logicals
       procedure, private :: from_string => atomlist_assign_string
@@ -88,14 +87,6 @@ module xtb_type_atomlist
       module procedure :: list_assign_atomlist
    end interface assignment(=)
 
-   interface write(formatted)
-      module procedure :: atomlist_write_formatted
-   end interface write(formatted)
-
-   interface read(formatted)
-      module procedure :: atomlist_read_formatted
-   end interface read(formatted)
-
 contains
 
 pure function atomlist_from_logicals(list, truth, delimiter, skip) result(self)
@@ -131,9 +122,9 @@ pure function atomlist_from_string(list, truth, delimiter, skip) result(self)
    call self%new(list)
 end function atomlist_from_string
 
-subroutine atomlist_defaults(self)
+subroutine from_defaults(self)
    class(TAtomList), intent(out) :: self
-end subroutine atomlist_defaults
+end subroutine from_defaults
 
 pure elemental subroutine atomlist_switch_truth(self)
    class(TAtomList), intent(inout) :: self

--- a/src/type/atomlist.f90
+++ b/src/type/atomlist.f90
@@ -34,6 +34,7 @@ module xtb_type_atomlist
       logical :: error = .false.
    contains
       generic :: new => from_integers, from_logicals, from_string, from_defaults
+      ! Should be private, but must be declared as public due to PGI bug #28452
       procedure, non_overridable :: from_defaults
       procedure, private :: from_integers => atomlist_assign_integers
       procedure, private :: from_logicals => atomlist_assign_logicals

--- a/src/type/coulomb.f90
+++ b/src/type/coulomb.f90
@@ -388,7 +388,7 @@ subroutine getCoulombMatrixCluster(mol, itbl, jmat)
       ii = itbl(1, iat)
       do jat = 1, iat-1
          jj = itbl(1, jat)
-         r1 = norm2(mol%xyz(:, jat) - mol%xyz(:, iat))
+         r1 = sqrt(sum((mol%xyz(:, jat) - mol%xyz(:, iat))**2))
          rterm = 1.0_wp/r1
          do ish = 1, itbl(2, iat)
             do jsh = 1, itbl(2, jat)

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -473,7 +473,7 @@ subroutine mol_calculate_distances(self)
    else
       do i = 1, self%n
          do j = 1, i-1
-            self%dist(j,i) = norm2(self%xyz(:,j)-self%xyz(:,i))
+            self%dist(j,i) = sqrt(sum((self%xyz(:,j)-self%xyz(:,i))**2))
             self%dist(i,j) = self%dist(j,i)
          enddo
          self%dist(i,i) = 0.0_wp

--- a/src/type/reader.f90
+++ b/src/type/reader.f90
@@ -53,6 +53,7 @@ module xtb_type_reader
       generic :: close => closeUnit
 
       !> Close connected unit
+      ! Should be private, but must be declared as public due to PGI bug #28452
       procedure :: closeUnit
 
    end type TReader

--- a/src/type/reader.f90
+++ b/src/type/reader.f90
@@ -53,7 +53,7 @@ module xtb_type_reader
       generic :: close => closeUnit
 
       !> Close connected unit
-      procedure, private :: closeUnit
+      procedure :: closeUnit
 
    end type TReader
 

--- a/src/xtb/gfn0.f90
+++ b/src/xtb/gfn0.f90
@@ -36,12 +36,14 @@ module xtb_xtb_gfn0
       module procedure :: initHamiltonian
    end interface initGFN0
 
+   real(wp), parameter :: enshell(4) = [0.6_wp, -0.1_wp, -0.2_wp, -0.2_wp]
+   real(wp), parameter :: kshell(4) = [2.0000000_wp, 2.4868000_wp, 2.2700000_wp, 0.6000000_wp]
 
    type(TxTBParameter), parameter :: gfn0Globals = TxTBParameter( &
-      kshell = [2.0000000_wp, 2.4868000_wp, 2.2700000_wp, 0.6000000_wp], &
+      kshell   = kshell, &
       kdiffa   = 0.0000000_wp, &
       kdiffb   =-0.1000000_wp, &
-      enshell = [0.6_wp, -0.1_wp, -0.2_wp, -0.2_wp], &
+      enshell  = enshell, &
       enscale4 = 4.0000000_wp, &
       ipeashift= 1.7806900_wp, &
       zcnf     = 0.0537000_wp, &

--- a/src/xtb/gfn1.f90
+++ b/src/xtb/gfn1.f90
@@ -44,8 +44,10 @@ module xtb_xtb_gfn1
       &[0.6_wp, 0.6_wp,-0.3_wp,-0.3_wp,-0.5_wp, 0.5_wp,-0.5_wp, 0.5_wp], &
       & shape(cnshell))
 
+   real(wp), parameter :: kshell(4) = [1.85_wp, 2.25_wp, 2.0_wp, 2.0_wp]
+
    type(TxTBParameter), parameter :: gfn1Globals = TxTBParameter( &
-      kshell = [1.85_wp, 2.25_wp, 2.0_wp, 2.0_wp], &
+      kshell = kshell, &
       enshell = -0.7_wp, &
       ksp = 2.08_wp, &
       kdiff = 2.85_wp, &

--- a/src/xtb/gfn2.f90
+++ b/src/xtb/gfn2.f90
@@ -45,8 +45,10 @@ module xtb_xtb_gfn2
       &[1.0_wp, 1.0_wp, 0.5_wp, 0.5_wp, 0.25_wp, 0.25_wp, 0.25_wp, 0.25_wp], &
       & shape(gam3shell))
 
+   real(wp), parameter :: kshell(4) = [1.85_wp, 2.23_wp, 2.23_wp, 2.23_wp]
+
    type(TxTBParameter), parameter :: gfn2Globals = TxTBParameter( &
-      kshell = [1.85_wp, 2.23_wp, 2.23_wp, 2.23_wp], &
+      kshell = kshell, &
       enshell = 2.0_wp, &
       ksd = 2.0_wp, &
       kpd = 2.0_wp, &


### PR DESCRIPTION
Fixes to compile `xtb` with the PGI compiler.

- [x] Fixes usage of `norm2` which is not yet implemented in `pgfortran`
- [x] Work around compiler bugs [TPR28451](https://www.pgroup.com/userforum/viewtopic.php?f=4&t=7631) and [TPR28452](https://www.pgroup.com/userforum/viewtopic.php?f=4&t=7630)
- [ ] Compile with OpenMP support
- [x] Compile and run the testsuite
- [ ] Rebase against master

Closes #189