### PR TITLE
Bump program version to 6.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 
 # Setup the XTB Project
 project(xtb
-  VERSION 6.3.3
+  VERSION 6.4.0
   LANGUAGES C Fortran
 )
 enable_testing()

--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@
 project(
   'xtb',
   'fortran', 'c',
-  version: '6.3.3',
+  version: '6.4.0',
   license: 'LGPL3',
   meson_version: '>=0.51',
   default_options: [


### PR DESCRIPTION
Finally, we are getting close to a new feature release (was about time). The release will be created shortly after this PR is merged.

*Release checklist*

- [x] Version is bumped in meson build file
- [x] Version is bumped in CMake build file
- [x] Conda-forge feedstock is tested for new version (see https://github.com/conda-forge/xtb-feedstock/pull/20)
- [x] xtb-python updates the xtb submodule correctly (https://github.com/grimme-lab/xtb-python/pull/43)
- [ ] Release version is compiled on cluster and checked internally (in progress)