### PR TITLE
Bug fix: Initialize qfrag for SDF and mol case in gfnff_setup  Resolves: #322

### DIFF
--- a/TESTSUITE/CMakeLists.txt
+++ b/TESTSUITE/CMakeLists.txt
@@ -159,6 +159,9 @@ add_test("GFN-FF_Solvation" ${XTB-TESTER} gfnff solvation)
 add_test("GFN-FF_SP" ${XTB-TESTER} gfnff sp)
 add_test("GFN-FF_HB" ${XTB-TESTER} gfnff hb)
 add_test("GFN-FF_GBSA" ${XTB-TESTER} gfnff gbsa)
+add_test("GFN-FF_Scale_up" ${XTB-TESTER} gfnff scaleup)
+add_test("GFN-FF_PDB" ${XTB-TESTER} gfnff pdb)
+add_test("GFN-FF_SDF" ${XTB-TESTER} gfnff sdf)
 
 add_test("CAPI" ${XTB-CTESTER})
 

--- a/TESTSUITE/gfnff.f90
+++ b/TESTSUITE/gfnff.f90
@@ -572,3 +572,79 @@ subroutine test_gfnff_pdb
    call terminate(afail)
 
 end subroutine test_gfnff_pdb
+
+
+subroutine test_gfnff_sdf
+   use assertion
+   use xtb_mctc_accuracy, only : wp
+   use xtb_test_molstock, only : getMolecule
+
+   use xtb_type_molecule
+   use xtb_type_param
+   use xtb_type_pcem
+   use xtb_type_data, only : scc_results
+   use xtb_type_environment, only : TEnvironment, init
+   use xtb_type_restart, only : TRestart
+
+   use xtb_gfnff_calculator, only : TGFFCalculator
+   use xtb_main_setup, only : newGFFCalculator, addSolvationModel
+   use xtb_solv_input, only : TSolvInput
+   use xtb_solv_kernel, only : gbKernel
+
+   use xtb_setparam, only : ichrg
+
+   implicit none
+
+   real(wp), parameter :: thr = 1.0e-8_wp
+
+   type(TEnvironment) :: env
+   type(TMolecule) :: mol
+   type(TRestart) :: chk
+   type(TGFFCalculator) :: calc
+   type(scc_results) :: res
+
+   integer :: iMol
+   logical :: exitRun
+   real(wp) :: energy, hl_gap, sigma(3, 3)
+   real(wp), allocatable :: gradient(:, :)
+   real(wp), parameter :: ref_energies(3) = &
+      &[-0.98330642628373_wp, -1.0751892050077_wp, -1.0752776712286_wp]
+   real(wp), parameter :: ref_gnorms(3) = &
+      &[0.11515550863614e-2_wp, 0.47224675049592e-2_wp, 0.47021127890168e-2_wp]
+
+   call init(env)
+   do iMol = 1, 3
+      if (afail > 0) exit
+
+      call getMolecule(mol, 'bug332')
+      ichrg = nint(mol%chrg)
+
+      if (allocated(gradient)) deallocate(gradient)
+      allocate(gradient(3, len(mol)))
+
+      call delete_file('charges')
+      call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false.)
+      if (iMol > 1) then
+         call addSolvationModel(env, calc, TSolvInput(solvent='h2o', &
+            & alpb=iMol==3, kernel=gbKernel%p16))
+      end if
+
+      call env%check(exitRun)
+      call assert(.not.exitRun)
+      if (exitRun) exit
+
+      call calc%singlepoint(env, mol, chk, 2, .false., energy, gradient, sigma, &
+         & hl_gap, res)
+
+      call env%check(exitRun)
+      call assert(.not.exitRun)
+      if (exitRun) exit
+
+      call assert_close(energy, ref_energies(iMol), thr)
+      call assert_close(norm2(gradient), ref_gnorms(iMol), thr)
+
+   end do
+
+   call terminate(afail)
+
+end subroutine test_gfnff_sdf

--- a/TESTSUITE/meson.build
+++ b/TESTSUITE/meson.build
@@ -189,3 +189,4 @@ test('GFN-FF: HB', xtb_test, args: ['gfnff', 'hb'], env: xtbenv, timeout: test_t
 test('GFN-FF: GBSA', xtb_test, args: ['gfnff', 'gbsa'], env: xtbenv, timeout: test_timeout)
 test('GFN-FF: Scale-up', xtb_test, args: ['gfnff', 'scaleup'], env: xtbenv, timeout: test_timeout)
 test('GFN-FF: PDB', xtb_test, args: ['gfnff', 'pdb'], env: xtbenv, timeout: test_timeout)
+test('GFN-FF: SDF', xtb_test, args: ['gfnff', 'sdf'], env: xtbenv, timeout: test_timeout)

--- a/TESTSUITE/molstock.f90
+++ b/TESTSUITE/molstock.f90
@@ -49,6 +49,7 @@ subroutine getMolecule(mol, name)
    case('remdesivir');  call remdesivir(mol)
    case('taxol');       call taxol(mol)
    case('pdb-4qxx');    call pdb_4qxx(mol)
+   case('bug332');      call bug332(mol)
    case('manganese');   call manganese(mol)
    case('vcpco4');      call vcpco4(mol)
    case('feco5');       call feco5(mol)
@@ -1021,6 +1022,61 @@ subroutine feco5(mol)
       & shape(xyz))
    call init(mol, sym, xyz)
 end subroutine feco5
