### PR TITLE
Correct reading/writing of charge in CT files

### DIFF
--- a/src/io/reader/ctfile.f90
+++ b/src/io/reader/ctfile.f90
@@ -152,8 +152,8 @@ subroutine readMoleculeMolfile(mol, unit, status, iomsg)
       call getline(unit, line, error)
       if (index(line, 'M  END') == 1) exit
       if (index(line, 'M  CHG') == 1) then
-         read(line(7:10), *) length
-         read(line(11:), '(*(1x,i3,1x,i3))') (charge(:, i), i=1, length)
+         read(line(7:9), *) length
+         read(line(10:), '(*(1x,i3,1x,i3))') (charge(:, i), i=1, length)
          do i = 1, length
             mol%sdf(charge(1, i))%charge = charge(2, i)
          enddo

--- a/src/io/writer/ctfile.f90
+++ b/src/io/writer/ctfile.f90
@@ -87,8 +87,8 @@ subroutine writeMoleculeMolfile(mol, unit, comment_line)
 
    do iatom = 1, mol%n
       if (has_sdf_data) then
-         list12 = [mol%sdf(iatom)%isotope, charge_to_ccc(mol%sdf(iatom)%charge), &
-            &      0, 0, 0, mol%sdf(iatom)%valence, 0, 0, 0, 0, 0, 0]
+         list12 = [mol%sdf(iatom)%isotope, 0, 0, 0, 0, mol%sdf(iatom)%valence, &
+            & 0, 0, 0, 0, 0, 0]
       else
          list12 = 0
       endif
@@ -102,9 +102,22 @@ subroutine writeMoleculeMolfile(mol, unit, comment_line)
          & iatoms, list4
    enddo
 
-   if (nint(mol%chrg) /= 0) then
-      write(unit, '(a,*(1x,i3))') "M  CHG", 1, 1, nint(mol%chrg)
-   endif
+   if (has_sdf_data) then
+      if (sum(mol%sdf%charge) /= nint(mol%chrg)) then
+         write(unit, '(a,*(i3,1x,i3,1x,i3))') "M  CHG", 1, 1, nint(mol%chrg)
+      else
+         do iatom = 1, mol%n
+            if (mol%sdf(iatom)%charge /= 0) then
+               write(unit, '(a,*(i3,1x,i3,1x,i3))') &
+                  & "M  CHG", 1, iatom, mol%sdf(iatom)%charge
+            end if
+         end do
+      end if
+   else
+      if (nint(mol%chrg) /= 0) then
+         write(unit, '(a,*(i3,1x,i3,1x,i3))') "M  CHG", 1, 1, nint(mol%chrg)
+      end if
+   end if
 
    write(unit, '(a)') "M  END"
 


### PR DESCRIPTION
- prefer CHG blocks over entries in the atom charge fields
- raise warning in case the molecular charge is overwritten
- fix spacing in CHG block

closes #253