### PR TITLE
add embd term to scc energy

### DIFF
--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -903,7 +903,7 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
    if (.not.allocated(scD4)) then
       energy = energy + ed
    endif
-   res%e_elec  = eel
+   res%e_elec  = eel + embd
    res%e_atom  = eat
    res%e_rep   = ep
    res%e_es    = ees


### PR DESCRIPTION
add `embd` the `scc_results%e_elec` term, so the total energy can be calculated as the sum of the printed terms.
