### PR TITLE
Remove check for __PGIC__ preprocessor in hessian

### DIFF
--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -203,7 +203,6 @@ subroutine numhess( &
       ! the non-frozen atoms and from nonfrozh+1:n the frozen ones also in
       ! ascending order
       ! now compute a subblock of the Hessian
-#ifndef __PGIC__
 ! PGI 20.7 produces invalid LLVM-IR with the following OpenMP directives
       !$ nproc = omp_get_num_threads()
       !$omp parallel default(shared) &
@@ -211,13 +210,10 @@ subroutine numhess( &
       !$omp private(ia,ic,ii,ja,jc,jj,eel,gr,gl,egap,sccr,sccl,sr,sl,chk,tmol) &
       !$omp shared (mol,h,dipd,pold,step,step2,t1,t0,w1,w0,indx,nonfrozh,env,calc,chk0)
       !$ call omp_set_num_threads(1)
-#endif
 #ifdef WITH_MKL
       !$ call mkl_set_num_threads(1)
 #endif
-#ifndef __PGIC__
       !$omp do schedule(dynamic)
-#endif
       do a = 1, nonfrozh
          ia=indx(a)
          do ic = 1, 3
@@ -256,11 +252,9 @@ subroutine numhess( &
                & 0.3333333d0*nonfrozh*(w1-w0)/60.
          endif
       enddo
-#ifndef __PGIC__
       !$omp end do
       !$omp end parallel
       !$ call omp_set_num_threads(nproc)
-#endif
 #ifdef WITH_MKL
       !$ call mkl_set_num_threads(nproc)
 #endif
@@ -269,7 +263,6 @@ subroutine numhess( &
 !! ------------------------------------------------------------------------
 !  normal case
 !! ------------------------------------------------------------------------
-#ifndef __PGIC__
 ! PGI 20.7 produces invalid LLVM-IR with the following OpenMP directives
       !$ nproc = omp_get_num_threads()
       !$omp parallel default(shared) &
@@ -277,13 +270,10 @@ subroutine numhess( &
       !$omp private(ia,ic,ii,ja,jc,jj,eel,gr,gl,egap,sccr,sccl,sr,sl,chk,tmol) &
       !$omp shared (mol,h,dipd,pold,step,step2,t1,t0,w1,w0,xyzsave,env,calc,chk0)
       !$ call omp_set_num_threads(1)
-#endif
 #ifdef WITH_MKL
       !$ call mkl_set_num_threads(1)
 #endif
-#ifndef __PGIC__
       !$omp do schedule(dynamic)
-#endif
       do ia = 1, mol%n
          do ic = 1, 3
             ii = (ia-1)*3+ic
@@ -331,11 +321,9 @@ subroutine numhess( &
                & 0.3333333d0*mol%n*(w1-w0)/60.
          endif
       enddo
-#ifndef __PGIC__
       !$omp end do
       !$omp end parallel
       !$ call omp_set_num_threads(nproc)
-#endif
 #ifdef WITH_MKL
       !$ call mkl_set_num_threads(nproc)
 #endif


### PR DESCRIPTION
`#ifndef __PGIC__` does break parallelisation with other compilers