+
+
+subroutine bug332(mol)
+   use xtb_mctc_filetypes, only : fileType
+   use xtb_type_vendordata, only : sdf_data
+   type(TMolecule), intent(out) :: mol
+   integer, parameter :: nat = 13
+   character(len=*), parameter :: sym(nat) = [character(len=4) ::&
+      & "O", "C", "C", "C", "C", "C", "N", "H", "H", "H", "H", "H", "H"]
+   real(wp), parameter :: xyz(3, nat) = reshape([&
+      &  2.81493577407313_wp, -4.24016708503309_wp, -0.05196746360567_wp,  &
+      &  1.60154274202939_wp, -2.27863154966258_wp, -0.01417294461973_wp,  &
+      &  2.83099844464216_wp,  0.08806122923725_wp,  0.44597532403414_wp,  &
+      &  1.46340377513576_wp,  2.31302456193979_wp,  0.48452573339981_wp,  &
+      & -1.07355331179575_wp,  2.33456743776178_wp,  0.09675396860402_wp,  &
+      & -2.54527188110842_wp, -0.01870828689804_wp, -0.38777176479579_wp,  &
+      & -0.96848454901482_wp, -2.31018997301585_wp, -0.41441690068088_wp,  &
+      &  4.85281623779525_wp,  0.06500657265582_wp,  0.75551243452903_wp,  &
+      &  2.44870688509933_wp,  4.07557195484931_wp,  0.83261325326035_wp,  &
+      & -2.07113964042975_wp,  4.12319304877160_wp,  0.14021766543785_wp,  &
+      & -3.51470129309789_wp,  0.11451739252741_wp, -2.22137285339888_wp,  &
+      & -4.00017188947235_wp, -0.25964834543344_wp,  1.07695481850448_wp,  &
+      & -1.83832540347633_wp, -4.00659695769996_wp, -0.74266229807381_wp], &
+      & shape(xyz))
+   integer, parameter :: bonds(3, 13) = reshape([ &
+      &  1,  2,  2,  &
+      &  2,  3,  1,  &
+      &  3,  4,  2,  &
+      &  3,  8,  1,  &
+      &  4,  5,  1,  &
+      &  4,  9,  1,  &
+      &  5,  6,  1,  &
+      &  5, 10,  1,  &
+      &  6,  7,  1,  &
+      &  6, 11,  1,  &
+      &  6, 12,  1,  &
+      &  7,  2,  1,  &
+      &  7, 13,  1], &
+      & shape(bonds))
+   integer, parameter :: charge_at = 5
+   real(wp), parameter :: charge = 1.0_wp
+   integer :: ibond
+
+   call init(mol, sym, xyz, chrg=charge)
+   mol%ftype = fileType%sdf
+
+   allocate(mol%sdf(nat), source=sdf_data())
+   mol%sdf(charge_at)%charge = nint(charge)
+
+   call mol%bonds%allocate(size=size(bonds, 2), order=size(bonds, 1))
+   do ibond = 1, size(bonds, 2)
+      call mol%bonds%push_back(bonds(:, ibond))
+   end do
+
+end subroutine bug332
 
 
 end module xtb_test_molstock

--- a/TESTSUITE/tests_peeq.f90
+++ b/TESTSUITE/tests_peeq.f90
@@ -105,6 +105,7 @@ program peeq_tester
       case('solvation'); call test_gfnff_mindless_solvation
       case('scaleup'); call test_gfnff_scaleup
       case('pdb'); call test_gfnff_pdb
+      case('sdf'); call test_gfnff_sdf
       case('sp');  call test_gfnff_sp
       case('hb');  call test_gfnff_hb
       case('gbsa');call test_gfnff_gbsa

--- a/src/gfnff/gfnff_setup.f90
+++ b/src/gfnff/gfnff_setup.f90
@@ -152,9 +152,6 @@ subroutine gfnff_input(env, mol, topo)
     end do
     ichrg=idint(sum(topo%qfrag(1:topo%nfrag)))
     write(env%unit,'(10x,"charge from pdb residues: ",i0)') ichrg
-    ! initialize qfrag as in the default case
-    topo%qfrag(1)=mol%chrg
-    topo%qfrag(2:mol%n)=0
   !--------------------------------------------------------------------
   ! SDF case
   case(fileType%sdf,fileType%molfile)

--- a/src/gfnff/gfnff_setup.f90
+++ b/src/gfnff/gfnff_setup.f90
@@ -152,6 +152,9 @@ subroutine gfnff_input(env, mol, topo)
     end do
     ichrg=idint(sum(topo%qfrag(1:topo%nfrag)))
     write(env%unit,'(10x,"charge from pdb residues: ",i0)') ichrg
+    ! initialize qfrag as in the default case
+    topo%qfrag(1)=mol%chrg
+    topo%qfrag(2:mol%n)=0
   !--------------------------------------------------------------------
   ! SDF case
   case(fileType%sdf,fileType%molfile)
@@ -191,6 +194,9 @@ subroutine gfnff_input(env, mol, topo)
         topo%nb(1,i)=k
       endif
     end do
+    ! initialize qfrag as in the default case
+    topo%qfrag(1)=mol%chrg
+    topo%qfrag(2:mol%n)=0
   !--------------------------------------------------------------------
   ! General case: input = xyz or coord
   case default


### PR DESCRIPTION
Added the initialization of the fragment charge qfrag for the sdf and mol file case as proposed by @awvwgk .
This seems to resolve the problem. I tested it for the given file.sdf, a self made molfile and for some few charges each.

