### PR TITLE
Fixes #1054 by ensuring thread savety of hessian calculations with GFN-FF

### DIFF
--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -197,6 +197,7 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
    real(wp),allocatable :: xtmp(:)
    type(tb_timer) :: timer
    real(wp) :: dispthr, cnthr, repthr, hbthr1, hbthr2
+   real(wp) :: dist(n,n)
    real(wp) :: ds(3,3)
    real(wp) :: convF  !convergence factor alpha, aka ewald parameter 
    logical, allocatable :: considered_ABH(:,:,:)
@@ -225,9 +226,6 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
 
    ! get Distances between atoms for repulsion
    call neigh%getTransVec(env,mol,sqrt(repthr))
-   if(allocated(neigh%distances)) deallocate(neigh%distances)
-   call getDistances(neigh%distances, mol, neigh)
-
 
    g  =  0
    exb = 0
@@ -291,6 +289,18 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
       sqrab(ij + i) = 0.0d0
       srab(ij + i) = 0.0d0
    enddo
+   if (mol%npbc.ne.0) then
+   dist = 0.0_wp
+   !$omp parallel do collapse(2) default(none) shared(dist,mol) &
+   !$omp private(i,j)
+   do i=1, mol%n
+     do j=1, mol%n
+       dist(j,i) = NORM2(mol%xyz(:,j)-mol%xyz(:,i))
+     enddo
+   enddo
+   !$omp end parallel do
+   endif
+
    if (pr) call timer%measure(1)
 
    !----------!
@@ -434,7 +444,7 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
      if (pr) call timer%measure(4)
    else
      if (pr) call timer%measure(4,'EEQ energy and q')
