### PR TITLE
Rescue failed geometry optimization

### DIFF
--- a/src/geoopt_driver.f90
+++ b/src/geoopt_driver.f90
@@ -58,7 +58,7 @@ subroutine geometry_optimization &
    logical, intent(in)    :: initial_sp
 
    type(scc_results) :: res
-   logical :: final_sp
+   logical :: final_sp, exitRun
    integer :: printlevel
    integer :: ilog
 
@@ -115,6 +115,12 @@ subroutine geometry_optimization &
       else
          call touch_file('.xtboptok')
       endif
+   end if
+
+   call env%check(exitRun)
+   if (exitRun) then
+      call env%rescue("Trying to recover from failed geometry optimization", source)
+      fail = .true.
    end if
 
    if (pr.and.pr_finalstruct) then

--- a/src/optimizer.f90
+++ b/src/optimizer.f90
@@ -355,7 +355,7 @@ subroutine ancopt(env,ilog,mol,chk,calc, &
 
    call env%check(fail)
    if (fail) then
-      call env%error("GEOMETRY OPTIMIZATION FAILED!", source)
+      call env%error("Could not relax structure", source)
       return
    endif
 

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -630,6 +630,15 @@ subroutine xtbMain(env, argParser)
       if (nscan.gt.0) then
          call relaxed_scan(env,mol,chk,calc)
       endif
+      if (murks) then
+         call generateFileName(tmpname, 'xtblast', extension, mol%ftype)
+         write(env%unit,'(/,a,1x,a,/)') &
+            "last geometry written to:",tmpname
+         call open_file(ich,tmpname,'w')
+         call writeMolecule(mol, ich, energy=res%e_total, gnorm=res%gnorm)
+         call close_file(ich)
+         call env%terminate("Geometry optimization failed")
+      end if
       call stop_timing(3)
    endif
 


### PR DESCRIPTION
- recover error in geoopt driver to perform a diagnostic SP
- report last failed structure before termination:

```
last geometry written to: xtblast.coord

########################################################################
[ERROR] Program stopped due to fatal error
-5- Geometry optimization failed
-4- xtb_geoopt: Trying to recover from failed geometry optimization
-3- xtb_geoopt: Geometry optimization did not converge
-2- optimizer_ancopt: Could not relax structure
-1- optimizer_relax: internal rational function error
########################################################################
abnormal termination of xtb
```