### PR TITLE
Fix dftd4 tests by updating to more recent version

### DIFF
--- a/subprojects/dftd4.wrap
+++ b/subprojects/dftd4.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = dftd4
 url = https://github.com/dftd4/dftd4
-revision = v3.5.0
+revision = v3.6.0


### PR DESCRIPTION
Take more recent `dftd4` version to prevent tests from failing.
```
[wrap-git]
directory = dftd4
url = https://github.com/dftd4/dftd4
revision = v3.6.0
```
