### PR TITLE
CMake support for library suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,8 +105,8 @@ install(FILES
 )
 install(TARGETS lib-xtb-static lib-xtb-shared xtb-exe
   EXPORT xtbTargets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib${LIB_SUFFIX}
+  ARCHIVE DESTINATION lib${LIB_SUFFIX}
   RUNTIME DESTINATION bin
 )
 # CMake package files


### PR DESCRIPTION
Allow use of library suffix on distributions that rely on it, e.g. `lib64` on Fedora and Red Hat, and `lib32` on Debian and Ubuntu.