### PR TITLE
Specify used languages in CMake project (no C++ needed).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.9)
 
 # Setup the XTB Project
 project(xtb
-   VERSION 6.3.2
+  VERSION 6.3.2
+  LANGUAGES C Fortran
 )
-enable_language(Fortran)
 enable_testing()
 
 set(xtb-dir "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
At present the `project` in CMake doesn't specify the used languages, which results in the default being used, which is C and C++. However, a C++ compiler is not needed for xtb.