### PR TITLE
specify ifort location

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -263,6 +263,7 @@ jobs:
       run: |
         sudo apt-get install ${APT_PACKAGES}
         source /opt/intel/oneapi/setvars.sh
+        source /opt/intel/oneapi/compiler/2024.0/env/vars.sh
         printenv >> $GITHUB_ENV
 
     - name: Configure meson build


### PR DESCRIPTION
Apparently, in the new oneAPI version, the  **setvars.sh** script does not configure `ifort`. 