### PR TITLE
add Stale workflow

### DIFF
--- a/.github/workflows/stale_label.yml
+++ b/.github/workflows/stale_label.yml
@@ -1,0 +1,28 @@
+name: "Close Stale"
+
+# The workflow triggers
+on:
+   schedule:
+      - cron: '0 0 * * *' # Runs daily at midnight
+   issues:
+      types: [labeled]
+   pull_request:
+      types: [labeled]
+
+# The stale workflow
+jobs:
+   stale:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/stale@v9
+           with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
+            stale-issue-label: 'stale' # Label to detect
+            stale-pr-label: 'stale' 
+            only-labels: 'stale'
+            days-before-stale: -1
+            days-before-close: 7
+            stale-issue-message: 'This issue is set to auto-close in 7 days if no further updates would be detected.' 
+            close-issue-message: 'This issue has been automatically closed due to inactivity.'
+            stale-pr-message: 'This PR is set to auto-close in 7 days if no further updates would be detected.' 
+            close-pr-message: 'This PR has been automatically closed due to inactivity.'


### PR DESCRIPTION
Automatically close PRs and issues labeled as **stale** if there's no activity within 7 days.