### PR TITLE
Add torsion potential to GFN-FF for rotation around triple bonded carbon

### DIFF
--- a/src/gfnff/topology.f90
+++ b/src/gfnff/topology.f90
@@ -58,6 +58,7 @@ module xtb_gfnff_topology
       integer,allocatable ::  alist(:,:)   ! angles
       integer,allocatable ::  tlist(:,:)   ! torsions
       integer,allocatable :: b3list(:,:)   ! bond atm
+      integer,allocatable :: sTorsl(:,:)
       !-----------------------------------------------
       integer,allocatable :: nr_hb(:)      ! Nr. of H bonds per O-H or N-H bond
       integer,allocatable :: bond_hb_AH(:,:) ! A, H atoms in bonds that are also part of HBs


### PR DESCRIPTION
This potential was requested to get the correct torsion potentials for diphenylacetylene.