### PR TITLE
Fix caching logic in Turbomole calculator

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -115,8 +115,12 @@ jobs:
           mingw-w64-${{ matrix.arch }}-gcc-fortran
           mingw-w64-${{ matrix.arch }}-openblas
           mingw-w64-${{ matrix.arch }}-lapack
-          mingw-w64-${{ matrix.arch }}-meson
+          mingw-w64-${{ matrix.arch }}-python
+          mingw-w64-${{ matrix.arch }}-python-pip
           mingw-w64-${{ matrix.arch }}-ninja
+
+    - name: Install meson
+      run: pip install meson==0.56
 
     - name: Configure build
       run: meson setup ${{ env.BUILD_DIR }} -Dla_backend=netlib --warnlevel=0

--- a/src/extern/turbomole.f90
+++ b/src/extern/turbomole.f90
@@ -39,7 +39,7 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lsolv)
       inquire(file='gradient', exist=exist)
       if (exist .and. grd) then
          call rdtm(n,grd,eel,g,xyz_cached)
-         cache = any(abs(xyz_cached - xyz) < 1.e-10_wp)
+         cache = all(abs(xyz_cached - xyz) < 1.e-10_wp)
       end if
       if (.not.cache) then
          call wrtm(n,at,xyz)
@@ -60,7 +60,7 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lsolv)
       inquire(file='gradient', exist=exist)
       if (exist .and. grd) then
          call rdtm(n,grd,eel,g,xyz_cached)
-         cache = any(abs(xyz_cached - xyz) < 1.e-10_wp)
+         cache = all(abs(xyz_cached - xyz) < 1.e-10_wp)
       end if
       if (.not.cache) then
          call wrtm(n,at,xyz)
@@ -83,7 +83,7 @@ subroutine external_turbomole(n,at,xyz,nel,nopen,grd,eel,g,dip,lsolv)
       inquire(file='gradient', exist=exist)
       if (exist .and. grd) then
          call rdtm(n,grd,eel,g,xyz_cached)
-         cache = any(abs(xyz_cached - xyz) < 1.e-10_wp)
+         cache = all(abs(xyz_cached - xyz) < 1.e-10_wp)
       end if
       if (.not.cache) then
          call wrtm(n,at,xyz)


### PR DESCRIPTION
Was checking for `any` but should check for `all` coordinates