-     call goed_pbc_gfnff(env,mol,accuracy.gt.1,n,at,neigh%distances(:,:,1), &
+     call goed_pbc_gfnff(env,mol,accuracy.gt.1,n,at,dist, &
      & dfloat(ichrg),eeqtmp,cn,nlist%q,ees,solvation,param,topo, gTrans, &
      & rTrans, xtmp, convF)  ! without dq/dr
      ees = ees*mcf_ees 
@@ -602,7 +612,7 @@ endif
          dx=xa-xyz(1,jat)-neigh%transVec(1,iTr)
          dy=ya-xyz(2,jat)-neigh%transVec(2,iTr)
          dz=za-xyz(3,jat)-neigh%transvec(3,iTr)
-         rab=neigh%distances(jat,iat,iTr)
+         rab=NORM2(xyz(:,iat)-(xyz(:,jat)+neigh%transVec(:,iTr)))
          r2=rab**2
          ati=at(iat)
          atj=at(jat)
@@ -734,8 +744,6 @@ endif
    call neigh%getTransVec(env,mol,sqrt(hbthr2))
    if (pr) call timer%measure(10,'HB/XB (incl list setup)')
    if (update.or.require_update) then
-     if(allocated(neigh%distances)) deallocate(neigh%distances)
-     call getDistances(neigh%distances, mol, neigh)
      call gfnff_hbset(n,at,xyz,topo,neigh,nlist,hbthr1,hbthr2)
    end if
 
@@ -781,12 +789,11 @@ endif
            nbk=0
            iTr=0 ! nbk is the first neighbor of k !
            atnb=0
-           call neigh%jth_nb(nbk,1,k,iTr)
+           call neigh%jth_nb(n,xyz,nbk,1,k,iTr)
            ! get iTrC and cycle if out of cutoff (the cutoff used in last getTransVec call)
            iTrDum=neigh%fTrSum(iTr,iTrk)
            if(iTrDum.eq.-1.or.iTrDum.gt.neigh%nTrans)  cycle
            ! get number neighbors of neighbor of k !
-           if(nbk.le.0 .or. nbk.gt.n) write(*,*) 'nbk=',nbk
            if(nbk.ne.0) then
               nbnbk=sum(neigh%nb(neigh%numnb,nbk,:))
               atnb=at(nbk)
@@ -2283,7 +2290,7 @@ subroutine abhgfnff_eg2new(n,A,B,H,iTrA,iTrB,nbb,at,xyz,q,sqrab, &
 !     Neighbours of B
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when inb is shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when inb is shifted to iTr
 !        compute distances
          vecDum = neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
          dranb(1:3,i) = (xyz(1:3,A)+neigh%transVec(1:3,iTrA)) -(xyz(1:3,inb)+vecDum)
@@ -2456,7 +2463,7 @@ subroutine abhgfnff_eg2new(n,A,B,H,iTrA,iTrB,nbb,at,xyz,q,sqrab, &
       gdr(1:3,H) = gdr(1:3,H) + gh(1:3)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          gdr(1:3,inb) = gdr(1:3,inb) + gnb(1:3,i)
       end do
 
@@ -2466,7 +2473,7 @@ subroutine abhgfnff_eg2new(n,A,B,H,iTrA,iTrB,nbb,at,xyz,q,sqrab, &
       sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          vecDum = neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
          sigma=sigma+mcf_ehb*spread(gnb(:,i),1,3)*spread(xyz(:,inb)+vecDum,2,3)
       enddo
@@ -2543,7 +2550,7 @@ subroutine abhgfnff_eg2_rnr(n,A,B,H,iTrA,iTrB,at,xyz,q,sqrab,srab,energy,gdr,par
 !     Neighbours of B
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
 !        compute distances
          vTrinb=neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
          dranb(1:3,i) = (xyz(1:3,A)+neigh%transVec(1:3,iTrA)) -(xyz(1:3,inb)+vTrinb)
@@ -2753,7 +2760,7 @@ subroutine abhgfnff_eg2_rnr(n,A,B,H,iTrA,iTrB,at,xyz,q,sqrab,srab,energy,gdr,par
       gdr(1:3,H) = gdr(1:3,H) + gh(1:3)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          gdr(1:3,inb) = gdr(1:3,inb) + gnb(1:3,i) - gnb_lp(1:3)/dble(nbb)
       end do
 
@@ -2764,7 +2771,7 @@ subroutine abhgfnff_eg2_rnr(n,A,B,H,iTrA,iTrB,at,xyz,q,sqrab,srab,energy,gdr,par
       sigma=sigma+mcf_ehb*spread(gnb_lp,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
-         call neigh%jth_nb(inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
+         call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          vTrinb=neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
          sigma=sigma+mcf_ehb*spread(gnb(:,i),1,3)*spread(xyz(:,inb)+vTrinb,2,3)
          sigma=sigma-mcf_ehb*spread(gnb_lp(1:3)/dble(nbb),1,3)*spread(xyz(:,inb)+vTrinb,2,3)
@@ -3267,8 +3274,8 @@ subroutine batmgfnff_eg(n,iat,jat,kat,iTrj,iTrk,at,xyz,q,sqrab,srab,energy,g,ds,
    real*8 r2ij,r2jk,r2ik,c9,mijk,imjk,ijmk,rijk3,ang,angr9,rav3
    real*8 rij(3),rik(3),rjk(3),ri(3),rj(3),rk(3),drij,drik,drjk,dang,ff,fi,fj,fk,fqq
    parameter (fqq=3.0d0)
-   integer linij,linik,linjk,lina,i,j,iTrDum,dm1,dm2
-    lina(i,j)=min(i,j)+max(i,j)*(max(i,j)-1)/2
+   integer :: linij,linik,linjk,lina,i,j,iTrDum,dm1,dm2
+   lina(i,j)=min(i,j)+max(i,j)*(max(i,j)-1)/2
 
    fi=(1.d0-fqq*q(iat))
    fi=min(max(fi,-4.0d0),4.0d0)
@@ -3278,13 +3285,13 @@ subroutine batmgfnff_eg(n,iat,jat,kat,iTrj,iTrk,at,xyz,q,sqrab,srab,energy,g,ds,
    fk=min(max(fk,-4.0d0),4.0d0)
    ff=fi*fj*fk ! charge term
    c9=ff*param%zb3atm(at(iat))*param%zb3atm(at(jat))*param%zb3atm(at(kat)) ! strength of interaction
-   r2ij=neigh%distances(jat,iat,iTrj)**2
-   r2ik=neigh%distances(kat,iat,iTrk)**2
+   r2ij=NORM2(xyz(:,iat)-(xyz(:,jat)+neigh%transVec(:,iTrj)))**2
+   r2ik=NORM2(xyz(:,iat)-(xyz(:,kat)+neigh%transVec(:,iTrk)))**2
    iTrDum=neigh%fTrSum(neigh%iTrNeg(iTrj),iTrk)
    if(iTrDum.le.0.or.iTrDum.gt.neigh%numctr) then
       r2jk=NORM2((xyz(:,kat)+neigh%transVec(:,iTrk))-(xyz(:,jat)+neigh%transVec(:,iTrj)))**2
    else
-      r2jk=neigh%distances(kat,jat,iTrDum)**2 !use adjusted iTr since jat is actually shifted
+      r2jk=NORM2(xyz(:,jat)-(xyz(:,kat)+neigh%transVec(:,iTrDum)))**2
    endif
    mijk=-r2ij+r2jk+r2ik
    imjk= r2ij-r2jk+r2ik

--- a/src/gfnff/gfnff_ini2.f90
+++ b/src/gfnff/gfnff_ini2.f90
@@ -343,7 +343,7 @@ subroutine gfnff_neigh(env,makeneighbor,natoms,at,xyz,rab,fq,f_in,f2_in,lintr, &
             if(nb20i.gt.3.and.ati.gt.10.and.nbdiff.eq.0) hyb(i)=5
             if(nb20i.eq.2)                               hyb(i)=3
             if(nb20i.eq.2.and.nbmdiff.gt.0) then
-              call nn_nearest_noM(i,natoms,at,neigh,rab,j,param) ! CN of closest non-M atom
+              call nn_nearest_noM(i,natoms,at,mol%xyz,neigh,rab,j,param) ! CN of closest non-M atom
                                         if(j.eq.3)       hyb(i)=2 ! M-O-X konj
                                         if(j.eq.4)       hyb(i)=3 ! M-O-X non
             endif
@@ -469,27 +469,32 @@ subroutine gfnff_neigh(env,makeneighbor,natoms,at,xyz,rab,fq,f_in,f2_in,lintr, &
 ! find the CN of the non metal atom that is closest to atom i
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine nn_nearest_noM(ii,n,at,neigh,r,nn,param)
+      subroutine nn_nearest_noM(ii,n,at,xyz,neigh,r,nn,param)
+      use xtb_mctc_accuracy, only : wp
       implicit none
       type(TGFFData), intent(in) :: param
       type(TNeigh), intent(in) :: neigh
       integer, intent(in) :: ii,n,at(n)
+      real(wp), intent(in) :: xyz(3,n)
       integer, intent(inout) :: nn
       real*8, intent(in) :: r(n*(n+1)/2)
 
       integer jmin,j,jj,lin, numnb, iTr
+      real(wp) :: dist
       real*8 rmin
 
       numnb=neigh%numnb
       nn=0
       rmin=1.d+42
       jmin=0
+      dist=0.0
       do iTr=1, neigh%numctr
         do j=1,neigh%nb(numnb,ii,iTr)
           jj=neigh%nb(j,ii,iTr)
           if(param%metal(at(jj)).ne.0) cycle
-          if(neigh%distances(jj,ii,iTr).lt.rmin)then
-            rmin=neigh%distances(jj,ii,iTr)
+          dist = NORM2(xyz(:,ii)-(xyz(:,jj)+neigh%transVec(:,iTr)))
+          if(dist.lt.rmin)then
+            rmin=dist
             jmin=jj
           endif
         enddo
@@ -786,29 +791,22 @@ subroutine gfnff_hbset(n,at,xyz,topo,neigh,nlist,hbthr1,hbthr2)
             ! get adjustet iTr -> for use of neigh% distances and bpair with two shifted atoms
             iTrDum=neigh%fTrSum(neigh%iTrNeg(iTri),iTrj) 
             if(iTrDum.gt.neigh%nTrans.or.iTrDum.lt.-1.or.iTrDum.eq.0) cycle ! cycle nonsense 
-            if(iTrDum.eq.-1) then
-              rab=NORM2((xyz(:,i)+neigh%transVec(:,iTri))-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
-              if(rab.gt.hbthr1) cycle
-              ijnonbond=.true. ! i and j are not in neighboring or same cell for iTrDum=-1
+            rab=NORM2((xyz(:,i)+neigh%transVec(:,iTri))-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
+            if(rab.gt.hbthr1) cycle
+            ! check if ij bonded
+            if(iTrDum.le.neigh%numctr) then
+              ijnonbond=neigh%bpair(j,i,iTrDum).ne.1
             else
-              ! check ij distance
-              rab=neigh%distances(j,i,iTrDum)**2 ! %distances are generated up to hbthr2 
-              if(rab.gt.hbthr1) cycle
-              ! check if ij bonded
-              if(iTrDum.le.neigh%numctr) then
-                ijnonbond=neigh%bpair(j,i,iTrDum).ne.1
-              else
-                ! i and j are not in neighboring cells
-                ijnonbond=.true. 
-              endif
+              ! i and j are not in neighboring cells
+              ijnonbond=.true. 
             endif
             ! loop over relevant H atoms
             do k=1,topo%nathbH
               free=.true. ! tripplet not assigned yet
               nh  =topo%hbatHl(1,k) ! nh always in central cell
               ! distances for non-cov bonded case
-              rih=neigh%distances(i,nh,iTri)**2
-              rjh=neigh%distances(j,nh,iTrj)**2
+              rih=NORM2(xyz(:,nh)-(xyz(:,i)+neigh%transVec(:,iTri)))**2
+              rjh=NORM2(xyz(:,nh)-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
               ! check if i is the bonded A    
               if(iTri.le.neigh%numctr) then ! nh is not shifted so bpair works without adjustment 
                 if(neigh%bpair(i,nh,iTri).eq.1.and.ijnonbond) then
@@ -902,16 +900,14 @@ use xtb_mctc_accuracy, only : wp
         do iTri=1,neigh%nTrans
           do iTrj=1,neigh%nTrans
             iTrDum=neigh%fTrSum(neigh%iTrNeg(iTri),iTrj)
-            if(iTrDum.eq.-1.or.iTrDum.gt.neigh%numctr) then 
-              rab=NORM2((xyz(:,i)+neigh%transVec(:,iTri))-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
-              if(rab.gt.hbthr1) cycle
-              ijnonbond=.true. ! i and j are not in neighboring cells for this range of iTrDum
-            else  
-              ! check ij distance
-              rab=neigh%distances(j,i,iTrDum)**2  ! %distances are generated up to hbthr2 
-              if(rab.gt.hbthr1) cycle
-              ! check if ij bonded
+            rab=NORM2((xyz(:,i)+neigh%transVec(:,iTri))-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
+            if(rab.gt.hbthr1) cycle
+            ! check if ij bonded
+            if(iTrDum.le.neigh%numctr) then
                 ijnonbond=neigh%bpair(j,i,iTrDum).ne.1
+            else
+                ! i and j are not in neighboring cells
+                ijnonbond=.true.
             endif
             ! loop over relevant H atoms
             do k=1,topo%nathbH  
@@ -983,7 +979,7 @@ use xtb_mctc_accuracy, only : wp
               ijnonbond=.true. ! i and j are not in neighboring or same cell for iTrDum=-1
             else
               ! check ij distance
-              rab=neigh%distances(j,i,iTrDum)**2
+              rab=NORM2(xyz(:,i)-(xyz(:,j)+neigh%transVec(:,iTrDum)))**2
               if(rab.gt.hbthr1) cycle
               ! check if ij bonded
               ijnonbond=neigh%bpair(j,i,iTrDum).ne.1
@@ -1295,15 +1291,15 @@ use xtb_mctc_accuracy, only : wp
               if(rab.gt.hbthr1) cycle
               ijnonbond=.true. ! i and j are not in neighboring or same cell for iTrDum=-1
             else
-              ! check ij distance
-              rab=neigh%distances(j,i,iTrDum)**2  ! %distances are generated up to hbthr2 
+              ! check
+              rab=NORM2(xyz(:,i)-(xyz(:,j)+neigh%transVec(:,iTrDum)))**2
               if(rab.gt.hbthr1) cycle
               ! check if ij bonded
               if(iTrDum.le.neigh%numctr) then
                 ijnonbond=neigh%bpair(j,i,iTrDum).ne.1
               else
                 ! i and j are not in neighboring cells
-                ijnonbond=.true. 
+                ijnonbond=.true.
               endif
             endif
             ! loop over relevant H atoms
@@ -1311,8 +1307,8 @@ use xtb_mctc_accuracy, only : wp
               free=.true.
               nh  =topo%hbatHl(1,k) ! nh always in central cell
               ! distances for non-cov bonded case
-              rih=neigh%distances(i,nh,iTri)**2
-              rjh=neigh%distances(j,nh,iTrj)**2
+              rih=NORM2(xyz(:,nh)-(xyz(:,i)+neigh%transVec(:,iTri)))**2
+              rjh=NORM2(xyz(:,nh)-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
               ! check if i is the bonded A    
               if(iTri.le.neigh%numctr) then ! nh is not shifted so bpair works without adjustment 
                 if(neigh%bpair(i,nh,iTri).eq.1.and.ijnonbond) then
@@ -1341,7 +1337,7 @@ use xtb_mctc_accuracy, only : wp
           i =topo%xbatABl(1,ix)
           j =topo%xbatABl(2,ix)
           iTrj=topo%xbatABl(4,ix)
-          rab=neigh%distances(j,i,iTrj)**2 ! %distances are generated up to hbthr2 
+          rab=NORM2(xyz(:,i)-(xyz(:,j)+neigh%transVec(:,iTrj)))**2
           if(rab.gt.hbthr2)cycle
           nxb=nxb+1
         !enddo


### PR DESCRIPTION
The distance array neigh%distances was not allocated thread save and was removed from the neigh class.
Now the distances are calculated from the atom coordinates and the translation vectors.