### PR TITLE
Fix crash in get_environment_variable()

### DIFF
--- a/src/mctc/systools.F90
+++ b/src/mctc/systools.F90
@@ -155,13 +155,17 @@ subroutine rdvar(name,var,iostat)
          call raise('E','could not be allocated',1)
       endif
    endif
-   call get_environment_variable(name,var,status=err)
-   if (err.ne.0) then
-      if (present(iostat)) then
-         iostat = err
-         return
-      else
-         call raise('E','System variable corrupted',1)
+   ! If the environment variable has not been set, l=0, and the
+   ! following get_environment_variable call crashes.
+   if (l.gt.0) then
+      call get_environment_variable(name,var,status=err)
+      if (err.ne.0) then
+         if (present(iostat)) then
+            iostat = err
+            return
+         else
+            call raise('E','System variable corrupted',1)
+         endif
       endif
    endif
    if (present(iostat)) iostat=0


### PR DESCRIPTION
This PR solves a long-standing issue in xtb, mysterious crashes on the build systems in the check phase. After several hours of debugging, I've finally found the root problem.

The mysterious crashes were always due to `Fortran runtime error: Zero-length string passed as value to get_environment_variable.`

The problem is triggered whenever you read the value for a variable that is not set. In this case the length is 0, which is properly allocated, but then the GNU Fortran library crashes when the variable is read since the result array has zero length.

The problem was triggered in the tests, since neither CMake nor Meson sets `XTBHOME`.