### PR TITLE
Add tcl Environment Module

### DIFF
--- a/assets/meson.build
+++ b/assets/meson.build
@@ -44,4 +44,5 @@ install_data(
     configuration: config,
   ),
   rename: meson.project_version(),
+  install_dir: get_option('datadir')/'modules'/'modulefiles'/meson.project_name()
 )

--- a/assets/meson.build
+++ b/assets/meson.build
@@ -30,3 +30,18 @@ pkg_config = '@0@.pc'.format(meson.project_name())
 install_data(configure_file(input: files('templates'/pkg_config),
              output: pkg_config, configuration: config),
              install_dir: get_option('libdir')/'pkgconfig')
+
+# generate a tcl environment module
+# The convention is to name the file after the version and put it in a directory
+# with the program name, but we will name the intermediate tcl file differently.
+# On installation the file will be copied to the data_dir (share/xtb) and renamed
+# to the version number.
+env_module = '@0@.tcl'.format(meson.project_name())
+install_data(
+  configure_file(
+    input: files('templates/env-module.tcl'),
+    output: env_module,
+    configuration: config,
+  ),
+  rename: meson.project_version(),
+)

--- a/assets/templates/env-module.tcl
+++ b/assets/templates/env-module.tcl
@@ -1,0 +1,12 @@
+#%Module
+set prefix @prefix@
+
+module-whatis "@description@"
+
+prepend-path XTBPATH $prefix/@datadir@
+prepend-path PATH $prefix/@bindir@
+prepend-path MANPATH $prefix/@mandir@
+prepend-path PKG_CONFIG_PATH $prefix/@libdir@/pkgconfig
+
+# Only allow to load one instance of @name@
+conflict @name@


### PR DESCRIPTION
- [x] configure a tcl compatible module file and install it along with `xtb`
- [x] the module file is currently installed in the datadir (`$prefix/share/modules/modulefiles/xtb`)