### PR TITLE
Implement support for ELPA solver

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -147,6 +147,24 @@ if get_option('openmp')
   dependencies += omp_dep
 endif
 
+if get_option('elpa') != 'none'
+  if get_option('openmp')
+    elpa_dep = dependency('elpa_onenode_openmp-@0@'.format(get_option('elpa')))
+  else
+    elpa_dep = dependency('elpa_onenode-@0@'.format(get_option('elpa')))
+  endif
+  if not fc.compiles('use elpa; end', dependencies: elpa_dep)
+    # Unfortunately, we have to hack this to get the include directory from fcflags
+    elpa_inc = elpa_dep.get_pkgconfig_variable('fcflags').split(' ')[0].split('-I')[-1].strip()
+    elpa_dep = declare_dependency(
+      include_directories: include_directories(elpa_inc),
+      dependencies: elpa_dep,
+    )
+  endif
+  dependencies += elpa_dep
+  add_project_arguments('-DWITH_ELPA', language: 'fortran')
+endif
+
 dependencies += dependency('threads')
 
 if get_option('nvtx')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,6 +28,9 @@ option('build_name', type: 'string', value: 'unknown',
        description: 'Name of the build, will be overwritten automatically by git')
 option('test_timeout', type: 'integer', min: 1, value: 30,
        description: 'test timeout in seconds')
