### PR TITLE
Implement DFTB+ style hessian.out

### DIFF
--- a/man/man7/xcontrol.7.txt
+++ b/man/man7/xcontrol.7.txt
@@ -539,6 +539,8 @@ $write
     (available with `--define`)
 *vib_normal_modes*='bool'::
     write normal modes as Turbomole vibrational modes data group
+*hessian.out*='bool'::
+    write DFTB+ style hessian.out file containing the unprojected hessian
 
 LEGACY
 ~~~~~~

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -476,6 +476,11 @@ subroutine numhess( &
       enddo
    endif
 
+   if (pr_dftbp_hessian_out) then
+      call writeHessianOut('hessian.out', res%hess)
+      write(env%unit, '(A)') "DFTB+ style hessian.out written"
+   end if
+
    ! prepare all for diag
    ! copy
    k=0
@@ -1184,5 +1189,27 @@ pure subroutine sortind(nvar,edum)
 
 end subroutine sortind
 
+
+!> Write the second derivative matrix
+subroutine writeHessianOut(fileName, pDynMatrix)
+
+   !> File name
+   character(*), intent(in) :: fileName
+
+   !> Dynamical (Hessian) matrix
+   real(wp), intent(in) :: pDynMatrix(:,:)
+
+   !> Format string for energy second derivative matrix
+   character(len=*), parameter :: formatHessian = '(4f16.10)'
+
+   integer :: ii, fd
+
+   call open_file(fd, fileName, 'w')
+   do ii = 1, size(pDynMatrix, dim=2)
+      write(fd, formatHessian) pDynMatrix(:, ii)
+   end do
+   call close_file(fd)
+
+end subroutine writeHessianOut
 
 end module xtb_hessian

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -376,6 +376,7 @@ subroutine write_set_write(ictrl)
    write(ictrl,'(3x,"modef=",a)')            bool2string(pr_modef)
    write(ictrl,'(3x,"gbsa=",a)')             bool2string(pr_gbsa)
    write(ictrl,'(3x,"vib_normal_modes=",a)') bool2string(pr_nmtm)
+   write(ictrl,'(3x,"hessian.out=",a)')      bool2string(pr_dftbp_hessian_out)
 end subroutine write_set_write
 
 subroutine write_set_external(ictrl)
@@ -1116,6 +1117,7 @@ subroutine set_write(env,key,val)
    logical,save :: set28 = .true.
    logical,save :: set29 = .true.
    logical,save :: set30 = .true.
+   logical,save :: set31 = .true.
    select case(key)
    case default ! do nothing
       call env%warning("the key '"//key//"' is not recognized by write",source)
@@ -1212,6 +1214,9 @@ subroutine set_write(env,key,val)
    case('vib_normal_modes', 'nmtm')
       if (getValue(env,val,ldum).and.set30) pr_nmtm = ldum
       set30 = .false.
+   case('hessian.out')
+      if (getValue(env,val,ldum).and.set31) pr_dftbp_hessian_out = ldum
+      set31 = .false.
    end select
 end subroutine set_write
 

--- a/src/setparam.f90
+++ b/src/setparam.f90
@@ -269,6 +269,7 @@ module xtb_setparam
    logical  :: pr_modef = .false.
    logical  :: pr_gbsa = .false.
    logical  :: pr_nmtm = .false.
+   logical  :: pr_dftbp_hessian_out = .false.
 
 !! ------------------------------------------------------------------------
 !  point group symmetrization threshold


### PR DESCRIPTION
Allow printing a DFTB+ compatible `hessian.out` file which can be read in *e.g.* with the `modes` program.

To run:

```bash
printf "\$write\n hessian.out=true\n\$end\n" > hess.inp
xtb --gfnff --hess --input hess.inp <geometry>
```

@pecchia Let me know if this works for you.