### PR TITLE
Access of uninitialized memory in gfn_eg. Fixes #276

### DIFF
--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -182,12 +182,10 @@ test('GFN0-xTB: SP  (PBC)', xtb_test, args: ['peeq', 'sp'], env: xtbenv, timeout
 test('GFN0-xTB: API (PBC)', xtb_test, args: ['peeq', 'api'], env: xtbenv, timeout: test_timeout)
 test('GFN0-xTB: SRB (PBC)', xtb_test, args: ['peeq', 'srb'], env: xtbenv, timeout: test_timeout)
 
-# Disable malloc perturbation to get reproducable GFN-FF runs
-gffenv = xtbenv
-test('GFN-FF: Basic', xtb_test, args: ['gfnff', 'basic'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: Solvation', xtb_test, args: ['gfnff', 'solvation'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: SP', xtb_test, args: ['gfnff', 'sp'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: HB', xtb_test, args: ['gfnff', 'hb'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: GBSA', xtb_test, args: ['gfnff', 'gbsa'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: Scale-up', xtb_test, args: ['gfnff', 'scaleup'], env: gffenv, timeout: test_timeout)
-test('GFN-FF: PDB', xtb_test, args: ['gfnff', 'pdb'], env: gffenv, timeout: test_timeout)
+test('GFN-FF: Basic', xtb_test, args: ['gfnff', 'basic'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: Solvation', xtb_test, args: ['gfnff', 'solvation'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: SP', xtb_test, args: ['gfnff', 'sp'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: HB', xtb_test, args: ['gfnff', 'hb'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: GBSA', xtb_test, args: ['gfnff', 'gbsa'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: Scale-up', xtb_test, args: ['gfnff', 'scaleup'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: PDB', xtb_test, args: ['gfnff', 'pdb'], env: xtbenv, timeout: test_timeout)

--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -184,7 +184,6 @@ test('GFN0-xTB: SRB (PBC)', xtb_test, args: ['peeq', 'srb'], env: xtbenv, timeou
 
 # Disable malloc perturbation to get reproducable GFN-FF runs
 gffenv = xtbenv
-gffenv.set('MALLOC_PERTURB_', '0')
 test('GFN-FF: Basic', xtb_test, args: ['gfnff', 'basic'], env: gffenv, timeout: test_timeout)
 test('GFN-FF: Solvation', xtb_test, args: ['gfnff', 'solvation'], env: gffenv, timeout: test_timeout)
 test('GFN-FF: SP', xtb_test, args: ['gfnff', 'sp'], env: gffenv, timeout: test_timeout)

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -151,6 +151,11 @@ contains
             endif
             srab (k)=sqrt(sqrab(k))
          enddo
+! The loop above only runs over the off diagonal elements
+! This initializes the unitialized diagonal to zero but does not
+! add it to the dispersion list.
+         sqrab(ij + i) = 0.0d0
+         srab(ij + i) = 0.0d0
       enddo
       if (pr) call timer%measure(1)
 


### PR DESCRIPTION
Bug #276 contained a rare invalid memory access bug, because part of a matrix was not zero initialized.

The issue was a missing initialization of the diagonals of a distance matrix in `gfn_eg`. This fixes the bug and removes invalid memory access in rare cases. It also turn memory perturbation on again by reverting part of a previous commit.

Unit tests run through, results.
```
Ok:                 8900
Expected Fail:      300 
Fail:               0   
Unexpected Pass:    0   
Skipped:            300 
Timeout:            0   
```

Before merging, the following has to be considered:
The loop I changed actually collects some ids in an array called
  `d3list`
I guess that this is present to collect the ids, which should be considered for d3 dispersion. I therefore did not extend the loop itself to `distance(i,i) == 0`, but rather let it run through until `distance(i,i-1)` and explicitly set the distance matrices zero for `distance(i,i)` without touching `d3list`.

Please consider, whether my interpretation of this was correct before merging.