### PR TITLE
Export API Symbols for MSVC

### DIFF
--- a/src/api/calculator.f90
+++ b/src/api/calculator.f90
@@ -34,7 +34,6 @@ module xtb_api_calculator
    use xtb_type_molecule
    use xtb_type_calculator
    use xtb_xtb_calculator
-   use xtb_main_setup, only : addSolvationModel
    implicit none
    private
 
@@ -57,6 +56,7 @@ contains
 
 function newCalculator_api() result(vcalc) &
       & bind(C, name="xtb_newCalculator")
+   !DEC$ ATTRIBUTES DLLEXPORT :: newCalculator_api
    type(VCalculator), pointer :: calc
    type(c_ptr) :: vcalc
 
@@ -70,6 +70,7 @@ end function newCalculator_api
 
 subroutine delCalculator_api(vcalc) &
       & bind(C, name="xtb_delCalculator")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delCalculator_api
    type(c_ptr), intent(inout) :: vcalc
    type(VCalculator), pointer :: calc
 
@@ -86,6 +87,7 @@ end subroutine delCalculator_api
 
 subroutine loadGFNFF_api(venv, vmol, vcalc, charptr) &
       & bind(C, name="xtb_loadGFNFF")
+   !DEC$ ATTRIBUTES DLLEXPORT :: loadGFNFF_api
    character(len=*), parameter :: source = 'xtb_api_loadGFNFF'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -148,6 +150,7 @@ end subroutine loadGFNFF_api
 
 subroutine loadGFN0xTB_api(venv, vmol, vcalc, charptr) &
       & bind(C, name="xtb_loadGFN0xTB")
+   !DEC$ ATTRIBUTES DLLEXPORT :: loadGFN0xTB_api
    character(len=*), parameter :: source = 'xtb_api_loadGFN0xTB'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -210,6 +213,7 @@ end subroutine loadGFN0xTB_api
 
 subroutine loadGFN1xTB_api(venv, vmol, vcalc, charptr) &
       & bind(C, name="xtb_loadGFN1xTB")
+   !DEC$ ATTRIBUTES DLLEXPORT :: loadGFN1xTB_api
    character(len=*), parameter :: source = 'xtb_api_loadGFN1xTB'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -272,6 +276,7 @@ end subroutine loadGFN1xTB_api
 
 subroutine loadGFN2xTB_api(venv, vmol, vcalc, charptr) &
       & bind(C, name="xtb_loadGFN2xTB")
+   !DEC$ ATTRIBUTES DLLEXPORT :: loadGFN2xTB_api
    character(len=*), parameter :: source = 'xtb_api_loadGFN2xTB'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -335,6 +340,7 @@ end subroutine loadGFN2xTB_api
 !> Add a solvation model to calculator (requires loaded parametrisation)
 subroutine setSolvent_api(venv, vcalc, charptr, state, temperature, grid) &
       & bind(C, name="xtb_setSolvent")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setSolvent_api
    character(len=*), parameter :: source = 'xtb_api_setSolvent'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -411,6 +417,7 @@ end subroutine setSolvent_api
 !> Unset the solvation model
 subroutine releaseSolvent_api(venv, vcalc) &
       & bind(C, name="xtb_releaseSolvent")
+   !DEC$ ATTRIBUTES DLLEXPORT :: releaseSolvent_api
    character(len=*), parameter :: source = 'xtb_api_setRelease'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -442,6 +449,7 @@ end subroutine releaseSolvent_api
 !> Add a external charge potential to calculator (only supported in GFN1/2-xTB)
 subroutine setExternalCharges_api(venv, vcalc, npc, numbers, charges, positions) &
       & bind(C, name="xtb_setExternalCharges")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setExternalCharges_api
    character(len=*), parameter :: source = 'xtb_api_setExternalCharges'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -504,6 +512,7 @@ end subroutine setExternalCharges_api
 !> Unset the external charge potential
 subroutine releaseExternalCharges_api(venv, vcalc) &
       & bind(C, name="xtb_releaseExternalCharges")
+   !DEC$ ATTRIBUTES DLLEXPORT :: releaseExternalCharges_api
    character(len=*), parameter :: source = 'xtb_api_releaseExternalCharges'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -536,6 +545,7 @@ end subroutine releaseExternalCharges_api
 
 subroutine setAccuracy_api(venv, vcalc, accuracy) &
       & bind(C, name="xtb_setAccuracy")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setAccuracy_api
    character(len=*), parameter :: source = 'xtb_api_setAccuracy'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -578,6 +588,7 @@ end subroutine setAccuracy_api
 
 subroutine setMaxIter_api(venv, vcalc, maxiter) &
       & bind(C, name="xtb_setMaxIter")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setMaxIter_api
    character(len=*), parameter :: source = 'xtb_api_setMaxIter'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -616,6 +627,7 @@ end subroutine setMaxIter_api
 
 subroutine setElectronicTemp_api(venv, vcalc, temperature) &
       & bind(C, name="xtb_setElectronicTemp")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setElectronicTemp_api
    character(len=*), parameter :: source = 'xtb_api_setElectronicTemp'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env

