### PR TITLE
New keywords for not-solvation

### DIFF
--- a/src/main/setup.f90
+++ b/src/main/setup.f90
@@ -335,7 +335,8 @@ subroutine addSolvationModel(env, calc, input)
    end select
 
    if (allocated(input%solvent)) then
-      calc%lSolv = input%solvent /= 'none'
+      calc%lSolv = input%solvent /= 'none' .and. input%solvent /= 'gas' &
+         & .and. input%solvent /= 'vac'
    else
       calc%lSolv = .false.
    end if


### PR DESCRIPTION
Allow `"gas"` and `"vac"` as keywords for not-solvation