### PR TITLE
Add interfaces to generate_wsc

### DIFF
--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -90,7 +90,7 @@ subroutine generate_wsc(mol,wsc)
             end do
          end do
          ! sanity check; otherwise code below crashes sometimes
-         if ( c .eq. 0 ) cycle
+         if (c .eq. 0) cycle
          ! get first image with same dist
          ! find minimum in dist-array and assign it to minpos = minimum position
          trans=.true.

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -89,6 +89,8 @@ subroutine generate_wsc(mol,wsc)
                end do
             end do
          end do
+         ! sanity check; otherwise code below crashes sometimes
+         if ( c .eq. 0 ) cycle
          ! get first image with same dist
          ! find minimum in dist-array and assign it to minpos = minimum position
          trans=.true.
@@ -125,4 +127,3 @@ subroutine generate_wsc(mol,wsc)
 !$omp endparallel
 
 end subroutine generate_wsc
-

--- a/src/gfnff/calculator.f90
+++ b/src/gfnff/calculator.f90
@@ -39,9 +39,9 @@ module xtb_gfnff_calculator
    implicit none
    interface
       subroutine generate_wsc(mol,wsc)
-        import :: TMolecule, tb_wsc
-        type(TMolecule), intent(inout) :: mol
-        type(tb_wsc),    intent(inout) :: wsc
+         import :: TMolecule, tb_wsc
+         type(TMolecule), intent(inout) :: mol
+         type(tb_wsc),    intent(inout) :: wsc
       end subroutine generate_wsc
    end interface
    private

--- a/src/gfnff/calculator.f90
+++ b/src/gfnff/calculator.f90
@@ -24,6 +24,7 @@ module xtb_gfnff_calculator
    use xtb_type_molecule, only : TMolecule
    use xtb_type_solvent, only : TSolvent
    use xtb_type_restart
+   use xtb_type_wsc, only : tb_wsc
    use xtb_setparam
    use xtb_fixparam
    use xtb_scanparam
@@ -36,6 +37,13 @@ module xtb_gfnff_calculator
    use xtb_gfnff_generator, only : TGFFGenerator
    use xtb_gfnff_eg
    implicit none
+   interface
+      subroutine generate_wsc(mol,wsc)
+        import :: TMolecule, tb_wsc
+        type(TMolecule), intent(inout) :: mol
+        type(tb_wsc),    intent(inout) :: wsc
+      end subroutine generate_wsc
+   end interface
    private
 
    public :: TGFFCalculator

--- a/src/type/dummycalc.f90
+++ b/src/type/dummycalc.f90
@@ -24,6 +24,7 @@ module xtb_type_dummycalc
    use xtb_type_molecule, only : TMolecule
    use xtb_type_param, only : scc_parameter
    use xtb_type_restart, only : TRestart
+   use xtb_type_wsc, only : tb_wsc
    use xtb_setparam
    use xtb_fixparam
    use xtb_scanparam
@@ -34,6 +35,13 @@ module xtb_type_dummycalc
    use xtb_metadynamic
    use xtb_constrainpot
    implicit none
+   interface
+      subroutine generate_wsc(mol,wsc)
+        import :: TMolecule, tb_wsc
+        type(TMolecule), intent(inout) :: mol
+        type(tb_wsc),    intent(inout) :: wsc
+      end subroutine generate_wsc
+   end interface
 
    public :: TDummyCalculator
    private

--- a/src/type/dummycalc.f90
+++ b/src/type/dummycalc.f90
@@ -37,9 +37,9 @@ module xtb_type_dummycalc
    implicit none
    interface
       subroutine generate_wsc(mol,wsc)
-        import :: TMolecule, tb_wsc
-        type(TMolecule), intent(inout) :: mol
-        type(tb_wsc),    intent(inout) :: wsc
+         import :: TMolecule, tb_wsc
+         type(TMolecule), intent(inout) :: mol
+         type(tb_wsc),    intent(inout) :: wsc
       end subroutine generate_wsc
    end interface
 

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -198,9 +198,9 @@ subroutine initMolecule &
 
    interface
       subroutine generate_wsc(mol,wsc)