+option('elpa', type: 'combo', value: 'none',
+       choices: ['none', '2020.11.001'],
+       description: 'Version of the ELPA library to use')
 
 # GPU specific options
 option('gpu', type: 'boolean', value: false,

--- a/src/mctc/CMakeLists.txt
+++ b/src/mctc/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND srcs
   "${dir}/boundaryconditions.f90"
   "${dir}/chartools.f90"
   "${dir}/convert.f90"
+  "${dir}/elpa.F90"
   "${dir}/filetypes.f90"
   "${dir}/io.f90"
   "${dir}/math.f90"

--- a/src/mctc/elpa.F90
+++ b/src/mctc/elpa.F90
@@ -1,0 +1,169 @@
+! This file is part of xtb.
+!
+! Copyright (C) 2021 Sebastian Ehlert
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+!> Proxy module to use the ELPA library, provides stubs when disabled
+module xtb_mctc_elpa
+   use xtb_mctc_accuracy, only : sp, dp
+   use xtb_type_environment, only : TEnvironment
+#ifdef WITH_ELPA
+   use elpa, only : elpa_t, elpa_init, elpa_allocate, elpa_deallocate, elpa_ok
+#endif
+!$ use omp_lib, only : omp_get_num_threads
+   implicit none
+   private
+   public :: TELPASolver, initELPASolver
+
+   type :: TELPASolver
+      private
+#ifdef WITH_ELPA
+      class(elpa_t), pointer :: elpa => null()
+#endif
+      integer :: n
+      real(sp), allocatable :: sbmat(:, :)
+      real(dp), allocatable :: dbmat(:, :)
+      real(sp), allocatable :: sevec(:, :)
+      real(dp), allocatable :: devec(:, :)
+   contains
+      generic :: solve => sgen_solve, dgen_solve
+      procedure :: sgen_solve
+      procedure :: dgen_solve
+      final :: finalizeELPA
+   end type TELPASolver
+
+   logical, save :: elpa_initialized = .false.
+
+contains
+
+subroutine initELPASolver(self, env, bmat)
+   character(len=*), parameter :: source = "mctc_elpa_newELPA"
+   type(TELPASolver), intent(out) :: self
+   type(TEnvironment), intent(inout) :: env
+   real(dp), intent(in) :: bmat(:, :)
+   integer :: stat
+
+#ifdef WITH_ELPA
+   if (.not.elpa_initialized) then
+      if (elpa_init(20200417) /= elpa_ok) then
+         call env%error("Cannot initialize ELPA library", source)
+         return
+      end if
+      elpa_initialized = .true.
+   end if
+
+   self%elpa => elpa_allocate(stat)
+   if (stat /= elpa_ok) then
+      call env%error("Cannot allocate new ELPA object", source)
+      return
+   end if
+
+   self%n = size(bmat, 1)
+   allocate(self%dbmat(self%n, self%n))
+   allocate(self%devec(self%n, self%n))
+
+   call self%elpa%set("na", self%n, stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set na failed", source)
+      return
+   end if
+   call self%elpa%set("nev", self%n, stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set nev failed", source)
+      return
+   end if
+   call self%elpa%set("local_nrows", self%n, stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set local_nrows failed", source)
+      return
+   end if
+   call self%elpa%set("local_ncols", self%n, stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set local_ncols failed", source)
+      return
+   end if
+   call self%elpa%set("nblk", self%n, stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set nblk failed", source)
+      return
+   end if
+!$ call self%elpa%set("omp_threads", omp_get_num_threads(), stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA set omp_threads failed", source)
+      return
+   end if
+
+   stat = self%elpa%setup()
+   if (stat /= elpa_ok) then
+      call env%error("ELPA setup failed", source)
+      return
+   end if
+#endif
+
+end subroutine initELPASolver
+
+subroutine dgen_solve(self, env, amat, bmat, eval)
+   character(len=*), parameter :: source = "mctc_elpa_solve"
+   class(TELPASolver), intent(inout) :: self
+   type(TEnvironment), intent(inout) :: env
+   real(dp), intent(inout) :: amat(:, :)
+   real(dp), intent(in) :: bmat(:, :)
+   real(dp), intent(out) :: eval(:)
+   integer :: stat
+
+   self%dbmat(:, :) = bmat
+#ifdef WITH_ELPA
+   call self%elpa%generalized_eigenvectors(amat, self%dbmat, eval, self%devec, &
+      & .false., stat)
+   if (stat /= elpa_ok) then
+      call env%error("ELPA eigenvalue solver failed", source)
+      return
+   end if
+#endif
+   amat(:, :) = self%devec
+
+end subroutine dgen_solve
+
+subroutine sgen_solve(self, env, amat, bmat, eval)
+   character(len=*), parameter :: source = "mctc_elpa_solve"
+   class(TELPASolver), intent(inout) :: self
+   type(TEnvironment), intent(inout) :: env
+   real(sp), intent(inout) :: amat(:, :)
+   real(sp), intent(in) :: bmat(:, :)
+   real(sp), intent(out) :: eval(:)
+   integer :: stat
+
+   self%sbmat(:, :) = bmat
+#ifdef WITH_ELPA
+   call self%elpa%generalized_eigenvectors(amat, self%sbmat, eval, self%sevec, &
+      & .false., stat)
+   if (stat /= elpa_ok) then
+   end if
+#endif
+   amat(:, :) = self%sevec
+
+end subroutine sgen_solve
+
+subroutine finalizeELPA(self)
+   type(TELPASolver) :: self
+
+#ifdef WITH_ELPA
+   if (elpa_initialized) then
+      if (associated(self%elpa)) call elpa_deallocate(self%elpa)
+   end if
+#endif
+end subroutine finalizeELPA
+
+end module xtb_mctc_elpa

--- a/src/mctc/meson.build
+++ b/src/mctc/meson.build
@@ -24,6 +24,7 @@ srcs += files(
   'boundaryconditions.f90',
   'chartools.f90',
   'convert.f90',
+  'elpa.F90',
   'filetypes.f90',
   'io.f90',
   'math.f90',


### PR DESCRIPTION
This PR implements support for the ELPA solver (onenode and onenode_openmp variant). Tested with GCC toolchain and ELPA 2020.11.001. No successful build with Intel toolchain so far.

For small systems (taxol, 113 atoms @ 2 core Sky Lake) the ELPA solver can be by a factor two slower for than the MKL solver.

The main issue results from a portion of ELPA which is running always sequentially on a single process with multiple threads. This breaks the efficiency for multi-threaded applications. Maybe it is possible to select a threaded algorithm instead and get a fully threaded ELPA run.

Needs further investigation.