### PR TITLE
Workaround for PGI 19.7 ICEing on norm2

### DIFF
--- a/src/bias_path.f90
+++ b/src/bias_path.f90
@@ -159,7 +159,7 @@ subroutine bias_path(env, mol, chk, calc, egap, et, maxiter, epot, grd, sigma)
    do i=1,mol%n
       cn(i)=0
       do j=1,mol%n
-         r=norm2(xyzp(:,i)-xyzp(:,j))
+         r=sqrt(sum(xyzp(:,i)-xyzp(:,j)))
          rco=(atomicRad(mol%at(i))+atomicRad(mol%at(j)))*autoaa
          if(r.lt.2.5*rco) then
             bo(j,i)=1


### PR DESCRIPTION
```
PGF90-S-0000-Internal compiler error. transform_call:Array Expression can't be here   79130  (../src/bias_path.f90: 162)
Lowering Error: bad ast optype in expression [ast=79582,asttype=12,datatype=0]
PGF90-F-0000-Internal compiler error. Errors in Lowering       1  (../src/bias_path.f90: 195)
PGF90/x86-64 Linux 19.10-0: compilation aborted
```

Fixed in PGI 20.1