### PR TITLE
Fixes incorrect basename detection when path does not contain '/'

### DIFF
--- a/src/mctc/filetypes.f90
+++ b/src/mctc/filetypes.f90
@@ -156,6 +156,16 @@ subroutine generateFileMetaInfo(Name, path, basename, extension)
    iDot = index(name, '.', back=.true.)
    iSlash = index(name, '/', back=.true.)
 
+   ! When given a name like "Gau-3333.Ein", the basename should be "Gau-3333",
+   ! so if there is no '/', we assume there is an implicit './' at the
+   ! beginning of name.
+   if (iSlash > 0) then
+      path = name(:iSlash)
+   else
+      path = ''
+      iSlash = 0
+   endif
+
    if (iDot > iSlash .and. iDot > 0) then
       extension = name(iDot+1:)
    else ! means point is somewhere in the path or absent
@@ -163,17 +173,12 @@ subroutine generateFileMetaInfo(Name, path, basename, extension)
       extension = ''
    endif
 
-   if (iDot > iSlash .and. iSlash > 0) then
+   if (iDot > iSlash) then
       basename = name(iSlash+1:iDot-1)
    else
       basename = ''
    endif
 
-   if (iSlash > 0) then
-      path = name(:iSlash)
-   else
-      path = ''
-   endif
 
 end subroutine generateFileMetaInfo
 

--- a/src/mctc/filetypes.f90
+++ b/src/mctc/filetypes.f90
@@ -163,7 +163,6 @@ subroutine generateFileMetaInfo(Name, path, basename, extension)
       path = name(:iSlash)
    else
       path = ''
-      iSlash = 0
    endif
 
    if (iDot > iSlash .and. iDot > 0) then


### PR DESCRIPTION
As of now, if the initial geometry file is given as a relative path without any / in it, the basename is empty. For example, running 

    xtb Gau-1234.EIn

generates an output file at `.EOu` as opposed to the correct `Gau-1234.EOu`, because the basename is not detected and defaults to the empty string. Running

    xtb ./Gau-1234.EIn

works fine however.

This very small PR fixes this by explicitly setting the position of the / (when it's not there) to just before the beginning of the filename (pos 0).