### PR TITLE
Use "--dftbplus" instead of "--dftb+" in the thermo submodule.

### DIFF
--- a/src/prog/thermo.f90
+++ b/src/prog/thermo.f90
@@ -204,7 +204,7 @@ subroutine parseArguments(env, args, htype, massWeighted)
          call thermoHelp(env%unit)
          call terminate(0)
 
-      case('--dftb+')
+      case('--dftb+','--dftbplus')
          htype = hessType%dftbplus
 
       case('--turbomole')
@@ -309,7 +309,7 @@ subroutine thermoHelp(unit)
    "   --temp REAL[,...]   Temperature for thermodynamic functions in K,",&
    "                       takes a comma separated list of temperatures",&
    "",&
-   "   --dftb+             Read a DFTB+ hessian.out file, implies projection",&
+   "   --dftbplus             Read a DFTB+ hessian.out file, implies projection",&
    "",&
    "   --turbomole         Read a Turbomole Hessian file",&
    "                       use this only when $nomw is not present in control",&


### PR DESCRIPTION
It seems, the + sign in the "--dftb+" argument in the thermo submodule can lead to problems depending on the used environment.
I propose changing the default commandline argument to "--dftbplus", keeping "--dftb+" as an alternative for backward compatibility.

Closes #845.