### PR TITLE
typo correction in the help output. iteration should be iterations

### DIFF
--- a/src/xhelp.f90
+++ b/src/xhelp.f90
@@ -75,7 +75,7 @@ subroutine help
    "",&
    "   -a,--acc REAL     accuracy for SCC calculation, lower is better (default = 1.0)",&
    "",&
-   "      --iteration INT number of iterations in SCC (default = 250)",&
+   "      --iterations INT number of iterations in SCC (default = 250)",&
    "",&
    "      --cycles       number of cycles in ANCopt (default = automatic)",&
    "",&


### PR DESCRIPTION
Minor correction to help options output text
iteration corrected to iterations 