### PR TITLE
Commandline flage "--alpb" now explicitly activates ALPB.

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -1532,6 +1532,7 @@ subroutine parseArguments(env, args, inputFile, paramFile, accuracy, lgrad, &
 
       case('--alpb')
          call args%nextArg(sec)
+         call set_gbsa(env, 'alpb', 'true')
          if (allocated(sec)) then
             call set_gbsa(env, 'solvent', sec)
             call args%nextArg(sec)

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -1546,7 +1546,7 @@ subroutine parseArguments(env, args, inputFile, paramFile, accuracy, lgrad, &
                end if
             end if
          else
-            call env%error("No solvent name provided for GBSA", source)
+            call env%error("No solvent name provided for ALPB", source)
          end if
 
       case('--cosmo')


### PR DESCRIPTION
The ALPB solvation model is activated by setting the solvation environment variable ``alpb=True``. Because this is our default, up until now, we only deactivate the solvation model when someone uses the ``--gbsa`` flag. However, this leads to prioritizing a custom ``xtbrc`` file over the command line interface if someone explicitly states ``alpb=False`` in his configuration file.

This is counterintuitive. If the user requests ALPB via the command line interface, it should be explicitly activated.

Signed-off-by: MtoLStoN <70513124+MtoLStoN@users.noreply.github.com>