-        import :: TMolecule, tb_wsc
-        type(TMolecule), intent(inout) :: mol
-        type(tb_wsc),    intent(inout) :: wsc
+         import :: TMolecule, tb_wsc
+         type(TMolecule), intent(inout) :: mol
+         type(tb_wsc),    intent(inout) :: wsc
       end subroutine generate_wsc
    end interface
 

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -16,7 +16,7 @@
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !> molecular structure information
-! 
+!
 !  contains information about the molecular geometry, the atom types
 !  the nuclear and total charge, atomic masses and all interatomic distances
 !  In periodic calculations the lattice parameters, a Wigner--Seitz cell
@@ -134,7 +134,7 @@ module xtb_type_molecule
 
       !> Turbomole specific information about input type
       type(turbo_info) :: turbo = turbo_info()
-      
+
       !> Specific information about input structure
       type(struc_info) :: struc = struc_info()
 
@@ -194,7 +194,16 @@ contains
 
 !> Constructor for the molecular structure type
 subroutine initMolecule &
-      & (mol, at, sym, xyz, chrg, uhf, lattice, pbc)
+     & (mol, at, sym, xyz, chrg, uhf, lattice, pbc)
+
+   interface
+      subroutine generate_wsc(mol,wsc)
+        import :: TMolecule, tb_wsc
+        type(TMolecule), intent(inout) :: mol
+        type(tb_wsc),    intent(inout) :: wsc
+      end subroutine generate_wsc
+   end interface
+
    type(TMolecule), intent(out) :: mol
    integer, intent(in) :: at(:)
    character(len=*), intent(in) :: sym(:)
@@ -532,7 +541,7 @@ subroutine mol_set_atomic_masses(self)
 end subroutine mol_set_atomic_masses
 
 !> wrap cartesian coordinates back into cell
-! 
+!
 !  This automatically done when calling @see xyz_to_abc, so we only have
 !  to perform the transformation there and back again
 subroutine wrap_back(self)

--- a/src/xtb/calculator.f90
+++ b/src/xtb/calculator.f90
@@ -27,6 +27,7 @@ module xtb_xtb_calculator
    use xtb_type_pcem
    use xtb_type_solvent, only : TSolvent
    use xtb_type_restart, only : TRestart
+   use xtb_type_wsc, only : tb_wsc
    use xtb_xtb_data, only : TxTBData
    use xtb_setparam
    use xtb_fixparam
@@ -39,6 +40,14 @@ module xtb_xtb_calculator
    use xtb_metadynamic
    use xtb_constrainpot
    implicit none
+   interface
+      subroutine generate_wsc(mol,wsc)
+        import :: TMolecule, tb_wsc
+        type(TMolecule), intent(inout) :: mol
+        type(tb_wsc),    intent(inout) :: wsc
+      end subroutine generate_wsc
+   end interface
+
    private
 
    public :: TxTBCalculator

--- a/src/xtb/calculator.f90
+++ b/src/xtb/calculator.f90
@@ -42,9 +42,9 @@ module xtb_xtb_calculator
    implicit none
    interface
       subroutine generate_wsc(mol,wsc)
-        import :: TMolecule, tb_wsc
-        type(TMolecule), intent(inout) :: mol
-        type(tb_wsc),    intent(inout) :: wsc
+         import :: TMolecule, tb_wsc
+         type(TMolecule), intent(inout) :: mol
+         type(tb_wsc),    intent(inout) :: wsc
       end subroutine generate_wsc
    end interface
 


### PR DESCRIPTION
The patch adds explicit interfaces for `generate_wsc`, as well as fixes a bug in `generate_wsc` that causes test failures on a number of architectures.