### PR TITLE
Fix issues with structure converter

### DIFF
--- a/src/gfnff/gfnff_setup.f90
+++ b/src/gfnff/gfnff_setup.f90
@@ -178,6 +178,7 @@ subroutine gfnff_input(env, mol, topo)
     do i=1,mol%n
       if(topo%nb(20,i).eq.0)then
         dum1=1.d+42
+        k = 0
         do j=1,i
           r=sqrt(sum((mol%xyz(:,i)-mol%xyz(:,j))**2))
           if(r.lt.dum1.and.r.gt.0.001)then
@@ -185,8 +186,10 @@ subroutine gfnff_input(env, mol, topo)
             k=j
           endif
         enddo
-        topo%nb(20,i)=1
-        topo%nb(1,i)=k
+        if (k > 0) then
+          topo%nb(20,i)=1
+          topo%nb(1,i)=k
+        end if
       endif
     end do
     ! initialize qfrag as in the default case

--- a/src/gfnff/struc_converter.f90
+++ b/src/gfnff/struc_converter.f90
@@ -81,7 +81,7 @@ subroutine struc_convert( &
   etot_arr = 0.0_wp
 !------------------------------------------------------------------------------
 ! set up force field
-  call struc_convert_header
+  call struc_convert_header(env%unit)
   if (allocated(set%opt_engine)) then
     opt_in = set%opt_engine
   end if

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -376,6 +376,7 @@ end function new_molecule_api
 subroutine structure_to_molecule(mol, struc)
    type(TMolecule), intent(inout) :: mol
    type(structure_type), intent(in) :: struc
+   integer :: ibd
 
    call initMolecule(mol, struc%num(struc%id), struc%sym(struc%id), struc%xyz, &
       & chrg=struc%charge, uhf=struc%uhf, pbc=struc%periodic, lattice=struc%lattice)
@@ -386,11 +387,18 @@ subroutine structure_to_molecule(mol, struc)
    if (allocated(struc%pdb)) then
       mol%pdb = struc%pdb
    end if
+   if (struc%nbd > 0) then
+      call mol%bonds%allocate(3, struc%nbd)
+      do ibd = 1, struc%nbd
+         call mol%bonds%push_back(struc%bond(:, ibd))
+      end do
+   end if
 end subroutine structure_to_molecule
 
 subroutine molecule_to_structure(struc, mol)
    type(structure_type), intent(inout) :: struc
    type(TMolecule), intent(in) :: mol
+   integer :: ibd, idx(3)
 
    call new_structure(struc, mol%at, mol%sym, mol%xyz, charge=mol%chrg, uhf=mol%uhf, &
       & periodic=mol%pbc, lattice=mol%lattice, info=mol%info)
@@ -399,6 +407,13 @@ subroutine molecule_to_structure(struc, mol)
    end if
    if (allocated(mol%pdb)) then
       struc%pdb = mol%pdb
+   end if
+   if (len(mol%bonds) > 0) then
+      allocate(struc%bond(3, len(mol%bonds)))
+      do ibd = 1, len(mol%bonds)
+         call mol%bonds%get_item(ibd, idx)
+         struc%bond(:, ibd) = idx
+      end do
    end if
 end subroutine molecule_to_structure
 

--- a/src/xtb/repulsion.F90
+++ b/src/xtb/repulsion.F90
@@ -149,7 +149,7 @@ subroutine repulsionEnGrad_latp(mol, repData, trans, cutoff, energy, gradient, &
 
    !$acc exit data copyout(energies, gradient, sigma) delete(mol, mol%at, &
    !$acc& mol%xyz, repData, repData%alpha, repData%zeff, rij, dG, dS, trans)
-#endif XTB_GPU
+#endif
 
    energy = energy + sum(energies)
 


### PR DESCRIPTION
- provide output unit for printing header in structure converter
- ensure fallback topology doesn't produce garbage for first atom
- recover bond topology from mctc-lib structure_type

Thanks to @hoelzerC for reporting.

Closes #603 