### PR TITLE
Make commandline for threaded and sequential builds consistent

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -72,13 +72,22 @@ if la_backend == 'mkl' or la_backend == 'mkl-static'
 
   if fc.get_id() == 'gcc'
     libmkl_exe = [fc.find_library('mkl_gf_lp64')]
-    libmkl_exe += fc.find_library('mkl_gnu_thread')
+    if get_option('openmp')
+      libmkl_exe += fc.find_library('mkl_gnu_thread')
+    endif
   elif fc.get_id() == 'intel'
     libmkl_exe = [fc.find_library('mkl_intel_lp64')]
-    libmkl_exe += fc.find_library('mkl_intel_thread')
+    if get_option('openmp')
+      libmkl_exe += fc.find_library('mkl_intel_thread')
+    endif
   elif fc.get_id() == 'pgi' or fc.get_id() == 'nvidia_hpc'
     libmkl_exe = [fc.find_library('mkl_intel_lp64')]
-    libmkl_exe += fc.find_library('mkl_pgi_thread')
+    if get_option('openmp')
+      libmkl_exe += fc.find_library('mkl_pgi_thread')
+    endif
+  endif
+  if not get_option('openmp')
+    libmkl_exe += fc.find_library('mkl_sequential')
   endif
   libmkl_exe += fc.find_library('mkl_core')
   lib_deps += mkl_rt_dep

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -1164,8 +1164,12 @@ subroutine parseArguments(env, args, inputFile, paramFile, accuracy, lgrad, &
       case(     '--define')
          call set_define
 
-   !$ case('-P','--parallel')
-   !$    call args%nextArg(sec)
+      case('-P','--parallel')
+   !$    if (.false.) then
+            call env%warning('Program compiled without threading support', source)
+   !$    endif
+         ! Always remove next argument to keep argument parsing consistent
+         call args%nextArg(sec)
    !$    if (allocated(sec)) then
    !$    if (getValue(env,sec,idum)) then
    !$       nproc = omp_get_num_threads()


### PR DESCRIPTION
- print a warning on sequential builds if -P option is encountered
- pop argument of -P option from argparser to make command line consistent