### PR TITLE
More robust Orca driver

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -506,7 +506,7 @@ subroutine xtbMain(env, argParser)
    ! ------------------------------------------------------------------------
    !> Obtain the parameter data
    call newCalculator(env, mol, calc, fnv, restart, acc, oniom)
-   call env%checkpoint("Could not setup parameterisation")
+   call env%checkpoint("Could not setup single-point calculator")
 
    call initDefaults(env, calc, mol, gsolvstate)
    call env%checkpoint("Could not setup defaults")


### PR DESCRIPTION
- error on suspicious orca binary, like GNOME screen reader
- reduce printout from Orca with miniprint / nopop keywords
- add identifier to input file name to avoid restart from broken input