### PR TITLE
replace deprecated `make_directory` with `file(MAKE_DIRECTORY)`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package("BLAS" REQUIRED)
 
 # Object library
 if(NOT EXISTS "${PROJECT_BINARY_DIR}/include")
-  make_directory("${PROJECT_BINARY_DIR}/include")
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/include")
 endif()
 add_library(
   "${PROJECT_NAME}-object"

--- a/cmake/modules/xtb-utils.cmake
+++ b/cmake/modules/xtb-utils.cmake
@@ -82,7 +82,7 @@ macro(
 
         # We need the module directory in the subproject before we finish the configure stage
         if(NOT EXISTS "${${_pkg_uc}_BINARY_DIR}/include")
-          make_directory("${${_pkg_uc}_BINARY_DIR}/include")
+          file(MAKE_DIRECTORY "${${_pkg_uc}_BINARY_DIR}/include")
         endif()
 
         break()
@@ -106,7 +106,7 @@ macro(
       FetchContent_GetProperties("${_pkg_lc}" SOURCE_DIR "${_pkg_uc}_SOURCE_DIR")
       FetchContent_GetProperties("${_pkg_lc}" BINARY_DIR "${_pkg_uc}_BINARY_DIR")
       if(NOT EXISTS "${${_pkg_uc}_BINARY_DIR}/include")
-        make_directory("${${_pkg_uc}_BINARY_DIR}/include")
+        file(MAKE_DIRECTORY "${${_pkg_uc}_BINARY_DIR}/include")
       endif()
 
       break()

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -71,7 +71,7 @@ set_target_properties(
   Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
 )
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/include")
-  make_directory("${CMAKE_CURRENT_BINARY_DIR}/include")
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
 endif()
 
 foreach(t IN LISTS tests)


### PR DESCRIPTION
https://cmake.org/cmake/help/v3.9/command/make_directory.html
Signed-off-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>