### PR TITLE
Increase number of characters for Schoenflies notation from 4 to 6

### DIFF
--- a/src/thermo.f90
+++ b/src/thermo.f90
@@ -31,7 +31,7 @@ subroutine getsymmetry (pr, iunit, n, iat, xyz, symthr, maxatdesy, sfsym)
    real(wp) symthr
    Character(len=*) sfsym
    logical pr
-   Character(len=4) atmp
+   Character(len=6) atmp
    integer,allocatable :: ictdum(:,:)
 
    Real(wp) :: paramar (11)  !parameter array for get_schoenflies_


### PR DESCRIPTION
Applies the fix suggested in #593 which should help with #1052. This should allow Dinfh and Cinfh symmetries.