### PR TITLE
Fix parallelization strategy for numerical differention

### DIFF
--- a/TESTSUITE/hessian.f90
+++ b/TESTSUITE/hessian.f90
@@ -127,7 +127,7 @@ subroutine test_gfn1_hessian
    dipgrad = 0.0_wp
    hessian = 0.0_wp
    ! omp parallel default(shared)
-   call numdiff2(env, mol, chk, calc, step, hessian, dipgrad)
+   call numdiff2(env, mol, chk, calc, step, hessian, dipgrad, .false.)
    ! omp end parallel
 
    do i = 1, size(dipgrad_ref, 2)
@@ -225,7 +225,7 @@ subroutine test_gfn2_hessian
    dipgrad = 0.0_wp
    hessian = 0.0_wp
    ! omp parallel default(shared)
-   call numdiff2(env, mol, chk, calc, step, hessian, dipgrad)
+   call numdiff2(env, mol, chk, calc, step, hessian, dipgrad, .false.)
    ! omp end parallel
 
    do i = 1, size(dipgrad_ref, 2)

--- a/src/freq/CMakeLists.txt
+++ b/src/freq/CMakeLists.txt
@@ -19,7 +19,7 @@ set(dir "${CMAKE_CURRENT_SOURCE_DIR}")
 
 list(APPEND srcs
   "${dir}/io.f90"
-  "${dir}/numdiff.f90"
+  "${dir}/numdiff.F90"
   "${dir}/project.f90"
   "${dir}/utils.f90"
 )

--- a/src/freq/meson.build
+++ b/src/freq/meson.build
@@ -17,7 +17,7 @@
 
 srcs += files(
   'io.f90',
-  'numdiff.f90',
+  'numdiff.F90',
   'project.f90',
   'utils.f90',
 )

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -208,14 +208,7 @@ subroutine numhess( &
       h = 0.0_wp
       dipd = 0.0_wp
       pold = 0.0_wp
-! This OpenMP statements lead to invalid LLVM-IRwith NVHPC (20.7 to 20.11)
-#ifndef __PGIC__
-      !$omp parallel if(parallize) default(shared)
-      call numdiff2(env, mol, chk0, calc, indx(:nonfrozh), step, h, dipd)
-      !$omp end parallel
-#else
-      call numdiff2(env, mol, chk0, calc, indx(:nonfrozh), step, h, dipd)
-#endif
+      call numdiff2(env, mol, chk0, calc, indx(:nonfrozh), step, h, dipd, parallize)
 
    else
 !! ------------------------------------------------------------------------
@@ -224,14 +217,7 @@ subroutine numhess( &
       h = 0.0_wp
       dipd = 0.0_wp
       pold = 0.0_wp
-! This OpenMP statements lead to invalid LLVM-IR with NVHPC (20.7 to 20.11)
-#ifndef __PGIC__
-      !$omp parallel if(parallize) default(shared)
-      call numdiff2(env, mol, chk0, calc, step, h, dipd)
-      !$omp end parallel
-#else
-      call numdiff2(env, mol, chk0, calc, step, h, dipd)
-#endif
+      call numdiff2(env, mol, chk0, calc, step, h, dipd, parallize)
    endif
 
 !  Hessian done -----------------------------------------------------------


### PR DESCRIPTION
- Intel Fortran has problems to properly handle orphaned OpenMP

@ucb-mgcf, @sespic, @fabothch Do you mind rechecking your failing examples with the version uploaded at:
https://github.com/awvwgk/xtb/suites/2519893098/artifacts/54567679

Closes https://github.com/grimme-lab/xtb/issues/458