### PR TITLE
Add CI workflow for MinGW compiler toolchains

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -26,3 +26,45 @@ jobs:
       run: meson test -C _build --print-errorlogs --no-rebuild
       env:
         OMP_NUM_THREADS: 2,1
+
+  # Test native MinGW Windows build
+  mingw-build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: [
+          { msystem: MINGW64, arch: x86_64 },
+          { msystem: MINGW32, arch: i686   }
+        ]
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: ${{ matrix.msystem }}
+        update: false
+        install: >-
+          git
+          mingw-w64-${{ matrix.arch }}-gcc-fortran
+          mingw-w64-${{ matrix.arch }}-openblas
+          mingw-w64-${{ matrix.arch }}-lapack
+          mingw-w64-${{ matrix.arch }}-meson
+          mingw-w64-${{ matrix.arch }}-ninja
+
+    - name: Configure build
+      run: meson setup _build -Dla_backend=netlib --warnlevel=0
+      env:
+        FC: gfortran
+        CC: gcc
+
+    - name: Build library
+      run: meson compile -C _build
+
+    - name: Run unit tests
+      run: meson test -C _build --print-errorlogs --no-rebuild
+      env:
+        OMP_NUM_THREADS: 2,1

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ This is the offical repository of the `xtb` program package developed by the Gri
 Statically linked binaries (Intel Compiler 17.0.7) can be found at the [latest release page](https://github.com/grimme-lab/xtb/releases/latest).
 There is also a version of the shared library, which requires the Math Kernel Library and additional Intel specific libraries to be installed.
 
-`xtb` is routinely compiled with Intel Parallel Studio 17 on our clusters in Bonn, successful builds on OSX have been performed as well.
-To compile on Windows we recommend the MinGW toolchain (installable with [MSYS2](https://msys2.org)), or if a POSIX environment is preferred [Cygwin](https://cygwin.com).
-It is also possible to compile `xtb` with GCC (version 8), but we recommend to use binaries compiled with Intel.
+`xtb` is routinely compiled with Intel Parallel Studio 17 and newer on our clusters in Bonn.
+It is also possible to compile `xtb` with GCC (version 7.5 or newer), but we recommend to use binaries compiled with Intel.
+Successful builds on OSX with GCC via homebrew have been performed as well.
+The NVHPC compilers (version 20.9) can be used to compile for CPU and GPU.
+To compile on Windows we recommend the MinGW toolchain (installable with [MSYS2](https://msys2.org)) or, if a POSIX environment is preferred, with [Cygwin](https://cygwin.com).
+It has been reported that `xtb` can be compiled using Intel Fortran on Windows as well, but official support is not yet established.
 
 This projects supports two build systems, meson and CMake.
 A short guide on the usage of each is given here, follow the linked instructions for a more detailed information ([meson guide](./meson/README.adoc), [CMake guide](./cmake/README.adoc)).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Statically linked binaries (Intel Compiler 17.0.7) can be found at the [latest r
 There is also a version of the shared library, which requires the Math Kernel Library and additional Intel specific libraries to be installed.
 
 `xtb` is routinely compiled with Intel Parallel Studio 17 on our clusters in Bonn, successful builds on OSX have been performed as well.
-We have not tried to build `xtb` on Windows so far.
+To compile on Windows we recommend the MinGW toolchain (installable with [MSYS2](https://msys2.org)), or if a POSIX environment is preferred [Cygwin](https://cygwin.com).
 It is also possible to compile `xtb` with GCC (version 8), but we recommend to use binaries compiled with Intel.
 
 This projects supports two build systems, meson and CMake.


### PR DESCRIPTION
Notes for `xtb` on Windows:
- [cygwin](https://cygwin.com) POSIX environment can compile `xtb`.
  - required packages: `gcc`, `gcc-fortran`, `libopenblas`, `lapack`, `meson`, `ninja`
  - configure: `meson setup _build_gcc -Dla_backend=netlib`
- [MSYS2](https://msys2.org)
  - msys POSIX environment does not work (`openblas`, `lapack` packages missing), use cygwin if you want a POSIX environment for `xtb`
  - MinGW native compilation works
  - required packages: `mingw-w64-*-gcc-fortran`, `mingw-w64-*-openblas`, `mingw-w64-*-lapack`, `mingw-w64-*-meson`, `mingw-w64-*-ninja`
  - configure: `meson setup _build_gcc -Dla_backend=netlib`

Closes https://github.com/grimme-lab/xtb/pull/296