### PR TITLE
fix preprocessor definitions

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
 
@@ -109,10 +109,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.x
  
@@ -149,7 +149,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Python
       uses: actions/setup-python@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(WITH_OBJECT "To build using object library" TRUE)
 option(INSTALL_MODULES "Install Fortran module files to include directory." FALSE)
 
 # Buggy CMake versions
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27.0)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27.0 AND CMAKE_VERSION VERSION_LESS 3.28.0)
    set(WITH_OBJECT FALSE)
 endif()
 
@@ -45,11 +45,13 @@ if(NOT TARGET "mctc-lib::mctc-lib")
 endif()
 
 if(NOT TARGET "tblite::tblite" AND WITH_TBLITE)
-  find_package("tblite" REQUIRED)
+   find_package("tblite" REQUIRED)
+   add_compile_definitions(-DWITH_TBLITE)
 endif()
 
 if(NOT TARGET "cpcmx::cpcmx" AND WITH_CPCMX)
-  find_package("cpcmx" REQUIRED)
+   find_package("cpcmx" REQUIRED)
+   add_compile_definitions(-DWITH_CPCMX)
 endif()
 
 if(NOT TARGET "test-drive::test-drive")
@@ -147,11 +149,10 @@ target_link_libraries(
    "$<$<BOOL:${WITH_OpenMP}>:OpenMP::OpenMP_Fortran>"
    "mctc-lib::mctc-lib"
    "$<$<BOOL:${WITH_CPCMX}>:cpcmx::cpcmx>"
-   "$<$<BOOL:${WITH_TBLITE}>:tblite::tblite>"
+   $<$<BOOL:${WITH_TBLITE}>:tblite::tblite>
 )
 
-
- set_target_properties(
+set_target_properties(
    "lib-${PROJECT_NAME}-static"
    PROPERTIES
    Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/include"
@@ -224,6 +225,7 @@ target_link_libraries(
    PRIVATE
    "lib-${PROJECT_NAME}-static"
 )
+
 set_target_properties(
   ${PROJECT_NAME}-exe
   PROPERTIES

--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,10 @@ xtb_exe = executable(
   dependencies: xtb_dep_static,
   link_language: 'fortran',
   install: install,
+  fortran_args: [
+    '-DWITH_TBLITE=@0@'.format(tblite_dep.found() ? 1 : 0),
+    '-DWITH_CPCMX=@0@'.format(cpx_dep.found() ? 1 : 0),
+  ],
 )
 
 xtb_header = files('include/xtb.h')


### PR DESCRIPTION
For the **CMake** build:

1. Enable the building of an object library for CMake versions newer than 3.28.0.
2. Allow compilation with preprocessor definitions.

For the **Meson** build:

1.  Enable preprocessor definitions in the main.f90 .