### PR TITLE
Add Turbomole vibrational modes format

### DIFF
--- a/man/man7/xcontrol.7.txt
+++ b/man/man7/xcontrol.7.txt
@@ -537,6 +537,8 @@ $write
 *torsions*='bool'::
     geometry summary on dihedral angles and torsions
     (available with `--define`)
+*vib_normal_modes*='bool'::
+    write normal modes as Turbomole vibrational modes data group
 
 LEGACY
 ~~~~~~

--- a/src/main/property.f90
+++ b/src/main/property.f90
@@ -381,10 +381,12 @@ subroutine main_freq &
 !! ========================================================================
 !  global storage of options, parameters and basis set
    use xtb_setparam
+   use xtb_splitparam, only : atmass
 
 !! ------------------------------------------------------------------------
    use xtb_hessian
    use xtb_disp_ncoord
+   use xtb_io_writer_turbomole, only : writeNormalModesTurbomole
 
    implicit none
 
@@ -432,6 +434,14 @@ subroutine main_freq &
    write(iunit,'(1x,a)') &
       & 'recommended (thermochemical) frequency scaling factor: 1.0'
    call g98fake2('g98.out',mol%n,mol%at,mol%xyz,res%freq,res%rmass,res%dipt,res%hess)
+
+   if (pr_nmtm) then
+      call open_file(ifile, "vib_normal_modes", 'w')
+      if (ifile .ne. -1) then
+         call writeNormalModesTurbomole(ifile, atmass, res%hess)
+         call close_file(ifile)
+      end if
+   end if
 
    call generic_header(iunit,"Thermodynamic Functions",49,10)
    call print_thermo(iunit,mol%n,res%n3true,mol%at,mol%xyz,res%freq,res%etot,res%htot,res%gtot, &

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -375,6 +375,7 @@ subroutine write_set_write(ictrl)
    write(ictrl,'(3x,"stm=",a)')              bool2string(pr_stm)
    write(ictrl,'(3x,"modef=",a)')            bool2string(pr_modef)
    write(ictrl,'(3x,"gbsa=",a)')             bool2string(pr_gbsa)
+   write(ictrl,'(3x,"vib_normal_modes=",a)') bool2string(pr_nmtm)
 end subroutine write_set_write
 
 subroutine write_set_external(ictrl)
@@ -1114,6 +1115,7 @@ subroutine set_write(env,key,val)
    logical,save :: set27 = .true.
    logical,save :: set28 = .true.
    logical,save :: set29 = .true.
+   logical,save :: set30 = .true.
    select case(key)
    case default ! do nothing
       call env%warning("the key '"//key//"' is not recognized by write",source)
@@ -1207,6 +1209,9 @@ subroutine set_write(env,key,val)
    case('gbsa')
       if (getValue(env,val,ldum).and.set29) pr_gbsa = ldum
       set29 = .false.
+   case('vib_normal_modes', 'nmtm')
+      if (getValue(env,val,ldum).and.set30) pr_nmtm = ldum
+      set30 = .false.
    end select
 end subroutine set_write
 

--- a/src/setparam.f90
+++ b/src/setparam.f90
@@ -268,6 +268,7 @@ module xtb_setparam
    logical  :: pr_moments = .true.
    logical  :: pr_modef = .false.
    logical  :: pr_gbsa = .false.
+   logical  :: pr_nmtm = .false.
 
 !! ------------------------------------------------------------------------
 !  point group symmetrization threshold


### PR DESCRIPTION
Implement printout for normal modes in Turbomole format.

Use with detailed input

```
$write
   vib_normal_modes=true
$end
```

Will create a file `vib_normal_modes` for `--hess` and `--ohess` runs containing the `vibrational` data group as

```
$vibrational normal modes
 1  1   0.0627745744  -0.0281330227  -0.0322002988  -0.0201372051  -0.0288325538
 1  2   0.0238768339  -0.0000093539   0.0000128526  -0.0000009103  -0.0000046597
 1  3  -0.0000059296   0.0000044965   0.0000114170  -0.0061363907  -0.0000481400
 1  4  -0.0335000536   0.0000767417   0.0325447599  -0.0000285850  -0.0152998377
 1  5   0.0318889379  -0.0359649174   0.0728160919   0.0679550961  -0.0006859928
 1  6   0.0803744515  -0.0002999631   0.0000629725   0.0000082075  -0.1128229229
 1  7   0.1044632519  -0.0000051232  -0.0278467442   0.0071728153   0.0377051923
 1  8   0.0231453050   0.0140560273   0.0000600801   0.0000167079  -0.0000009068
 1  9  -0.0479425821   0.0668438969   0.0014995246   0.0074298436   0.0077212541
...
```