### PR TITLE
Same header include directory in CMake as in meson.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ set_target_properties(lib-xtb-static PROPERTIES
 target_include_directories(lib-xtb-static
   PUBLIC
   $<BUILD_INTERFACE:${xtb-dir}/include>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/xtb>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
 )
 
 # Shared Library
@@ -75,7 +75,7 @@ set_target_properties(lib-xtb-shared PROPERTIES
 target_include_directories(lib-xtb-shared
   PUBLIC
   $<BUILD_INTERFACE:${xtb-dir}/include>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/xtb>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
 )
 
 # Executables
@@ -93,7 +93,7 @@ target_include_directories(xtb-exe PRIVATE "${xtb-dir}/include")
 
 # Install
 install(FILES "${xtb-dir}/include/xtb.h"
-  DESTINATION include/xtb/
+  DESTINATION include
 )
 install(FILES
   "${xtb-dir}/param_gfn0-xtb.txt"


### PR DESCRIPTION
CMake is placing the `xtb.h` header in `include/xtb/` whereas Meson installs them in `include/`; with this PR both install the header in `include/`.