### PR TITLE
-lmo prints now list of basic atoms

### DIFF
--- a/src/filetools.F90
+++ b/src/filetools.F90
@@ -84,7 +84,6 @@ subroutine close_file(unit)
    use xtb_mctc_global, only : persistentEnv
    implicit none
    integer,intent(in) :: unit
-   logical :: opened
 
    call persistentEnv%io%closeFile(unit)
 

--- a/src/header.f90
+++ b/src/header.f90
@@ -16,8 +16,12 @@
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine xtb_header(iunit)
-integer,intent(in) :: iunit
-write(iunit,'(a)') &
+   
+   implicit none
+   integer,intent(in) :: iunit
+      !! I/O unit
+
+   write(iunit,'(a)') &
    !< < < < < < < < < < < < < < < < < < > > > > > > > > > > > > > > > > > >!
    "      -----------------------------------------------------------      ",&
    "     |                   =====================                   |     ",&
@@ -30,14 +34,20 @@ write(iunit,'(a)') &
    "      -----------------------------------------------------------      ",""
    !< < < < < < < < < < < < < < < < < < > > > > > > > > > > > > > > > > > >!
    call xtb_version(iunit)
+
 end subroutine xtb_header
 
 subroutine xtb_version(iunit)
-integer,intent(in) :: iunit
-include 'xtb_version.fh'
-write(iunit,'(3x,"*",*(1x,a))') &
-   & "xtb version", version, "compiled by", author, "on", date
-write(iunit,'(a)')
+
+   implicit none
+   integer,intent(in) :: iunit
+      !! I/O unit
+   
+   include 'xtb_version.fh'
+   write(iunit,'(3x,"*",*(1x,a))') &
+      & "xtb version", version, "compiled by", author, "on", date
+   write(iunit,'(a)')
+
 end subroutine xtb_version
 
 subroutine disclamer(iunit)

--- a/src/local.f90
+++ b/src/local.f90
@@ -276,7 +276,6 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis,r
    if(set%pr_local) write(*,*) 'lmo centers(Z=2) and atoms on file <lmocent.coord>'
    if(set%pr_local) write(*,*) 'LMO Fii/eV  ncent    charge center   contributions...'
    if(set%pr_local) call open_file(iscreen,'xtbscreen.xyz','w')
-
    allocate(tmpq(nat,n))
    tmpq(1:nat,1:n)=qmo(1:nat,1:n)
    maxlp=0
@@ -321,10 +320,11 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis,r
          call lmotype(nat,at,xyz,ecent(i,1),ecent(i,2),ecent(i,3), &
          &                imem(1),imem(2),xcen(i),.true.,pithr,jdum)
       endif
-      if(set%pr_local) write(*,'(i5,1x,a5,2f7.2,3f10.5,12(i5,a2,'':'',f6.2))')  &
+      if(set%pr_local) then 
+      write(*,'(i5,1x,a5,2f7.2,3f10.5,12(i5,2x,a2,'':'',f6.2))')  &
       &   i,lmostring(jdum),autoev*f(i),xcen(i),ecent(i,1:3), &
       &   (imem(j),toSymbol(at(imem(j))),qmo(j,i),j=1,idum)
-
+      end if
       !        write + LP/pi as H for protonation search
       if(set%pr_local) then
          if(jdum.gt.1) then
@@ -495,8 +495,9 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis,r
       enddo
       new=k
 
-      if(set%pr_local) call close_file(iscreen)
-
+      if(set%pr_local) then 
+      call close_file(iscreen)
+      end if
       deallocate(wbo)
 
 

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -1089,6 +1089,7 @@ end subroutine set_cut
 
 
 !> charge initialization
+!> Priority: cml -> xcontrol -> .CHRG
 subroutine set_chrg(env,val)
 
    implicit none

--- a/src/type/iohandler.f90
+++ b/src/type/iohandler.f90
@@ -108,7 +108,7 @@ elemental function initFileHandle(name, status, unit, open) result(self)
 
 end function initFileHandle
 
-
+!> check for namespace and, if present, add it accordingly to the file name
 subroutine getName(self, file, filename)
    class(TIOHandler), intent(inout) :: self
    character(len=*), intent(in) :: file


### PR DESCRIPTION
The "basicatoms" list can be better parsed than the default printout and can be used in workflows, where basic reaction sides are important.