### PR TITLE
Use --json flag in GFN-FF to write all topology information.

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -856,7 +856,7 @@ subroutine xtbMain(env, argParser)
          call main_cube(set%verbose,mol,chk%wfn,calc%basis,res)
       end select
    endif
-
+   
 
    if (set%pr_json) then
       select type(calc)
@@ -1415,6 +1415,7 @@ subroutine parseArguments(env, args, inputFile, paramFile, accuracy, lgrad, &
 
       case('--json')
          call set_write(env,'json','true')
+         Call setWRtopo("json",printTopo)
        
       case('--ceasefiles')
          restart = .false. 
@@ -1738,6 +1739,17 @@ subroutine selectList(secSplit, printTopo)
    case("hbbond")
       printTopo%hbbond = .true.
    case("eeq")
+      printTopo%eeq = .true.
+   case("json")
+      printTopo%nb = .true.
+      printTopo%bpair = .true.
+      printTopo%alist = .true.
+      printTopo%blist = .true.
+      printTopo%tlist = .true.
+      printTopo%vtors = .true.
+      printTopo%vbond = .true.
+      printTopo%vangl = .true.
+      printTopo%hbbond = .true.
       printTopo%eeq = .true.
    case default
      printTopo%warning = .true.


### PR DESCRIPTION
The "--json" flag was not used with GFN-FF, which caused some confusion. In the future, we could use this flag to just write all available topology information in GFN-FF.

Related to #745.

Signed-off-by: MtoLStoN <70513124+MtoLStoN@users.noreply.github.com>