### PR TITLE
Fixes a bug that occurs when calculating an hessian specific builds

### DIFF
--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -226,7 +226,11 @@ subroutine initMolecule &
    end if
 
    if (present(pbc)) then
-      mol%pbc = pbc
+      if (size(pbc) == 1) then
+         mol%pbc = (/pbc, pbc, pbc/)
+      else
+         mol%pbc = pbc
+      end if
       mol%npbc = count(pbc)
       if (any(pbc)) then
          mol%boundaryCondition = boundaryCondition%pbc3d


### PR DESCRIPTION
One of our dependencies ([mctc-lib](https://github.com/grimme-lab/mctc-lib)) handles the logic of the allocation of PBC a little bit different than we did. This lead to errors with a specific version of the gfortran compiler when explicitly copying the molecular type, that was done as a compatibility fix for ifort in #752.

Handling the PBC logical explicitly for different sized logical arrays should fix this. This will close #772.