### PR TITLE
Make CMake behave similar to meson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project(xtb
 )
 enable_testing()
 
+# Follow GNU conventions for installing directories
+include(GNUInstallDirs)
+
+# Include CMake specific configurations
 set(xtb-dir "${CMAKE_CURRENT_SOURCE_DIR}")
 add_subdirectory("cmake")
 
@@ -36,7 +40,7 @@ target_include_directories(xtb-object
   ${xtb-config-dir}
   ${CMAKE_CURRENT_BINARY_DIR}
   $<BUILD_INTERFACE:${xtb-dir}/include>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/xtb>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Static Library
@@ -51,12 +55,12 @@ set_target_properties(lib-xtb-static PROPERTIES
   Fortran_MODULE_DIRECTORY ${xtb-mod}
   ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
   POSITION_INDEPENDENT_CODE ON
-  OUTPUT_NAME xtb
+  OUTPUT_NAME "${PROJECT_NAME}"
 )
 target_include_directories(lib-xtb-static
   PUBLIC
   $<BUILD_INTERFACE:${xtb-dir}/include>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/xtb>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Shared Library
@@ -70,12 +74,14 @@ target_link_libraries(lib-xtb-shared
 set_target_properties(lib-xtb-shared PROPERTIES
   Fortran_MODULE_DIRECTORY ${xtb-mod}
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
-  OUTPUT_NAME xtb
+  OUTPUT_NAME "${PROJECT_NAME}"
+  VERSION "${PROJECT_VERSION}"
+  SOVERSION "${XTB_VERSION_MAJOR}"
 )
 target_include_directories(lib-xtb-shared
   PUBLIC
   $<BUILD_INTERFACE:${xtb-dir}/include>
-  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/xtb>
+  $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 # Executables
@@ -87,13 +93,13 @@ target_link_libraries(xtb-exe
 set_target_properties(xtb-exe PROPERTIES
   Fortran_MODULE_DIRECTORY ${xtb-mod}
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
-  OUTPUT_NAME xtb
+  OUTPUT_NAME "${PROJECT_NAME}"
 )
 target_include_directories(xtb-exe PRIVATE "${xtb-dir}/include")
 
 # Install
 install(FILES "${xtb-dir}/include/xtb.h"
-  DESTINATION include/xtb/
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 install(FILES
   "${xtb-dir}/param_gfn0-xtb.txt"
@@ -101,13 +107,14 @@ install(FILES
   "${xtb-dir}/param_gfn2-xtb.txt"
   "${xtb-dir}/param_ipea-xtb.txt"
   "${xtb-dir}/.param_gfnff.xtb"
-  DESTINATION share/xtb/
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
 )
 install(TARGETS lib-xtb-static lib-xtb-shared xtb-exe
   EXPORT xtbTargets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 # CMake package files
 include(CMakePackageConfigHelpers)
@@ -121,21 +128,21 @@ write_basic_package_version_file(
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/xtbConfig.cmake"
-  INSTALL_DESTINATION share/cmake/xtb
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 # -- Install config and configVersion
 install(
   FILES
   "${CMAKE_CURRENT_BINARY_DIR}/xtbConfig.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/xtbConfigVersion.cmake"
-  DESTINATION share/cmake/xtb
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 # -- Targets file
 # -- This makes the project importable from the build directory
 export(EXPORT xtbTargets FILE "${CMAKE_CURRENT_BINARY_DIR}/xtbTargets.cmake")
 # -- This makes the project importable from the install directory
 install(EXPORT xtbTargets FILE "xtbTargets.cmake"
-  DESTINATION share/cmake/xtb
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
 add_subdirectory("TESTSUITE")

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure the testsuite is running without errors.
 To install the `xtb` binaries to `/usr/local` use (might require `sudo`)
 
 ```bash
-ninja -C build_intel install
+ninja -C build install
 ```
 
 For more information on the build with meson see the instructions [here](./meson/README.adoc).
@@ -66,7 +66,7 @@ popd
 To install the `xtb` binaries to `/usr/local` use (might require `sudo`)
 
 ```bash
-make -C build_intel install
+make -C build install
 ```
 
 For more detailed information on the build with CMake see the instructions [here](./cmake/README.adoc).

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -15,6 +15,12 @@ set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} ${bounds}" PARENT_SC
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${dialect}" PARENT_SCOPE)
 
 
+# Program version, split to get major version for SOVERSION
+string(REGEX MATCHALL "[0-9]+" version-split "${PROJECT_VERSION}")
+list(GET version-split 0 XTB_VERSION_MAJOR)
+set(XTB_VERSION_MAJOR "${XTB_VERSION_MAJOR}" PARENT_SCOPE)
+
+
 # Populate xtb_version.fh
 set(version ${PROJECT_VERSION})
 execute_process(COMMAND git rev-parse HEAD
@@ -33,4 +39,5 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/xtb_version.fh"
   @ONLY
 )
+
 set(xtb-config-dir "${CMAKE_CURRENT_BINARY_DIR}" PARENT_SCOPE)

--- a/cmake/README.adoc
+++ b/cmake/README.adoc
@@ -126,3 +126,47 @@ ninja -C _build install
 
 If you have chosen make as generator use the same command with make.
 Depending on the installation prefix and your user rights ninja/make might ask for the `root` access to perform the installation.
+
+=== Advanced configuration of install destinations
+
+The CMake installation uses the install directories as defined by the https://www.gnu.org/prep/standards/html_node/Directory-Variables.html[GNU Coding Standards] and implemented in the https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html[`GNUInstallDirs`] module.
+To modify the behaviour configure CMake with
+
+[source,bash]
+----
+cmake _build \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_INSTALL_BINDIR=bin \
+  -DCMAKE_INSTALL_LIBDIR=lib \
+  -DCMAKE_INSTALL_INCLUDEDIR=include \
+  -DCMAKE_INSTALL_DATADIR=share \
+  -DCMAKE_INSTALL_MANDIR=man
+----
+
+This will result in a directory structure like
+
+[source]
+----
+usr
+├── bin
+│   └── xtb
+├── include
+│   └── xtb.h
+├── lib
+│   ├── cmake
+│   │   └── xtb
+│   │       ├── xtbConfig.cmake
+│   │       ├── xtbConfigVersion.cmake
+│   │       ├── xtbTargets.cmake
+│   │       └── xtbTargets-noconfig.cmake
+│   ├── libxtb.a
+│   ├── libxtb.so -> libxtb.so.6
+│   ├── libxtb.so.6 -> libxtb.so.6.3.2
+│   └── libxtb.so.6.3.2
+└── share
+    └── xtb
+        ├── param_gfn0-xtb.txt
+        ├── param_gfn1-xtb.txt
+        ├── param_gfn2-xtb.txt
+        └── param_ipea-xtb.txt
+----

--- a/meson/README.adoc
+++ b/meson/README.adoc
@@ -79,6 +79,7 @@ ninja -C build test
 
 All tests should pass, otherwise https://github.com/grimme-lab/xtb/issues/new/choose[open an issue].
 
+
 == Installing `xtb` with meson
 
 To use `xtb` in production or to pack a release with precompiled binaries the project should be installed with ninja.
@@ -97,6 +98,56 @@ ninja -C build install
 ----
 
 Depending on the installation prefix and your user rights ninja might ask for the `root` access to perform the installation.
+
+
+=== Advanced configuration of install destinations
+
+The installation uses the default install directories of the https://mesonbuild.com/Builtin-options.html[meson build system]
+To modify the behaviour configure meson with
+
+[source,bash]
+----
+meson build \
+  --prefix=/usr \
+  --bindir=bin \
+  --libdir=lib \
+  --includedir=include \
+  --datadir=share \
+  --mandir=man
+----
+
+This will result in a directory structure like
+
+[source]
+----
+usr
+├── bin
+│   └── xtb
+├── include
+│   └── xtb.h
+├── lib
+│   ├── libxtb.a
+│   ├── libxtb.so -> libxtb.so.6
+│   ├── libxtb.so.6 -> libxtb.so.6.3.2
+│   ├── libxtb.so.6.3.2
+│   └── pkgconfig
+│       └── xtb.pc
+└── share
+    ├── man
+    │   ├── man1
+    │   │   └── xtb.1
+    │   └── man7
+    │       └── xcontrol.7
+    ├── modules
+    │   └── modulefiles
+    │       └── xtb
+    │           └── 6.3.2
+    └── xtb
+        ├── param_gfn0-xtb.txt
+        ├── param_gfn1-xtb.txt
+        ├── param_gfn2-xtb.txt
+        └── param_ipea-xtb.txt
+----
 
 
 == Optimization Level

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,7 +17,7 @@
 
 option('la_backend', type: 'combo', value: 'mkl-static',
        choices: ['mkl', 'mkl-rt', 'mkl-static', 'openblas', 'netlib', 'custom'],
-       description : 'Linear algebra backend for program.')
+       description: 'Linear algebra backend for program.')
 option('custom_libraries', type: 'array', value: [],
        description: 'libraries to load for custom linear algebra backend')
 option('openmp', type: 'boolean', value: true,


### PR DESCRIPTION
- create SOVERSION and VERSION postfixed shared object
- use GNUInstallDir to get installation directories consistent to meson
- Update READMEs about installation configurations

closes #311, #312, #313 