### PR TITLE
Fix point charge embedding calculations

### DIFF
--- a/src/main/defaults.f90
+++ b/src/main/defaults.f90
@@ -18,7 +18,6 @@
 !> Initialize default values for global variables
 module xtb_main_defaults
    use xtb_mctc_accuracy, only : wp
-   use xtb_embedding, only : init_pcem
    use xtb_type_calculator, only : TCalculator
    use xtb_type_environment, only : TEnvironment
    use xtb_type_molecule, only : TMolecule
@@ -53,9 +52,6 @@ subroutine initDefaults(env, calc, mol, gsolvstate)
 
    ! Optionally add a solvation model
    call addSolvationModel(env, calc, solvInput)
-
-   ! initialize PC embedding (set default file names and stuff)
-   call init_pcem
 
 end subroutine initDefaults
 

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -351,6 +351,7 @@ subroutine xtbMain(env, argParser)
    call init_constr(mol%n,mol%at)
    call init_scan
    call init_walls
+   call init_pcem
    if (runtyp.eq.p_run_bhess) then
       call init_bhess(mol%n)
    else


### PR DESCRIPTION
- move default initialization of pcem input

Fixes https://github.com/grimme-lab/xtb/issues/374