### PR TITLE
Flush output at end of write functions

### DIFF
--- a/src/io/writer.f90
+++ b/src/io/writer.f90
@@ -88,6 +88,8 @@ subroutine writeMolecule(self, unit, format, energy, gnorm, number)
       endif
    end select
 
+   ! Flush file so that the output file can be visualized during optimization
+   flush(unit)
 end subroutine writeMolecule
 
 


### PR DESCRIPTION
Output files aren't currently flushed, which makes it painstaking to follow progress of the optimization in xtb.

This PR adds `flush(unit)` at the ends of writer functions, allowing one to visualize e.g. `xtbopt.log` with Jmol or other programs.