### PR TITLE
Make c-api example MSVC compatible

### DIFF
--- a/test/api/c_api_example.c
+++ b/test/api/c_api_example.c
@@ -28,9 +28,15 @@ static inline bool check_double(double actual, double expected, double tol,
 
 int testFirst() {
   // first molecule
+  double* q;
+  char* buffer;
+  double* wbo;
 
+  int buffersize = 512;
+  int tester = 0;
   double const thr = 1.0e-10;
   int const natoms = 7;
+  int const natsq = 49;
   int const attyp[7] = {6, 6, 6, 1, 1, 1, 1};
   double const charge = 0.0;
   int const uhf = 0;
@@ -49,10 +55,9 @@ int testFirst() {
   xtb_TResults res = NULL;
   double energy;
   double dipole[3];
-  double q[natoms];
-  double wbo[natoms * natoms];
-  int buffersize = 512;
-  char buffer[buffersize];
+  q = (double*) malloc(natoms * sizeof(double));
+  wbo = (double*) malloc(natsq * sizeof(double));
+  buffer = (char*) malloc(buffersize *sizeof(char));
   char solvent[] = "h2o";
 
   if (!check(XTB_API_VERSION, xtb_getAPIVersion(), "API version does not match"))
@@ -131,13 +136,21 @@ int testFirst() {
   xtb_delete(mol);
   xtb_delete(env);
 
-  if (!check(!res, 1, "Results not deleted"))
+  free(q);
+  free(wbo);
+  free(buffer);
+
+  tester = !res;
+  if (!check(tester, 1, "Results not deleted"))
     goto error;
-  if (!check(!calc, 1, "Calculator not deleted"))
+  tester = !calc;
+  if (!check(tester, 1, "Calculator not deleted"))
     goto error;
-  if (!check(!mol, 1, "Molecule not deleted"))
+  tester = !mol;
+  if (!check(tester, 1, "Molecule not deleted"))
     goto error;
-  if (!check(!env, 1, "Environment not deleted"))
+  tester = !env;
+  if (!check(tester, 1, "Environment not deleted"))
     goto error;
 
   return 0;

--- a/test/api/c_api_example.c
+++ b/test/api/c_api_example.c
@@ -34,12 +34,9 @@ int testFirst() {
 
   int buffersize = 512;
   int tester = 0;
-  double const thr = 1.0e-10;
   int const natoms = 7;
   int const natsq = 49;
   int const attyp[7] = {6, 6, 6, 1, 1, 1, 1};
-  double const charge = 0.0;
-  int const uhf = 0;
   double const coord[3 * 7] = {
       +0.00000000000000, +0.00000000000000, -1.79755622305860,
       +0.00000000000000, +0.00000000000000, +0.95338756106749,
@@ -192,8 +189,6 @@ int testSecond() {
       32.94292201,  -1.094745099, 11.448025710, 28.96323675,  0.563579412,
       11.458509150, 27.70991388,  -1.947354387, 8.933606299,  29.46637609,
       -0.489290309, 7.918137207,  29.92393411};
-
-  double energy = 0;
 
   int npc = 32;
 


### PR DESCRIPTION
MSVC cl has stricter rules about constants than other compilers
(e.g variables declared `const` are not constant at compile time and so
aren't consider constant). This means the compiler won't allow `const`
variables to be used to declare array sizes.

The changes here explicitly allocate/free memory for arrays so that
the MSVC cl compiler can run this example. The c-api itself should work
without these changes, but the example was incompatible and was halting
compilation.