### PR TITLE
change product to hardcoded number fixes #1012 fixes #998 fixes #997

### DIFF
--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4039,7 +4039,7 @@ function get_cf(rTrans,gTrans,vol,avgAlp) result(cf)
   integer, parameter :: ewaldCutD(3) = 2
   integer, parameter :: ewaldCutR(3) = 2
   ! real space lattice vectors
-  real(wp), intent(in) :: rTrans(3, 125)  !previously rTrans(3, product(2*ewaldCutD + 1))
+  real(wp), intent(in) :: rTrans(:, :)
   ! reciprocal space lattice vectors
   real(wp), intent(in) :: gTrans(:, :)
   ! unit cell volume 

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4039,9 +4039,9 @@ function get_cf(rTrans,gTrans,vol,avgAlp) result(cf)
   integer, parameter :: ewaldCutD(3) = 2
   integer, parameter :: ewaldCutR(3) = 2
   ! real space lattice vectors
-  real(wp), intent(in) :: rTrans( 3, product(2*ewaldCutD+1))
+  real(wp), intent(in) :: rTrans( 3, 125)
   ! reciprocal space lattice vectors
-  real(wp), intent(in) :: gTrans(3, product(2*ewaldCutR+1)-1)
+  real(wp), intent(in) :: gTrans(3, 124)
   ! unit cell volume 
   real(wp), intent(in) :: vol
   ! average alphaEEQ value

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4039,9 +4039,9 @@ function get_cf(rTrans,gTrans,vol,avgAlp) result(cf)
   integer, parameter :: ewaldCutD(3) = 2
   integer, parameter :: ewaldCutR(3) = 2
   ! real space lattice vectors
-  real(wp), intent(in) :: rTrans( 3, 125)
+  real(wp), intent(in) :: rTrans(3, 125)  !previously rTrans(3, product(2*ewaldCutD + 1))
   ! reciprocal space lattice vectors
-  real(wp), intent(in) :: gTrans(3, 124)
+  real(wp), intent(in) :: gTrans(3, 124)  !previously gTrans(3, product(2*ewaldCutR + 1) - 1)
   ! unit cell volume 
   real(wp), intent(in) :: vol
   ! average alphaEEQ value

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4041,7 +4041,7 @@ function get_cf(rTrans,gTrans,vol,avgAlp) result(cf)
   ! real space lattice vectors
   real(wp), intent(in) :: rTrans(3, 125)  !previously rTrans(3, product(2*ewaldCutD + 1))
   ! reciprocal space lattice vectors
-  real(wp), intent(in) :: gTrans(3, 124)  !previously gTrans(3, product(2*ewaldCutR + 1) - 1)
+  real(wp), intent(in) :: gTrans(:, :)
   ! unit cell volume 
   real(wp), intent(in) :: vol
   ! average alphaEEQ value


### PR DESCRIPTION
I had the same compilation error as reference in #1012 , #998,  and #997.

This is clearly some sort of bug in gcc as it is clearly passing an array to product.

Unless I am misunderstanding something, changing to hardcoded numbers should not pose a problem. If desired, I could also do the explicit product. e.g. `(2*ewaldCutD(1) + 1)*(2*ewaldCutD(2) + 1)*(2*ewaldCutD(3) + 1)`

Closes #1012
Closes #998
Closes #997