### PR TITLE
Use -fexternal-blas with gfortran so that matmul gets wrapped to BLAS

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -28,6 +28,7 @@ if fc.get_id() == 'gcc'
   add_project_arguments('-fdefault-double-8', language: 'fortran')
   add_project_arguments('-ffree-line-length-none', language: 'fortran')
   add_project_arguments('-fbacktrace', language: 'fortran')
+  add_project_arguments('-fexternal-blas', language: 'fortran')
 elif fc.get_id() == 'intel'
   add_project_arguments('-axAVX2',    language: 'fortran')
   add_project_arguments('-r8',        language: 'fortran')


### PR DESCRIPTION
As described above, this adds `-fexternal-blas` to the gfortran flags so that the `matmul` intrinsic is evaluated with the BLAS library, if the matrix size is bigger than `n` (gfortran default 30).

The flag is available at least since gfortran 4.4.7 on RHEL 6, released in 2010, so this should be no problem.