### PR TITLE
Bump C standard to C11 for using _Generic

### DIFF
--- a/include/xtb.h
+++ b/include/xtb.h
@@ -33,6 +33,14 @@
 #define XTB_VERBOSITY_MINIMAL 1
 #define XTB_VERBOSITY_MUTED   0
 
+/// Convencience macro for deleting a handle
+#define xtb_delete(ptr) _Generic((ptr), \
+                xtb_TEnvironment: xtb_delEnvironment, \
+                   xtb_TMolecule: xtb_delMolecule, \
+                 xtb_TCalculator: xtb_delCalculator, \
+                    xtb_TResults: xtb_delResults \
+                                )(&ptr)
+
 #ifdef __cplusplus
 extern "C" {
 #else

--- a/meson.build
+++ b/meson.build
@@ -23,10 +23,10 @@ project(
   license: 'LGPL3',
   meson_version: '>=0.55',
   default_options: [
-    'includedir=include/xtb',
     'buildtype=debugoptimized',
     'default_library=both',
     'optimization=2',
+    'c_std=c11',
   ],
 )
 

--- a/test/api/c_api_example.c
+++ b/test/api/c_api_example.c
@@ -126,10 +126,10 @@ int testFirst() {
   if (!check(wbo[9], +2.89453979224265, 1.0e-8, "Bond order does not match"))
     goto error;
 
-  xtb_delResults(&res);
-  xtb_delCalculator(&calc);
-  xtb_delMolecule(&mol);
-  xtb_delEnvironment(&env);
+  xtb_delete(res);
+  xtb_delete(calc);
+  xtb_delete(mol);
+  xtb_delete(env);
 
   if (!check(!res, 1, "Results not deleted"))
     goto error;
@@ -144,10 +144,10 @@ int testFirst() {
 
 error:
   xtb_showEnvironment(env, NULL);
-  xtb_delResults(&res);
-  xtb_delCalculator(&calc);
-  xtb_delMolecule(&mol);
-  xtb_delEnvironment(&env);
+  xtb_delete(res);
+  xtb_delete(calc);
+  xtb_delete(mol);
+  xtb_delete(env);
   return 1;
 }
 
@@ -260,10 +260,10 @@ int testSecond() {
   if (xtb_checkEnvironment(env))
     goto error;
 
-  xtb_delResults(&res);
-  xtb_delCalculator(&calc);
-  xtb_delMolecule(&mol);
-  xtb_delEnvironment(&env);
+  xtb_delete(res);
+  xtb_delete(calc);
+  xtb_delete(mol);
+  xtb_delete(env);
 
   if (!check(pcgrad[0], 0.00000755, 1.0e-6, "pcgrad[0] does not match"))
     goto error;
@@ -274,10 +274,10 @@ int testSecond() {
 
 error:
   xtb_showEnvironment(env, NULL);
-  xtb_delResults(&res);
-  xtb_delCalculator(&calc);
-  xtb_delMolecule(&mol);
-  xtb_delEnvironment(&env);
+  xtb_delete(res);
+  xtb_delete(calc);
+  xtb_delete(mol);
+  xtb_delete(env);
   return 1;
 }
 


### PR DESCRIPTION
Also add a convenience type generic macro for deleting API objects.

Not setting `c_std` can lead to failures with `icc` which default to a last century C standard (C89).