### PR TITLE
Allow to unset the solvation model in the API

### DIFF
--- a/src/api/calculator.f90
+++ b/src/api/calculator.f90
@@ -419,6 +419,9 @@ subroutine releaseSolvent_api(venv, vcalc) &
 
       if (allocated(calc%ptr)) then
          calc%ptr%lSolv = .false.
+         if (allocated(calc%ptr%solvation)) then
+            deallocate(calc%ptr%solvation)
+         end if
       end if
 
    end if


### PR DESCRIPTION
- deallocate `TSolvModel` object in calculator (setting `lSolv=.false.` is not sufficient anymore)