### PR TITLE
Clarifying xtb license

### DIFF
--- a/man/xtb.1.adoc
+++ b/man/xtb.1.adoc
@@ -460,4 +460,17 @@ Main web site: http://grimme.uni-bonn.de/software/xtb
 
 COPYING
 -------
-Copyright \(C) 2015-2018 S. Grimme. For non-commerical, academia use only.
+Copyright (C) 2017-2023 Stefan Grimme
+
+xtb is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+xtb is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with xtb.  If not, see <https://www.gnu.org/licenses/>.


### PR DESCRIPTION
The xTB man page was not in accordance with our license. This will clarify this.