### PR TITLE
Fix build error "macro names must be identifiers"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,12 @@ endif()
 
 if(NOT TARGET "tblite::tblite" AND WITH_TBLITE)
    find_package("tblite" REQUIRED)
-   add_compile_definitions(-DWITH_TBLITE)
+   add_compile_definitions(WITH_TBLITE)
 endif()
 
 if(NOT TARGET "cpcmx::cpcmx" AND WITH_CPCMX)
    find_package("cpcmx" REQUIRED)
-   add_compile_definitions(-DWITH_CPCMX)
+   add_compile_definitions(WITH_CPCMX)
 endif()
 
 if(NOT TARGET "test-drive::test-drive")


### PR DESCRIPTION
I was trying to compile xtb and it was failing with

```
Error: macro names must be identifiers
```

I traced it back to this line where an extra -D was being applied to these flags. Maybe this works as is with a different version of cmake? Happy to close this PR if everything is working as intended. But it compiled successfully for me after applying this patch.

cmake=3.22.1
gfortran=11.4.0
gcc=11.4.0
ubuntu=22.04
