### PR TITLE
Restore support for custom lapack backend

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -146,6 +146,11 @@ elif lapack_vendor == 'openblas'
     lib_deps += lapack_dep
   endif
 
+elif lapack_vendor == 'custom'
+  foreach lib: get_option('custom_libraries')
+    lib_deps += fc.find_library(lib)
+  endforeach
+
 else
   lapack_dep = dependency('lapack', required: false)
   if not lapack_dep.found()


### PR DESCRIPTION
When the meson options were renamed, the support for a custom lapack backend in meson.build was also removed. This patch restores that support.