### PR TITLE
PCEM Conversion

### DIFF
--- a/src/setparam.f90
+++ b/src/setparam.f90
@@ -357,7 +357,7 @@ module xtb_setparam
    ! pcharge input file
    character(len=:),allocatable :: pcem_file
    character(len=:),allocatable :: pcem_grad
-   logical  :: pcem_orca   = .true.
+   logical  :: pcem_orca   = .false.
 !  controls which interactions included in the Fockian depend on the
 !  external point charges
    logical  :: pcem_l_es   = .true.


### PR DESCRIPTION
There was an error in the conversion of point charge coordinates in external embedding. The Orca flag was wrongly set to "true" without an "interface=orca" command. This led to deviations between point charge gradients calculated with the xTB binaries and our test suite. This will fix this. Will also close Issue #693 and PRs #718 and #719.