### PR TITLE
Ifort 2023 compatibility

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -156,10 +156,10 @@ jobs:
       FC: ${{ matrix.fc }}
       CC: ${{ matrix.cc }}
       APT_PACKAGES: >-
-        intel-oneapi-compiler-fortran-2022.2.1
-        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.2.1
-        intel-oneapi-mkl-2022.2.1
-        intel-oneapi-mkl-devel-2022.2.1
+        intel-oneapi-compiler-fortran
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        intel-oneapi-mkl
+        intel-oneapi-mkl-devel
         asciidoctor
 
     steps:

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -856,7 +856,6 @@ subroutine xtbMain(env, argParser)
          call main_cube(set%verbose,mol,chk%wfn,calc%basis,res)
       end select
    endif
-   
 
    if (set%pr_json) then
       select type(calc)

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -856,7 +856,7 @@ subroutine xtbMain(env, argParser)
          call main_cube(set%verbose,mol,chk%wfn,calc%basis,res)
       end select
    endif
-
+   
 
    if (set%pr_json) then
       select type(calc)
@@ -1415,6 +1415,7 @@ subroutine parseArguments(env, args, inputFile, paramFile, accuracy, lgrad, &
 
       case('--json')
          call set_write(env,'json','true')
+         Call setWRtopo("json",printTopo)
        
       case('--ceasefiles')
          restart = .false. 
@@ -1738,6 +1739,17 @@ subroutine selectList(secSplit, printTopo)
    case("hbbond")
       printTopo%hbbond = .true.
    case("eeq")
+      printTopo%eeq = .true.
+   case("json")
+      printTopo%nb = .true.
+      printTopo%bpair = .true.
+      printTopo%alist = .true.
+      printTopo%blist = .true.
+      printTopo%tlist = .true.
+      printTopo%vtors = .true.
+      printTopo%vbond = .true.
+      printTopo%vangl = .true.
+      printTopo%hbbond = .true.
       printTopo%eeq = .true.
    case default
      printTopo%warning = .true.

--- a/src/type/calculator.f90
+++ b/src/type/calculator.f90
@@ -133,8 +133,8 @@ subroutine hessian(self, env, mol0, chk0, list, step, hess, dipgrad)
    real(wp), intent(inout) :: dipgrad(:, :)
 
    integer :: iat, jat, kat, ic, jc, ii, jj
-   type(TMolecule), allocatable :: mol
-   type(TRestart), allocatable :: chk
+   type(TMolecule) :: mol
+   type(TRestart) :: chk
    real(wp) :: er, el, dr(3), dl(3), sr(3, 3), sl(3, 3), egap, step2
    real(wp) :: t0, t1, w0, w1
    real(wp), allocatable :: gr(:, :), gl(:, :)
@@ -157,15 +157,15 @@ subroutine hessian(self, env, mol0, chk0, list, step, hess, dipgrad)
          gr = 0.0_wp
          gl = 0.0_wp
 
-         mol = mol0
+         call mol%copy(mol0)
          mol%xyz(ic, iat) = mol0%xyz(ic, iat) + step
-         chk = chk0
+         call chk%copy(chk0)
          call self%singlepoint(env, mol, chk, -1, .true., er, gr, sr, egap, rr)
          dr = rr%dipole
 
-         mol = mol0
+         call mol%copy(mol0)
          mol%xyz(ic, iat) = mol0%xyz(ic, iat) - step
-         chk = chk0
+         call chk%copy(chk0)
          call self%singlepoint(env, mol, chk, -1, .true., el, gl, sl, egap, rl)
          dl = rl%dipole
 

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -157,6 +157,8 @@ module xtb_type_molecule
 
       procedure :: align_to_principal_axes
 
+      procedure ::  copy => copyMolecule
+
    end type TMolecule
 
 
@@ -185,6 +187,16 @@ module xtb_type_molecule
 
 contains
 
+
+!> Copy molecule type
+subroutine copyMolecule(self,mol0)
+
+   class(TMolecule), intent(out) :: self
+   type(TMolecule), intent(in) :: mol0
+
+      Call init(self, mol0%at, mol0%sym, mol0%xyz, mol0%chrg, mol0%uhf, &
+           & mol0%lattice, mol0%pbc)
+end subroutine copyMolecule
 
 !> Constructor for the molecular structure type
 subroutine initMolecule &

--- a/src/type/restart.F90
+++ b/src/type/restart.F90
@@ -44,9 +44,22 @@ module xtb_type_restart
       !> TBLite cache
       type(wavefunction_type) :: tblite
 #endif
+   contains
+      procedure :: copy => copyRestartType
    end type TRestart
 
 contains
+
+subroutine copyRestartType(self, other)
+   class(TRestart), intent(out) :: self
+   class(TRestart), intent(in) :: other
+
+   self%wfn = other%wfn
+   self%nlist = other%nlist
+#if WITH_TBLITE
+   self%tblite = other%tblite
+#endif
+end subroutine copyRestartType
 
 
 end module xtb_type_restart


### PR DESCRIPTION
The new version of the ifort compiler in oneAPI 2023.0.0 seems to have problems with the copying of certain derived types. This compatibility patch introduces some additional copy routine which should hopefully fix this.

Also reverts the respective ifort github workflow back to the latest compilers as we can now build xTB with oneAPI 2023.0.0