### PR TITLE
Setup CI build with Intel compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
               - intel-oneapi-ifort
               - intel-oneapi-icc
               - intel-oneapi-mkl
+              - intel-oneapi-mkl-devel
               - intel-oneapi-openmp
         before_install:
         - source /opt/intel/inteloneapi/setvars.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,31 @@ addons:
 jobs:
    include:
       - name: meson-build
+        env: FC=ifort CC=icc
+        addons:
+           apt:
+              sources:
+              - sourceline: 'deb https://apt.repos.intel.com/oneapi all main'
+                key_url: 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB'
+              packages:
+              - intel-oneapi-ifort
+              - intel-oneapi-icc
+              - intel-oneapi-mkl
+              - intel-oneapi-openmp
+        before_install:
+        - source /opt/intel/inteloneapi/setvars.sh
+        script:
+        - meson build --buildtype=release --prefix=$PWD/install -Dla_backend=mkl-static
+        - OMP_NUM_THREADS=2 ninja -C build test install
+      - name: meson-build
         env: FC=gfortran-8 CC=gcc-8
         script:
-        - meson build --buildtype release --prefix $PWD/install --warnlevel 0 -Dla_backend=netlib
+        - meson build --buildtype=release --prefix=$PWD/install --warnlevel=0 -Dla_backend=netlib
         - OMP_NUM_THREADS=2 ninja -C build test install
       - name: meson-build
         env: FC=gfortran-7 CC=gcc-7
         script:
-        - meson build --buildtype release --prefix $PWD/install --warnlevel 0 -Dla_backend=netlib
+        - meson build --buildtype=release --prefix=$PWD/install --warnlevel=0 -Dla_backend=netlib
         - OMP_NUM_THREADS=2 ninja -C build test install
       - name: CMake-build
         env: FC=gfortran-8 CC=gcc-8
@@ -33,4 +50,4 @@ jobs:
         - OMP_NUM_THREADS=2 make -j all test install
 
 install:
-   - pip3 install meson==0.53.2 ninja pytest numpy
+   - pip3 install meson ninja pytest numpy

--- a/meson.build
+++ b/meson.build
@@ -24,7 +24,6 @@ project(
   meson_version: '>=0.51',
   default_options: [
     'includedir=include/xtb',
-    'c_std=c11',
     'buildtype=release',
     'default_library=both',
   ],

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -123,7 +123,14 @@ else
 endif
 
 if get_option('openmp')
-  dependencies += dependency('openmp')
+  omp_dep = dependency('openmp', required: fc.get_id() != 'intel')
+  if not omp_dep.found()
+    omp_dep = declare_dependency(
+      compile_args: '-qopenmp',
+      link_args: '-qopenmp',
+    )
+  endif
+  dependencies += omp_dep
 endif
 
 dependencies += dependency('threads')


### PR DESCRIPTION
Intel is providing compilers and MKL for apt, the PR enables the Intel oneAPI on Travis CI to build `xtb`.
For more details see: https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html#aptpkg

Could be used to continuously compile and release `xtb` binaries, maybe together with the CentOS8 docker image: https://hub.docker.com/r/intel/oneapi-hpckit