### PR TITLE
Integral backend changes

### DIFF
--- a/TESTSUITE/gfn1.f90
+++ b/TESTSUITE/gfn1.f90
@@ -543,7 +543,7 @@ subroutine test_gfn1_pbc3d
    call calc%singlepoint(env, mol, wfn, 2, .false., energy, gradient, sigma, &
       & hl_gap, res)
 
-   call assert_close(hl_gap, 7.5302549721955_wp,thr)
+   call assert_close(hl_gap, 7.5302549612743_wp,thr)
    call assert_close(energy,-11.069452578476_wp,thr)
    call assert_close(norm2(gradient), 0.28766497266274E-01_wp,thr)
 


### PR DESCRIPTION
- slightly more consistent way to evaluate integrals

500 atom wall time reduces from 5.8s -> 5.4s (8 cores, Intel(R) Xeon(R) Gold 6148 CPU @ 2.40GHz).
4.7k atom memory usage reduced from 12G @ 10 cores to 1G @ 16 cores (see https://github.com/grimme-lab/xtb/issues/474).