### PR TITLE
Intel oneAPI testing + continuous delivery

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -2,13 +2,27 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  osx-build:
-    runs-on: macos-latest
+  gcc-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+        fc: [gfortran-9]
+        cc: [gcc-9]
+
+    env:
+      FC: ${{ matrix.fc }}
+      CC: ${{ matrix.cc }}
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
       with:
-        python-version: '3.x'
+        python-version: 3.x
 
     - name: Install meson
       run: pip3 install meson==0.55.3 ninja
@@ -19,7 +33,7 @@ jobs:
         FC: gfortran-9
         CC: gcc-9
 
-    - name: Build library
+    - name: Build project
       run: meson compile -C _build
 
     - name: Run unit tests
@@ -41,9 +55,11 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v2
 
-    - uses: msys2/setup-msys2@v2
+    - name: Setup MSYS2 toolchain
+      uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.msystem }}
         update: false
@@ -61,10 +77,147 @@ jobs:
         FC: gfortran
         CC: gcc
 
-    - name: Build library
+    - name: Build project
       run: meson compile -C _build
 
     - name: Run unit tests
       run: meson test -C _build --print-errorlogs --no-rebuild
       env:
         OMP_NUM_THREADS: 2,1
+
+  intel-build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        fc: [ifort]
+        cc: [icc]
+    env:
+      FC: ${{ matrix.fc }}
+      CC: ${{ matrix.cc }}
+      APT_PACKAGES: >-
+        intel-oneapi-compiler-fortran
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        intel-oneapi-mkl
+        intel-oneapi-mkl-devel
+        meson
+        asciidoctor
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
+
+    - name: Add Intel repository
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
+
+    - name: Install Intel oneAPI compiler
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get install ${APT_PACKAGES}
+        source /opt/intel/oneapi/setvars.sh
+        printenv >> $GITHUB_ENV
+
+    - name: Configure meson build
+      run: meson setup build --prefix=/ -Dfortran_args=-qopenmp
+
+    - name: Build project
+      run: ninja -C build
+
+    - name: Run unit tests
+      run: meson test -C build --print-errorlogs --no-rebuild
+      env:
+        OMP_NUM_THREADS: 2,1
+
+    - name: Install package
+      run: |
+        meson install -C build --no-rebuild
+        tar cJvf xtb-bleed.tar.xz xtb-bleed
+      env:
+        DESTDIR: ${{ env.PWD }}/xtb-bleed
+
+    - name: Upload binary
+      if: github.event_name == 'push'
+      uses: actions/upload-artifact@v2
+      with:
+        name: xtb-bleed.tar.xz
+        path: xtb-bleed.tar.xz
+
+  # Inspired from https://github.com/endless-sky/endless-sky
+  continuous-delivery:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs:
+      - intel-build
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: bleed
+      OUTPUT_INTEL: xtb-bleed.tar.xz
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install github-release
+      run: |
+        go get github.com/github-release/github-release
+        echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+    - name: Set environment variables
+      run: |
+        echo "GITHUB_USER=$( echo ${{ github.repository }} | cut -d/ -f1 )" >> $GITHUB_ENV
+        echo "GITHUB_REPO=$( echo ${{ github.repository }} | cut -d/ -f2 )" >> $GITHUB_ENV
+
+    - name: Move/Create continuous tag
+      run: |
+        git tag --force ${{ env.RELEASE_TAG }} ${{ github.sha }}
+        git push --tags --force
+
+    - name: Get Time
+      run: echo "TIME=$(date -u '+%Y/%m/%d, %H:%M')" >> $GITHUB_ENV
+
+    - name: Check continuous release status
+      run: |
+        if ! github-release info -t ${{ env.RELEASE_TAG }} > /dev/null 2>&1; then
+          echo "RELEASE_COMMAND=release" >> $GITHUB_ENV
+        else
+          echo "RELEASE_COMMAND=edit" >> $GITHUB_ENV
+        fi
+
+    - name: Setup continuous release
+      run: >-
+        github-release ${{ env.RELEASE_COMMAND }}
+        --tag ${{ env.RELEASE_TAG }}
+        --name "Bleeding edge version"
+        --description "$DESCRIPTION"
+        --pre-release
+      env:
+        DESCRIPTION: |
+          Created on ${{ env.TIME }} UTC by @${{ github.actor }} with commit ${{ github.sha }}.
+          This is an automated distribution of the latest `xtb` version. This version is only minimally tested and may be unstable or even crash. Use with caution!
+          https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v2
+      with:
+        path: ${{ github.workspace }} # This will download all files
+
+    - name: Add ${{ env.OUTPUT_INTEL }} to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name ${{ env.OUTPUT_INTEL }}
+        --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -214,6 +214,11 @@ jobs:
       with:
         path: ${{ github.workspace }} # This will download all files
 
+    - name: Create SHA256 checksum
+      run: |
+        cd ${{ env.OUTPUT_INTEL }}
+        sha256sum ${{ env.OUTPUT_INTEL }} > sha256.txt
+
     - name: Add ${{ env.OUTPUT_INTEL }} to release tag
       run: >-
         github-release upload
@@ -221,3 +226,11 @@ jobs:
         --replace
         --name ${{ env.OUTPUT_INTEL }}
         --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}
+
+    - name: Add SHA256 checksums to release tag
+      run: >-
+        github-release upload
+        --tag ${{ env.RELEASE_TAG }}
+        --replace
+        --name sha256.txt
+        --file ${{ env.OUTPUT_INTEL }}/sha256.txt

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This is the offical repository of the `xtb` program package developed by the Gri
 
 Statically linked binaries (Intel Compiler 17.0.7) can be found at the [latest release page](https://github.com/grimme-lab/xtb/releases/latest).
 There is also a version of the shared library, which requires the Math Kernel Library and additional Intel specific libraries to be installed.
+Bleeding edge releases of the latest source from this repository are available on the [continuous release tag](https://github.com/grimme-lab/xtb/releases/tag/bleed).
 
 `xtb` is routinely compiled with Intel Parallel Studio 17 and newer on our clusters in Bonn.
 It is also possible to compile `xtb` with GCC (version 7.5 or newer), but we recommend to use binaries compiled with Intel.


### PR DESCRIPTION
This PR adds a GitHub actions workflow for the Intel oneAPI classic compilers. The procedure to produce used in the workflow is similar enough to the setup I usually use to produce the release version, meaning the resulting version should be suitable to perform production calculations. Therefore, this PR also adds a continuous delivery of statically linked Intel binaries as cutting/bleeding edge version as well (use them with extra caution).

The workflow will run on every fork enabling GH actions and allows you to create Intel compiled releases on your development branches as well. For an example see: https://github.com/awvwgk/xtb/releases/tag/bleed