--- a/src/api/environment.f90
+++ b/src/api/environment.f90
@@ -45,6 +45,7 @@ contains
 !> Create new xtb calculation environment object
 function newEnvironment_api() result(venv) &
       & bind(C, name="xtb_newEnvironment")
+   !DEC$ ATTRIBUTES DLLEXPORT :: newEnvironment_api
    type(VEnvironment), pointer :: env
    type(c_ptr) :: venv
 
@@ -61,6 +62,7 @@ end function newEnvironment_api
 !> Delete a xtb calculation environment object
 subroutine delEnvironment_api(venv) &
       & bind(C, name="xtb_delEnvironment")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delEnvironment_api
    type(c_ptr), intent(inout) :: venv
    type(VEnvironment), pointer :: env
 
@@ -79,6 +81,7 @@ end subroutine delEnvironment_api
 !> Check current status of calculation environment
 function checkEnvironment_api(venv) result(status) &
       & bind(C, name="xtb_checkEnvironment")
+   !DEC$ ATTRIBUTES DLLEXPORT :: checkEnvironment_api
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
    integer(c_int) :: status
@@ -102,6 +105,7 @@ end function checkEnvironment_api
 !> Show and empty error stack
 subroutine showEnvironment_api(venv, charptr) &
       & bind(C, name="xtb_showEnvironment")
+   !DEC$ ATTRIBUTES DLLEXPORT :: showEnvironment_api
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
    character(kind=c_char), intent(in), optional :: charptr(*)
@@ -126,6 +130,7 @@ end subroutine showEnvironment_api
 !> Bind output from this environment
 subroutine setOutput_api(venv, charptr) &
       & bind(C, name="xtb_setOutput")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setOutput_api
    character(len=*), parameter :: source = 'xtb_api_setOutput'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -160,6 +165,7 @@ end subroutine setOutput_api
 !> Release output unit from this environment
 subroutine releaseOutput_api(venv) &
       & bind(C, name="xtb_releaseOutput")
+   !DEC$ ATTRIBUTES DLLEXPORT :: releaseOutput_api
    character(len=*), parameter :: source = 'xtb_api_releaseOutput'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -184,6 +190,7 @@ end subroutine releaseOutput_api
 !> Set verbosity of calculation output
 subroutine setVerbosity_api(venv, verbosity) &
       & bind(C, name="xtb_setVerbosity")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setVerbosity_api
    character(len=*), parameter :: source = 'xtb_api_setVerbosity'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -206,6 +213,7 @@ end subroutine setVerbosity_api
 !> Set verbosity of calculation output
 subroutine getError_api(venv, charptr, buffersize) &
       & bind(C, name="xtb_getError")
+   !DEC$ ATTRIBUTES DLLEXPORT :: setVerbosity_api, getError_api
    character(len=*), parameter :: source = 'xtb_api_getError'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env

--- a/src/api/interface.f90
+++ b/src/api/interface.f90
@@ -39,6 +39,7 @@ contains
 
 subroutine singlepoint_api(venv, vmol, vcalc, vres) &
       & bind(C, name="xtb_singlepoint")
+   !DEC$ ATTRIBUTES DLLEXPORT :: singlepoint_api
    character(len=*), parameter :: source = 'xtb_api_singlepoint'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env

--- a/src/api/molecule.f90
+++ b/src/api/molecule.f90
@@ -45,6 +45,7 @@ contains
 function newMolecule_api(venv, natoms, numbers, positions, charge, uhf, lattice, &
       & periodic) result(vmol) &
       & bind(C, name="xtb_newMolecule")
+   !DEC$ ATTRIBUTES DLLEXPORT :: newMolecule_api
    character(len=*), parameter :: source = 'xtb_api_newMolecule'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -95,6 +96,7 @@ end function newMolecule_api
 
 subroutine delMolecule_api(vmol) &
       & bind(C, name="xtb_delMolecule")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delMolecule_api
    type(c_ptr), intent(inout) :: vmol
    type(VMolecule), pointer :: mol
 
@@ -111,6 +113,7 @@ end subroutine delMolecule_api
 
 subroutine updateMolecule_api(venv, vmol, positions, lattice) &
       & bind(C, name="xtb_updateMolecule")
+   !DEC$ ATTRIBUTES DLLEXPORT :: updateMolecule_api
    character(len=*), parameter :: source = 'xtb_api_updateMolecule'
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env

--- a/src/api/results.f90
+++ b/src/api/results.f90
@@ -51,6 +51,7 @@ contains
 !> Create new singlepoint results object
 function newResults_api() result(vres) &
       & bind(C, name="xtb_newResults")
+   !DEC$ ATTRIBUTES DLLEXPORT :: newResults_api
    type(VResults), pointer :: res
    type(c_ptr) :: vres
 
@@ -65,6 +66,7 @@ end function newResults_api
 !> Delete singlepoint results object
 subroutine delResults_api(vres) &
       & bind(C, name="xtb_delResults")
