### PR TITLE
Add torsion potential to GFN-FF for rotation around triple bonded carbon

### DIFF
--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -458,13 +458,15 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! triple bonded carbon torsion potential
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      m = size(topo%sTorsl(1,:))
-      if (m.ne.0) then
-         do i=1, m
+      if allocated(topo%sTorsl) then
+        m = size(topo%sTorsl(1,:))
+        if (m.ne.0) then
+          do i=1, m
             call sTors_eg(m, n, xyz, topo, etmp, g5tmp)
             etors = etors + etmp
             g = g + g5tmp
-         enddo
+          enddo
+        endif
       endif
       if (pr) call timer%measure(8)
 

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -458,7 +458,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! triple bonded carbon torsion potential
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      if allocated(topo%sTorsl) then
+      if (allocated(topo%sTorsl)) then
         m = size(topo%sTorsl(1,:))
         if (m.ne.0) then
           do i=1, m

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -3127,6 +3127,7 @@ use xtb_mctc_accuracy, only : wp
   integer :: c1,c2,c3,c4
   integer :: i
   real(wp) :: phi, valijklff  ! torsion angle between C1-C4
+  real(wp) :: erefhalf  
   real(wp) :: dp1(3),dp2(3),dp3(3),dp4(3)
 
   energy = 0.0_wp
@@ -3141,12 +3142,14 @@ use xtb_mctc_accuracy, only : wp
     ! dihedral angle in radians
     phi=valijklff(n,xyz,c1,c2,c3,c4)
     call dphidr(n,xyz,c1,c2,c3,c4,phi,dp1,dp2,dp3,dp4)
-    energy = -4.609_wp*1.0e-4_wp*cos(2.0_wp*phi) + 4.609_wp*1.0e-4_wp
+    ! reference energy for torsion of 90° calculated with DLPNO-CCSD(T) CBS on diphenylacetylene
+    erefhalf = 3.75_wp*1.0e-4_wp  ! approx 1.97 kJ/mol
+    energy = -erefhalf*cos(2.0_wp*phi) + erefhalf 
     do i=1, 3
-      dg(i, c1) = dg(i, c1) + 4.609_wp*1.0e-4_wp*2.0_wp*sin(2.0_wp*phi)*dp1(i)
-      dg(i, c2) = dg(i, c2) + 4.609_wp*1.0e-4_wp*2.0_wp*sin(2.0_wp*phi)*dp2(i)
-      dg(i, c3) = dg(i, c3) + 4.609_wp*1.0e-4_wp*2.0_wp*sin(2.0_wp*phi)*dp3(i)
-      dg(i, c4) = dg(i, c4) + 4.609_wp*1.0e-4_wp*2.0_wp*sin(2.0_wp*phi)*dp4(i)
+      dg(i, c1) = dg(i, c1) + erefhalf*2.0_wp*sin(2.0_wp*phi)*dp1(i)
+      dg(i, c2) = dg(i, c2) + erefhalf*2.0_wp*sin(2.0_wp*phi)*dp2(i)
+      dg(i, c3) = dg(i, c3) + erefhalf*2.0_wp*sin(2.0_wp*phi)*dp3(i)
+      dg(i, c4) = dg(i, c4) + erefhalf*2.0_wp*sin(2.0_wp*phi)*dp4(i)
     enddo
   endif
 

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -454,21 +454,19 @@ contains
          enddo
          !$omp end parallel do
       endif
-      if (pr) call timer%measure(8)
-
-
+      
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! triple bonded carbon torsion potential
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-m = size(topo%sTorsl(1,:))
-if (m.ne.0) then
-  do i=1, m
-    call sTors_eg(m, n, xyz, topo, etmp, g5tmp)
-    etors = etors + etmp
-    g = g + g5tmp
-  enddo
-endif
-
+      m = size(topo%sTorsl(1,:))
+      if (m.ne.0) then
+         do i=1, m
+            call sTors_eg(m, n, xyz, topo, etmp, g5tmp)
+            etors = etors + etmp
+            g = g + g5tmp
+         enddo
+      endif
+      if (pr) call timer%measure(8)
 
 !!!!!!!!!!!!!!!!!!
 ! BONDED ATM

--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -1867,9 +1867,6 @@ subroutine gfnff_ini(env,pr,makeneighbor,mol,gen,param,topo,accuracy)
         nn = nn/2
         allocate(topo%sTorsl(6, nn), source=0)
         call specialTorsList(nn, mol, topo, topo%sTorsl)
-      else
-        ! allocate with size() = 0
-        allocate(topo%sTorsl(6, nn), source=0)
       endif
 
 

--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -1911,7 +1911,7 @@ subroutine specialTorsList(nst, mol, topo, sTorsList)
         nbi=topo%nb(j,i)
         if (mol%at(nbi).eq.6.and.topo%nb(20,nbi).eq.2) then  ! *other carbon
           ! check carbon triple bond distance
-          if (NORM2(mol%xyz(1:3,i)-mol%xyz(1:3,nbi)).le.2.47) then
+          if (NORM2(mol%xyz(1:3,i)-mol%xyz(1:3,nbi)).le.2.37) then
             ! at this point we know that i and nbi are carbons bonded through triple bond
             ! check C2 and C3
             do k=1, 2  ! C2 is other nb of Ci

--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -1885,6 +1885,7 @@ contains
 ! special treatment for rotation around carbon triple bonds
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! requested for obtaining diphenylacetylene torsion potential
+! also applied for e.g. divinylacetylene
 
 ! Check for triple bonded carbon (Ci and Cnbi) and setup list for calculating
 !  torsion potential using dehidral angle between C1 C2 C3 C4
@@ -1958,8 +1959,8 @@ subroutine specialTorsList(nst, mol, topo, sTorsList)
             endif ! C1-C4 are sp2 carbon
           endif  ! CC distance
         endif  ! other carbon
-      enddo  ! is carbon with nnb=2
-    endif
+      enddo
+    endif ! is carbon with nnb=2
   enddo
 end subroutine specialTorsList
 

--- a/src/gfnff/topology.f90
+++ b/src/gfnff/topology.f90
@@ -58,6 +58,7 @@ module xtb_gfnff_topology
       integer,allocatable ::  alist(:,:)   ! angles
       integer,allocatable ::  tlist(:,:)   ! torsions
       integer,allocatable :: b3list(:,:)   ! bond atm
+      integer,allocatable :: sTorsl(:,:)
       !-----------------------------------------------
       integer,allocatable :: nr_hb(:)      ! Nr. of H bonds per O-H or N-H bond
       integer,allocatable :: bond_hb_AH(:,:) ! A, H atoms in bonds that are also part of HBs


### PR DESCRIPTION
This potential was requested to get the correct torsion potentials for diphenylacetylene.