### PR TITLE
resolve debug compilation errors

### DIFF
--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -788,7 +788,7 @@ subroutine disppot(dispm,nat,ndim,at,itbl,q,g_a,g_c,wdispmat,gw,hdisp)
    !$acc loop gang private(k, ati)
 #else
    !$omp parallel do reduction(+:hdisp) shared(itbl, at, dumvec, zerovec) &
-   !$omp private(ati, ii)
+   !$omp private(ati, ii, k)
 #endif
    do iat = 1, nat
       k = itbl(iat)

--- a/src/oniom.f90
+++ b/src/oniom.f90
@@ -673,30 +673,23 @@ subroutine cutbond(self, env, mol, chk, topo, inner_mol, jacobian, idx2)
    
    ! divide initial mol into inner and outer regions !
    do i = 1, mol%n
-      if (i==self%idx(in_itr)) then
-         
-         if (in_itr > in) then
-            call env%error("The internal error, inconsistent molecular dimensionality", source=source) 
-            return
+      if (in_itr <= size(self%idx)) then
+         if (i==self%idx(in_itr)) then
+            at(in_itr) = mol%at(i)
+            xyz(:, in_itr) = mol%xyz(:, i)
+            in_itr = in_itr + 1
+         else
+            at_out(out_itr) = mol%at(i)
+            xyz_out(:, out_itr) = mol%xyz(:, i)
+            out_itr = out_itr + 1
          endif
-         
-         at(in_itr) = mol%at(i)
-         xyz(:, in_itr) = mol%xyz(:, i)
-         in_itr = in_itr + 1
-      
       else
-         
-         if (out_itr > out) then 
-            call env%error("The internal error, inconsistent molecular dimensionality", source=source) 
-            return
-         endif
-         
          at_out(out_itr) = mol%at(i)
          xyz_out(:, out_itr) = mol%xyz(:, i)
          out_itr = out_itr + 1
-      
       endif
    enddo 
+ 
  
    ! initialiaze jacobian as identity !
    call create_jacobian(jacobian,at)

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -218,11 +218,10 @@ subroutine initMolecule &
    nAt = min(size(at, dim=1), size(xyz, dim=2), size(sym, dim=1))
 
    call mol%allocate(nAt)
-
+   
+   mol%lattice = 0.0_wp
    if (present(lattice)) then
-      mol%lattice = lattice
-   else
-      mol%lattice = 0.0_wp
+      if (size(lattice).ne.0) mol%lattice = lattice
    end if
 
    if (present(pbc)) then


### PR DESCRIPTION
 CMake build in debug mode results in several runtime errors (with both `gfortran` v11.4.0 and `ifort` v2021.5.0):
1. Race condition in `dftd4.f90`
2. Out of bound exception in `oniom.f90` 
3. Dimension mismatch in `molecule.f90`