+   !DEC$ ATTRIBUTES DLLEXPORT :: delResults_api
    type(c_ptr), intent(inout) :: vres
    type(VResults), pointer :: res
 
@@ -82,6 +84,7 @@ end subroutine delResults_api
 !> Create copy from a singlepoint results object
 function copyResults_api(vold) result(vres) &
       & bind(C, name="xtb_copyResults")
+   !DEC$ ATTRIBUTES DLLEXPORT :: copyResults_api
    type(VResults), pointer :: res
    type(c_ptr) :: vres
    type(VResults), pointer :: old
@@ -103,6 +106,7 @@ end function copyResults_api
 !> Query singlepoint results object for energy
 subroutine getEnergy_api(venv, vres, dptr) &
       & bind(C, name="xtb_getEnergy")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getEnergy_api
    character(len=*), parameter :: source = "xtb_api_getEnergy"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -135,6 +139,7 @@ end subroutine getEnergy_api
 !> Query singlepoint results object for gradient
 subroutine getGradient_api(venv, vres, dptr) &
       & bind(C, name="xtb_getGradient")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getGradient_api
    character(len=*), parameter :: source = "xtb_api_getGradient"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -167,6 +172,7 @@ end subroutine getGradient_api
 !> Query singlepoint results object for gradients on external charges
 subroutine getPCGradient_api(venv, vres, dptr) &
       & bind(C, name="xtb_getPCGradient")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getPCGradient_api
    character(len=*), parameter :: source = "xtb_api_getGradient"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -199,6 +205,7 @@ end subroutine getPCGradient_api
 !> Query singlepoint results object for virial
 subroutine getVirial_api(venv, vres, dptr) &
       & bind(C, name="xtb_getVirial")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getVirial_api
    character(len=*), parameter :: source = "xtb_api_getVirial"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -231,6 +238,7 @@ end subroutine getVirial_api
 !> Query singlepoint results object for dipole moment
 subroutine getDipole_api(venv, vres, dptr) &
       & bind(C, name="xtb_getDipole")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getDipole_api
    character(len=*), parameter :: source = "xtb_api_getDipole"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -263,6 +271,7 @@ end subroutine getDipole_api
 !> Query singlepoint results object for partial charges
 subroutine getCharges_api(venv, vres, dptr) &
       & bind(C, name="xtb_getCharges")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getCharges_api
    character(len=*), parameter :: source = "xtb_api_getCharges"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -295,6 +304,7 @@ end subroutine getCharges_api
 !> Query singlepoint results object for bond orders
 subroutine getBondOrders_api(venv, vres, dptr) &
       & bind(C, name="xtb_getBondOrders")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getBondOrders_api
    character(len=*), parameter :: source = "xtb_api_getBondOrders"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -327,6 +337,7 @@ end subroutine getBondOrders_api
 !> Query singlepoint results object for bond orders
 subroutine getNao_api(venv, vres, iptr) &
       & bind(C, name="xtb_getNao")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getNao_api
    character(len=*), parameter :: source = "xtb_api_getNao"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -358,6 +369,7 @@ end subroutine getNao_api
 !> Query singlepoint results object for orbital energies
 subroutine getOrbitalEigenvalues_api(venv, vres, dptr) &
       & bind(C, name="xtb_getOrbitalEigenvalues")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getOrbitalEigenvalues_api
    character(len=*), parameter :: source = "xtb_api_getOrbitalEigenvalues"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -391,6 +403,7 @@ end subroutine getOrbitalEigenvalues_api
 !> Query singlepoint results object for occupation numbers
 subroutine getOrbitalOccupations_api(venv, vres, dptr) &
       & bind(C, name="xtb_getOrbitalOccupations")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getOrbitalOccupations_api 
    character(len=*), parameter :: source = "xtb_api_getOrbitalOccupations"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env
@@ -424,6 +437,7 @@ end subroutine getOrbitalOccupations_api
 !> Query singlepoint results object for orbital coefficients
 subroutine getOrbitalCoefficients_api(venv, vres, dptr) &
       & bind(C, name="xtb_getOrbitalCoefficients")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getOrbitalCoefficients_api 
    character(len=*), parameter :: source = "xtb_api_getOrbitalCoefficients"
    type(c_ptr), value :: venv
    type(VEnvironment), pointer :: env

--- a/src/api/version.f90
+++ b/src/api/version.f90
@@ -33,6 +33,7 @@ contains
 
 function getAPIVersion_api() result(version) &
       & bind(C, name="xtb_getAPIVersion")
+   !DEC$ ATTRIBUTES DLLEXPORT :: getAPIVersion_api
    integer(c_int) :: version
 
    version = 10000_c_int * apiMajor + 100_c_int * apiMinor + apiPatch


### PR DESCRIPTION
* By default, the Visual Studio C compiler doesn't export any symbols,
so xtb.lib wasn't being created. Adding a def file of functions exported
and pointing to it in meson.build allows it create xtb.lib.

This should close https://github.com/grimme-lab/xtb/issues/646