### PR TITLE
writing updated coord AND xtbopt.xyz during external driver optimization (including nicer printout)

### DIFF
--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -117,19 +117,16 @@ contains
     efix = 0.0_wp
     dipole(:) = 0.0_wp
 
-    write(*,*) printlevel
-
     !$omp critical (turbo_lock)
     inquire (file='gradient', exist=exist)
     if (exist) then
       ! ### only TM output is supported for now ###
       call rdtm(env,mol%n, .true., energy, gradient, xyz_cached)
       cache = all(abs(xyz_cached - mol%xyz) < 1.e-10_wp)
-      if (cache) then
-       if (printlevel > 0) &
+      if (cache .and. printlevel > 0) then 
          write(env%unit,'(/,a,/)') &
-         "Geometry is equivalent to the one in &
-         'gradient'. Reading gradient from: 'gradient'."
+         & "Geometry is equivalent to the one in &
+         & 'gradient'. Reading gradient from: 'gradient'."
       endif
     end if
     if (.not. cache) then

--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -117,6 +117,8 @@ contains
     efix = 0.0_wp
     dipole(:) = 0.0_wp
 
+    write(*,*) printlevel
+
     !$omp critical (turbo_lock)
     inquire (file='gradient', exist=exist)
     if (exist) then
@@ -131,9 +133,11 @@ contains
       endif
     end if
     if (.not. cache) then
-      call generateFileName(tmpname, 'xtbopt', extension, mol%ftype)
-      write(env%unit,'(/,a,1x,a,/)') &
-         "updated geometry written to:",tmpname
+      call generateFileName(tmpname, 'xtbdriver', extension, mol%ftype)
+      if (printlevel > 0) then
+        write(env%unit,'(/,a,1x,a,/)') &
+           "updated geometry written to:",tmpname
+      endif
       call open_file(ich,tmpname,'w')
       if (exist) then
         call writeMolecule(mol, ich, format=mol%ftype, energy=energy, &

--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -17,7 +17,7 @@
 module xtb_extern_driver
   use xtb_mctc_accuracy, only: wp
   use xtb_mctc_io, only: stdout
-  use xtb_mctc_filetypes, only: fileType
+  use xtb_mctc_filetypes, only: fileType, generateFileName
   use xtb_mctc_symbols, only: toSymbol
   use xtb_type_calculator, only: TCalculator
   use xtb_type_data, only: scc_results
@@ -104,6 +104,8 @@ contains
                                    '(9x,"::",1x,a,f23.12,1x,a,1x,"::")'
     real(wp) :: xyz_cached(3, mol%n)
     integer :: err
+    character(len=:),allocatable :: extension
+    character(len=:),allocatable :: tmpname
 
     call mol%update
 
@@ -122,6 +124,14 @@ contains
     end if
     if (.not. cache) then
       call wrtm(mol%n, mol%at, mol%xyz)
+      write(env%unit,'(/,a,/)') &
+         "updated geometry written to: coord"
+      call generateFileName(tmpname, 'xtbopt', extension, mol%ftype)
+      write(env%unit,'(/,a,1x,a,/)') &
+         "updated geometry written to:",tmpname
+      call open_file(ich,tmpname,'w')
+      call writeMolecule(mol, ich, format=1)
+      call close_file(ich)
 
       write (env%unit, '(72("="))')
       write (env%unit, '(1x,"*",1x,a)') &

--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -109,6 +109,7 @@ contains
 
     call mol%update
 
+    cache = .false.
     energy = 0.0_wp
     gradient(:, :) = 0.0_wp
     sigma(:, :) = 0.0_wp
@@ -122,6 +123,11 @@ contains
       ! ### only TM output is supported for now ###
       call rdtm(env,mol%n, .true., energy, gradient, xyz_cached)
       cache = all(abs(xyz_cached - mol%xyz) < 1.e-10_wp)
+      if (cache) then
+        write(env%unit,'(/,a,/)') &
+         "Geometry is equivalent to the one in &
+         'gradient'. Reading gradient from: 'gradient'."
+      endif
     end if
     if (.not. cache) then
       call generateFileName(tmpname, 'xtbopt', extension, mol%ftype)

--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -124,10 +124,10 @@ contains
     end if
     if (.not. cache) then
       call wrtm(mol%n, mol%at, mol%xyz)
-      write(env%unit,'(/,a,/)') &
+      write(env%unit,'(/,a)') &
          "updated geometry written to: coord"
       call generateFileName(tmpname, 'xtbopt', extension, mol%ftype)
-      write(env%unit,'(/,a,1x,a,/)') &
+      write(env%unit,'(a,1x,a,/)') &
          "updated geometry written to:",tmpname
       call open_file(ich,tmpname,'w')
       call writeMolecule(mol, ich, format=1)

--- a/src/extern/driver.f90
+++ b/src/extern/driver.f90
@@ -124,7 +124,8 @@ contains
       call rdtm(env,mol%n, .true., energy, gradient, xyz_cached)
       cache = all(abs(xyz_cached - mol%xyz) < 1.e-10_wp)
       if (cache) then
-        write(env%unit,'(/,a,/)') &
+       if (printlevel > 0) &
+         write(env%unit,'(/,a,/)') &
          "Geometry is equivalent to the one in &
          'gradient'. Reading gradient from: 'gradient'."
       endif

--- a/src/optimizer.f90
+++ b/src/optimizer.f90
@@ -739,7 +739,7 @@ subroutine relax(env,iter,mol,anc,restart,maxcycle,maxdispl,ethr,gthr, &
    anc%coord = anc%coord + displ * alp
 
 ! conv ?
-   if(abs(echng).lt.ethr.and.gnorm.lt.gthr.and.echng.lt.0) then
+   if(abs(echng).lt.ethr.and.gnorm.lt.gthr.and.echng.lt.1.0e-10_wp) then
       restart=.false.
       converged = .true.
       etot=energy


### PR DESCRIPTION
- write xtbopt.xyz constantly in the external driver mode so that not only "coord"-based external methods can be used for geometry optimization.
- nicer formatting
