### PR TITLE
temporary fix for CI

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -232,10 +232,10 @@ jobs:
       FC: ${{ matrix.fc }}
       CC: ${{ matrix.cc }}
       APT_PACKAGES: >-
-        intel-oneapi-compiler-fortran
-        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-        intel-oneapi-mkl
-        intel-oneapi-mkl-devel
+        intel-oneapi-compiler-fortran-2022.1.0
+        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0
+        intel-oneapi-mkl-2022.1.0
+        intel-oneapi-mkl-devel-2022.1.0
         asciidoctor
 
     steps:
@@ -263,7 +263,6 @@ jobs:
       run: |
         sudo apt-get install ${APT_PACKAGES}
         source /opt/intel/oneapi/setvars.sh
-        source /opt/intel/oneapi/compiler/2024.0/env/vars.sh
         printenv >> $GITHUB_ENV
 
     - name: Configure meson build

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Bleeding edge releases (Linux only) of the latest source from this repository ar
 This projects supports two build systems, meson and CMake.
 A short guide on the usage of each is given here, follow the linked instructions for a more detailed information ([meson guide](./meson/README.adoc), [CMake guide](./cmake/README.adoc)).
 
+**Compilers**: 
+  1. ifort(<=2021.10.0), icc(<=2021.10.0)
+  2. gfortran(<=13.2.0), gcc(<=13.2.0) 
+
 
 ### Meson
 


### PR DESCRIPTION
Address the issue of the new ifort version not compiling programs by temporarily reverting CI to an older version of ifort as a workaround, until ifx is fully integrated.