### PR TITLE
Reduce memory usage in egbond_hb for GFN-FF

### DIFF
--- a/meson/meson.build
+++ b/meson/meson.build
@@ -207,6 +207,20 @@ tblite_dep = dependency(
 )
 lib_deps += tblite_dep
 
+# Get multicharge dependency
+multicharge_dep = dependency(
+  'multicharge',
+  fallback: ['multicharge', 'multicharge_dep'],
+)
+lib_deps += multicharge_dep
+
+# Get DFTD dependency
+dftd4_dep = dependency(
+  'dftd4',
+  fallback: ['dftd4', 'dftd4_dep'],
+)
+lib_deps += dftd4_dep
+
 # Get CPCM-X
 cpx_dep = dependency(
   'cpx',

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -555,7 +555,7 @@ endif
       endif
       deallocate(dcn, dcndr)
       allocate(dEdcn(n),source=0.0_wp)
-      allocate(considered_ABH(n,n,n), source=.false.)
+      allocate(considered_ABH(topo%hb_mapNAB,topo%hb_mapNAB,topo%hb_mapNH), source=.false.)
 
      !$omp parallel do default(none) reduction(+:g, ebond, sigma, dEdcn) &
      !$omp shared(grab0, topo, neigh, param, rab0, rabdcn, xyz, at, hb_cn, hb_dcn, n, dhbcndL, considered_ABH) &
@@ -1038,7 +1038,7 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
       real*8,intent(in)    :: hb_cn(n)
       real*8,intent(in)    :: hb_dcn(3,n,n)
       real(wp), intent(in) :: dhbcndL(3,3,n)
-      logical, intent(inout)  :: considered_ABH(n,n,n) ! only consider ABH triplets once; indep of iTr
+      logical, intent(inout)  :: considered_ABH(topo%hb_mapNAB,topo%hb_mapNAB,topo%hb_mapNH)! only consider ABH triplets once; indep of iTr
       real*8,intent(inout) :: e
       real*8,intent(inout) :: g(3,n)
       real*8,intent(inout) :: sigma(3,3)
@@ -1048,11 +1048,11 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
       integer j,k
       integer jA,jH,iTrA,iTrH,iTrB
       integer hbH,hbB,hbA
+      integer mapA,mapB,mapH
       real*8 dr,dum
       real*8 dx,dy,dz,vrab(3),dg(3)
       real*8 yy,zz
       real*8 t1,t4,t5,t6,t8
-
 
          if (at(iat).eq.1) then
            hbH=iat
@@ -1128,8 +1128,11 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
                   hbB = topo%bond_hb_B(1,k,j)
                   iTrB= topo%bond_hb_B(2,k,j)
                  ! only add gradient one time per ABH triple (independent of iTrB)
-                 if(.not.considered_ABH(hbA,hbB,hbH)) then
-                   considered_ABH(hbA,hbB,hbH)=.true.
+                  mapA=topo%hb_mapABH(hbA)
+                  mapB=topo%hb_mapABH(hbB)
+                  mapH=topo%hb_mapABH(hbH)
+                 if(.not.considered_ABH(mapA,mapB,mapH)) then
+                   considered_ABH(mapA,mapB,mapH)=.true.
                    dg=hb_dcn(:,hbB,hbH)*zz
                    g(:,hbB)=g(:,hbB)-dg
                  endif

--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -1422,6 +1422,7 @@ endif
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
       !Set up fix hblist just like for the HB term
+      allocate(topo%isABH(mol%n), source=.false.)
       call bond_hbset0(mol%n,mol%at,mol%xyz,mol%npbc,bond_hbn,topo,neigh,hbthr1,hbthr2)
       allocate(bond_hbl(6,bond_hbn))
       allocate(neigh%nr_hb(neigh%nbond), source=0)
@@ -1430,11 +1431,32 @@ endif
       !Set up AH, B and nr. of B list
       call bond_hb_AHB_set0(mol%n,mol%at,neigh%nbond,bond_hbn,bond_hbl,AHB_nr,neigh)
       allocate( lin_AHB(4,0:AHB_nr), source=0  )
-      call bond_hb_AHB_set1(mol%n,mol%at,neigh%nbond,bond_hbn,bond_hbl,AHB_nr,lin_AHB,topo%bond_hb_nr,topo%b_max,neigh)
+      call bond_hb_AHB_set1(mol%n,mol%at,neigh%nbond,bond_hbn,bond_hbl,AHB_nr,lin_AHB,topo%bond_hb_nr,topo%b_max,topo,neigh)
       allocate( topo%bond_hb_AH(4,topo%bond_hb_nr), source = 0 )
       allocate( topo%bond_hb_B(2,topo%b_max,topo%bond_hb_nr), source = 0 )
       allocate( topo%bond_hb_Bn(topo%bond_hb_nr), source = 0 )
       call bond_hb_AHB_set(mol%n,mol%at,neigh%nbond,bond_hbn,bond_hbl,AHB_nr,lin_AHB,topo,neigh)
+
+      ! create mapping from atom index to hb index, for AB and H seperately
+      allocate(topo%hb_mapABH(mol%n), source=0)
+      j=0 ! H counter
+      k=0 ! AB counter
+      do i=1, mol%n
+        ! check if atom i is A,B, or H
+        if (topo%isABH(i)) then
+           ! check if it is H
+           if (mol%at(i).eq.1) then
+              j = j + 1
+              topo%hb_mapABH(i) = j
+           ! then it is A or B
+           else
+              k = k + 1
+              topo%hb_mapABH(i) = k
+           end if
+        end if
+      end do
+      topo%hb_mapNAB=k
+      topo%hb_mapNH=j
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !

--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -248,6 +248,7 @@ subroutine gfnff_ini(env,pr,makeneighbor,mol,gen,param,topo,neigh,efield,accurac
 
         call init_l(latPoint, env, mol%lattice, mol%boundaryCondition, MaxCutOff)
         call latPoint%getLatticepoints(transVec, MaxCutOff)
+        latPoint%ntrans = size(transVec, dim=2)
         allocate(dcndL(3,3,mol%n),source = 0.0d0)
         call getCoordinationNumber(mol, latPoint%nTrans, transVec, 40.0_wp, 5, cn, dcn, dcndL, param)   
         deallocate(dcndL)

--- a/src/gfnff/gfnff_ini2.f90
+++ b/src/gfnff/gfnff_ini2.f90
@@ -1107,12 +1107,13 @@ subroutine bond_hb_AHB_set(n,at,numbond,bond_hbn,bond_hbl,tot_AHB_nr,lin_AHB,top
 
 end subroutine bond_hb_AHB_set
 
-subroutine bond_hb_AHB_set1(n,at,numbond,bond_hbn,bond_hbl,tot_AHB_nr,lin_AHB,AH_count,bmax,neigh)
+subroutine bond_hb_AHB_set1(n,at,numbond,bond_hbn,bond_hbl,tot_AHB_nr,lin_AHB,AH_count,bmax,topo,neigh)
       use xtb_gfnff_param
       use xtb_gfnff_neighbor
       implicit none
       !Dummy
       type(TNeigh), intent(inout) :: neigh
+      type(TGFFTopology), intent(inout) :: topo
       integer,intent(in)  :: n
       integer,intent(in)  :: numbond
       integer,intent(in)  :: at(n)
@@ -1172,6 +1173,7 @@ subroutine bond_hb_AHB_set1(n,at,numbond,bond_hbn,bond_hbl,tot_AHB_nr,lin_AHB,AH
                      lin_AHB(2,tot_count) = hbH
                      lin_AHB(3,tot_count) = iTrA
                      lin_AHB(4,tot_count) = iTrH
+                     topo%isABH(Bat)=.true.
                      if (lin_AHB(1,tot_count)-lin_AHB(1,tot_count-1).eq.0.and.&
                         &lin_AHB(2,tot_count)-lin_AHB(2,tot_count-1).eq.0) then
                        lin_diff=0
@@ -1190,6 +1192,8 @@ subroutine bond_hb_AHB_set1(n,at,numbond,bond_hbn,bond_hbl,tot_AHB_nr,lin_AHB,AH
                  cycle
                end if
             end do
+            topo%isABH(hbA)=.true.
+            topo%isABH(hbH)=.true.
             neigh%nr_hb(i) = B_count
          end if
       end do

--- a/src/gfnff/topology.f90
+++ b/src/gfnff/topology.f90
@@ -84,6 +84,10 @@ module xtb_gfnff_topology
       real(wp),allocatable:: qfrag (:)     ! fragment charge (for EEQ)
       real(wp),allocatable:: hbbas (:)     ! HB donor atom basicity
       real(wp),allocatable:: hbaci (:)     ! HB acceptor atom acidity
+      integer, allocatable:: hb_mapABH(:)
+      logical, allocatable:: isABH(:)
+      integer :: hb_mapNAB
+      integer :: hb_mapNH
 
       integer, allocatable  :: ispinsyst(:,:)
       integer, allocatable  :: nspinsyst(:)

--- a/src/gfnff/topology.f90
+++ b/src/gfnff/topology.f90
@@ -84,10 +84,10 @@ module xtb_gfnff_topology
       real(wp),allocatable:: qfrag (:)     ! fragment charge (for EEQ)
       real(wp),allocatable:: hbbas (:)     ! HB donor atom basicity
       real(wp),allocatable:: hbaci (:)     ! HB acceptor atom acidity
-      integer, allocatable:: hb_mapABH(:)
-      logical, allocatable:: isABH(:)
-      integer :: hb_mapNAB
-      integer :: hb_mapNH
+      integer, allocatable:: hb_mapABH(:)  ! mapping of indices from all atoms to only AB and H separately
+      logical, allocatable:: isABH(:)      ! logical set to true if the atom is part of a hydrogen bond
+      integer :: hb_mapNAB                 ! number of AB atoms that are part of a hydrogen bond
+      integer :: hb_mapNH                  ! number of H atoms that are part of a hydrogen bond
 
       integer, allocatable  :: ispinsyst(:,:)
       integer, allocatable  :: nspinsyst(:)

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -125,11 +125,14 @@ subroutine read_restart_gff(env,fname,n,version,success,verbose,topo,neigh)
                     & topo%natxbAB,topo%nbatm,topo%nfrag,topo%nsystem,topo%maxsystem
             read(ich) topo%nbond_blist,topo%nbond_vbond,topo%nangl_alloc,topo%ntors_alloc,topo%bond_hb_nr,topo%b_max
             read(ich) neigh%numnb, neigh%numctr, neigh%nbond, neigh%iTrDim
+            read(ich) topo%hb_mapNAB, topo%hb_mapNH
             topo%nbond = neigh%nbond
             call gfnff_param_alloc(topo,neigh, n)
             if (.not.allocated(topo%ispinsyst)) allocate( topo%ispinsyst(n,topo%maxsystem), source = 0 )
             if (.not.allocated(topo%nspinsyst)) allocate( topo%nspinsyst(topo%maxsystem), source = 0 )
             if (.not.allocated(neigh%nr_hb)) allocate(neigh%nr_hb(neigh%nbond))
+            if (.not.allocated(topo%hb_mapABH)) allocate(topo%hb_mapABH(n))
+            if (.not.allocated(topo%isABH)) allocate(topo%isABH(n))
             read(ich) neigh%blist
             read(ich) topo%alist
             read(ich) topo%tlist
@@ -145,6 +148,8 @@ subroutine read_restart_gff(env,fname,n,version,success,verbose,topo,neigh)
             read(ich) topo%bond_hb_B
             read(ich) topo%bond_hb_Bn
             read(ich) neigh%nr_hb
+            read(ich) topo%hb_mapABH
+            read(ich) topo%isABH
             read(ich) topo%vangl,topo%vtors,topo%chieeq, &
                & topo%gameeq,topo%alpeeq,topo%alphanb,topo%qa, &
                & topo%xyze0,topo%zetac6,&
@@ -214,6 +219,7 @@ subroutine write_restart_gff(env,fname,nat,version,topo,neigh)
             & topo%natxbAB,topo%nbatm,topo%nfrag,topo%nsystem, topo%maxsystem
    write(ich) topo%nbond_blist,topo%nbond_vbond,topo%nangl_alloc,topo%ntors_alloc,topo%bond_hb_nr,topo%b_max
    write(ich) neigh%numnb, neigh%numctr, neigh%nbond, neigh%iTrDim
+   write(ich) topo%hb_mapNAB, topo%hb_mapNH
    !Arrays Integers
    write(ich) neigh%blist
    write(ich) topo%alist
@@ -230,6 +236,8 @@ subroutine write_restart_gff(env,fname,nat,version,topo,neigh)
    write(ich) topo%bond_hb_B
    write(ich) topo%bond_hb_Bn
    write(ich) neigh%nr_hb
+   write(ich) topo%hb_mapABH
+   write(ich) topo%isABH
    !Arrays Reals
    write(ich) topo%vangl,topo%vtors,topo%chieeq,&
            & topo%gameeq,topo%alpeeq,topo%alphanb,topo%qa, &

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -129,6 +129,7 @@ subroutine read_restart_gff(env,fname,n,version,success,verbose,topo,neigh)
             call gfnff_param_alloc(topo,neigh, n)
             if (.not.allocated(topo%ispinsyst)) allocate( topo%ispinsyst(n,topo%maxsystem), source = 0 )
             if (.not.allocated(topo%nspinsyst)) allocate( topo%nspinsyst(topo%maxsystem), source = 0 )
+            if (.not.allocated(neigh%nr_hb)) allocate(neigh%nr_hb(neigh%nbond))
             read(ich) neigh%blist
             read(ich) topo%alist
             read(ich) topo%tlist
@@ -151,7 +152,6 @@ subroutine read_restart_gff(env,fname,n,version,success,verbose,topo,neigh)
             if (.not.allocated(neigh%vbond)) allocate (neigh%vbond(3,neigh%nbond))
             if (.not.allocated(neigh%nb)) allocate (neigh%nb(neigh%numnb,n,neigh%numctr))
             if (.not.allocated(neigh%blist)) allocate (neigh%blist(3,neigh%nbond))
-            if (.not.allocated(neigh%nr_hb)) allocate(neigh%nr_hb(neigh%nbond))
             if (.not.allocated(neigh%vbond)) allocate(neigh%vbond(3,neigh%nbond))
             if (.not.allocated(neigh%bpair)) allocate(neigh%bpair(n,n,neigh%numctr))
             if (.not.allocated(neigh%iTrSum)) allocate(neigh%iTrSum(neigh%iTrDim*(neigh%iTrDim+1)/2))


### PR DESCRIPTION
The matrix considered_ABH(n,n,n) allocation used in the HB scaled bond energy was unnecessarily large. I introduced a mapping from the atom index to the hb index for AB atoms and H atoms separately. Since this is done in the initialization of the force field, the new variables need to be part of the topology as well.