### PR TITLE
Update GitHub workflow to latest state

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -10,13 +10,13 @@ jobs:
       strategy:
          fail-fast: false
          matrix:
-            os: [macos-13, ubuntu-latest]
-            fc: [gfortran-11]
-            cc: [gcc-11]
+            os: [macos-latest, ubuntu-latest]
+            fc: [gfortran-12]
+            cc: [gcc-12]
             include:
             -  os: ubuntu-latest
-               fc: gfortran-9
-               cc: gcc-9
+               fc: gfortran-11
+               cc: gcc-11
             -  os: ubuntu-latest
                fc: gfortran-10
                cc: gcc-10
@@ -26,18 +26,20 @@ jobs:
          uses: actions/checkout@v4
 
       -  name: Setup Python
-         uses: actions/setup-python@v4
+         uses: actions/setup-python@v5
          with:
             python-version: 3.x
 
-      -  name: Install OpenBLAS (OSX)
+      -  name: Install OpenBLAS (macOS)
          if: ${{ contains(matrix.os, 'macos') }}
          run: |
             brew install openblas
             echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
-        
+            echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
+            echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
+
       -  name: Install meson
-         run: pip3 install meson==0.62.0 ninja cmake
+         run: pip install meson ninja cmake
 
       -  name: Configure build
          run: >-

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -1,9 +1,7 @@
 name: CI
 on: [push, pull_request]
-
 env:
-  BUILD_DIR: _build
-
+   BUILD_DIR: _build
 jobs:
    gcc-meson-build:
       runs-on: ${{ matrix.os }}
@@ -11,59 +9,49 @@ jobs:
          fail-fast: false
          matrix:
             os: [macos-latest, ubuntu-latest]
-            fc: [gfortran-12]
-            cc: [gcc-12]
+            fc: [gfortran-11, gfortran-12]
+            cc: [gcc-11, gcc-12]
             include:
-            -  os: ubuntu-latest
-               fc: gfortran-11
-               cc: gcc-11
-            -  os: ubuntu-latest
-               fc: gfortran-10
-               cc: gcc-10
-
+               - os: ubuntu-latest
+                 fc: gfortran-10
+                 cc: gcc-10
+               - os: macos-latest
+                 fc: gfortran-13
+                 cc: gcc-13
+               - os: macos-latest
+                 fc: gfortran-14
+                 cc: gcc-14
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v4
-
-      -  name: Setup Python
-         uses: actions/setup-python@v5
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v4
+         - name: Setup Python
+           uses: actions/setup-python@v5
+           with:
             python-version: 3.x
-
-      -  name: Install OpenBLAS (macOS)
-         if: ${{ contains(matrix.os, 'macos') }}
-         run: |
+         - name: Install OpenBLAS (macOS)
+           if: ${{ contains(matrix.os, 'macos') }}
+           run: |
             brew install openblas
             echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
             echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
             echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
-
-      -  name: Install meson
-         run: pip install meson ninja cmake
-
-      -  name: Configure build
-         run: >-
-            meson setup ${{ env.BUILD_DIR }}
-            --buildtype=debug
-            --warnlevel=0
-            -Db_coverage=true
-            ${{ env.MESON_ARGS }}
-         env:
+         - name: Install meson
+           run: pip install meson ninja cmake
+         - name: Configure build
+           run: >-
+            meson setup ${{ env.BUILD_DIR }} --buildtype=debug --warnlevel=0 -Db_coverage=true ${{ env.MESON_ARGS }}
+           env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}
             MESON_ARGS: ${{ contains(matrix.os, 'macos') && '-Dlapack=openblas' || '-Dlapack=netlib' }}
-
-      -  name: Build project
-         run: meson compile -C ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
-         env:
+         - name: Build project
+           run: meson compile -C ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
+           env:
             OMP_NUM_THREADS: 2,1
-
-      -  name: Upload coverage report
-         run: bash <(curl -s https://codecov.io/bash)
-
+         - name: Upload coverage report
+           run: bash <(curl -s https://codecov.io/bash)
    gcc-cmake-build:
       runs-on: ${{ matrix.os }}
       strategy:
@@ -72,34 +60,27 @@ jobs:
             os: [ubuntu-latest]
             fc: [gfortran-10]
             cc: [gcc-10]
-
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v4
-      
-      -  name: Setup Python
-         uses: actions/setup-python@v4
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v4
+         - name: Setup Python
+           uses: actions/setup-python@v4
+           with:
             python-version: 3.x
-
-      -  name: Install CMake
-         run: pip3 install ninja cmake
-
-      -  name: Configure build
-         run: cmake -B ${{ env.BUILD_DIR }} -G Ninja
-         env:
+         - name: Install CMake
+           run: pip3 install ninja cmake
+         - name: Configure build
+           run: cmake -B ${{ env.BUILD_DIR }} -G Ninja
+           env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}
-
-      -  name: Build project
-         run: cmake --build ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: ctest --parallel --output-on-failure -R 'xtb/*'
-         working-directory: ${{ env.BUILD_DIR }}
-         env:
+         - name: Build project
+           run: cmake --build ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: ctest --parallel --output-on-failure -R 'xtb/*'
+           working-directory: ${{ env.BUILD_DIR }}
+           env:
             OMP_NUM_THREADS: 2,1
-   
    xtb-lightweight-meson-build:
       runs-on: ${{ matrix.os }}
       strategy:
@@ -108,38 +89,28 @@ jobs:
             os: [ubuntu-latest]
             fc: [gfortran-11]
             cc: [gcc-11]
-
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v4
-
-      -  name: Setup Python
-         uses: actions/setup-python@v4
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v4
+         - name: Setup Python
+           uses: actions/setup-python@v4
+           with:
             python-version: 3.x
-   
-      -  name: Install meson
-         run: pip3 install meson==0.62.0 ninja cmake
-
-      -  name: Configure build
-         run: >-
-            meson setup ${{ env.BUILD_DIR }}
-            --buildtype=debug
-            --warnlevel=0
-            ${{ env.MESON_ARGS }}
-         env:
+         - name: Install meson
+           run: pip3 install meson==0.62.0 ninja cmake
+         - name: Configure build
+           run: >-
+            meson setup ${{ env.BUILD_DIR }} --buildtype=debug --warnlevel=0 ${{ env.MESON_ARGS }}
+           env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}
             MESON_ARGS: ${{ '-Dlapack=netlib -Dtblite=disabled -Dcpcmx=disabled' }}
-
-      -  name: Build project
-         run: meson compile -C ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
-         env:
+         - name: Build project
+           run: meson compile -C ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
+           env:
             OMP_NUM_THREADS: 2,1
-
    xtb-lightweight-cmake-build:
       runs-on: ${{ matrix.os }}
       strategy:
@@ -148,80 +119,60 @@ jobs:
             os: [ubuntu-latest]
             fc: [gfortran-10]
             cc: [gcc-10]
-
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v4
-
-      -  name: Setup Python
-         uses: actions/setup-python@v4
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v4
+         - name: Setup Python
+           uses: actions/setup-python@v4
+           with:
             python-version: 3.x
-
-      -  name: Install CMake
-         run: pip3 install ninja cmake
-
-      -  name: Configure build
-         run: cmake -B ${{ env.BUILD_DIR }} -DWITH_CPCMX=false -DWITH_TBLITE=false -G Ninja
-         env:
+         - name: Install CMake
+           run: pip3 install ninja cmake
+         - name: Configure build
+           run: cmake -B ${{ env.BUILD_DIR }} -DWITH_CPCMX=false -DWITH_TBLITE=false -G Ninja
+           env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}
-
-      -  name: Build project
-         run: cmake --build ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: ctest --parallel --output-on-failure -R 'xtb/*'
-         working-directory: ${{ env.BUILD_DIR }}
-         env:
+         - name: Build project
+           run: cmake --build ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: ctest --parallel --output-on-failure -R 'xtb/*'
+           working-directory: ${{ env.BUILD_DIR }}
+           env:
             OMP_NUM_THREADS: 2,1
-
    # Test native MinGW Windows build
    mingw-meson-build:
       runs-on: windows-latest
       strategy:
          fail-fast: false
          matrix:
-            include: [
-               { msystem: MINGW64, arch: x86_64 },
-            # { msystem: MINGW32, arch: i686   }
+            include: [{msystem: MINGW64, arch: x86_64,}
+               # { msystem: MINGW32, arch: i686   }
             ]
       defaults:
          run:
             shell: msys2 {0}
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v3
-
-      -  name: Setup MSYS2 toolchain
-         uses: msys2/setup-msys2@v2
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v3
+         - name: Setup MSYS2 toolchain
+           uses: msys2/setup-msys2@v2
+           with:
             msystem: ${{ matrix.msystem }}
             update: false
             install: >-
-               git
-               mingw-w64-${{ matrix.arch }}-gcc-fortran
-               mingw-w64-${{ matrix.arch }}-openblas
-               mingw-w64-${{ matrix.arch }}-lapack
-               mingw-w64-${{ matrix.arch }}-python
-               mingw-w64-${{ matrix.arch }}-python-pip
-               mingw-w64-${{ matrix.arch }}-meson
-               mingw-w64-${{ matrix.arch }}-ninja
-
-      -  name: Configure build
-         run: meson setup ${{ env.BUILD_DIR }} -Dlapack=netlib --warnlevel=0
-         env:
+               git mingw-w64-${{ matrix.arch }}-gcc-fortran mingw-w64-${{ matrix.arch }}-openblas mingw-w64-${{ matrix.arch }}-lapack mingw-w64-${{ matrix.arch }}-python mingw-w64-${{ matrix.arch }}-python-pip mingw-w64-${{ matrix.arch }}-meson mingw-w64-${{ matrix.arch }}-ninja
+         - name: Configure build
+           run: meson setup ${{ env.BUILD_DIR }} -Dlapack=netlib --warnlevel=0
+           env:
             FC: gfortran
             CC: gcc
-
-      -  name: Build project
-         run: meson compile -C ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
-         env:
+         - name: Build project
+           run: meson compile -C ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --no-rebuild -t 120 --suite xtb
+           env:
             OMP_NUM_THREADS: 1
-
    intel-meson-build:
       runs-on: ${{ matrix.os }}
       strategy:
@@ -234,155 +185,104 @@ jobs:
          FC: ${{ matrix.fc }}
          CC: ${{ matrix.cc }}
          APT_PACKAGES: >-
-            intel-oneapi-compiler-fortran-2022.1.0
-            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0
-            intel-oneapi-mkl-2022.1.0
-            intel-oneapi-mkl-devel-2022.1.0
-            asciidoctor
-
+            intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-mkl-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 asciidoctor
       steps:
-      -  name: Checkout code
-         uses: actions/checkout@v3
-
-      -  name: Setup Python
-         uses: actions/setup-python@v1
-         with:
+         - name: Checkout code
+           uses: actions/checkout@v3
+         - name: Setup Python
+           uses: actions/setup-python@v1
+           with:
             python-version: 3.x
-
-      - run: pip3 install meson ninja --user
-
-      -  name: Add Intel repository
-         if: contains(matrix.os, 'ubuntu')
-         run: |
+         - run: pip3 install meson ninja --user
+         - name: Add Intel repository
+           if: contains(matrix.os, 'ubuntu')
+           run: |
             wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
             sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
             rm GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
             echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
             sudo apt-get update
-
-      -  name: Install Intel oneAPI compiler
-         if: contains(matrix.os, 'ubuntu')
-         run: |
+         - name: Install Intel oneAPI compiler
+           if: contains(matrix.os, 'ubuntu')
+           run: |
             sudo apt-get install ${APT_PACKAGES}
             source /opt/intel/oneapi/setvars.sh
             printenv >> $GITHUB_ENV
-
-      -  name: Configure meson build
-         run: >-
-            meson setup ${{ env.BUILD_DIR }}
-            --prefix=/ --libdir=lib
-            -Dfortran_link_args="-lifcoremt -static"
-            -Ddefault_library=static
-            -Dlapack=mkl
-
-      -  name: Build project
-         run: ninja -C ${{ env.BUILD_DIR }}
-
-      -  name: Run unit tests
-         run: >-
-            meson test -C ${{ env.BUILD_DIR }}
-            --print-errorlogs
-            --num-processes 1
-            --no-rebuild
-            --suite xtb
-            -t 120
-         env:
+         - name: Configure meson build
+           run: >-
+            meson setup ${{ env.BUILD_DIR }} --prefix=/ --libdir=lib -Dfortran_link_args="-lifcoremt -static" -Ddefault_library=static -Dlapack=mkl
+         - name: Build project
+           run: ninja -C ${{ env.BUILD_DIR }}
+         - name: Run unit tests
+           run: >-
+            meson test -C ${{ env.BUILD_DIR }} --print-errorlogs --num-processes 1 --no-rebuild --suite xtb -t 120
+           env:
             OMP_NUM_THREADS: 2,1
-
-      -  name: Install package
-         run: |
+         - name: Install package
+           run: |
             meson install -C ${{ env.BUILD_DIR }} --no-rebuild
             tar cJvf xtb-bleed.tar.xz xtb-bleed
-         env:
+           env:
             DESTDIR: ${{ env.PWD }}/xtb-bleed
-
-      -  name: Upload binary
-         if: github.event_name == 'push'
-         uses: actions/upload-artifact@v2
-         with:
+         - name: Upload binary
+           if: github.event_name == 'push'
+           uses: actions/upload-artifact@v2
+           with:
             name: xtb-bleed.tar.xz
             path: xtb-bleed.tar.xz
-
    # Inspired from https://github.com/endless-sky/endless-sky
    continuous-delivery:
       if: github.event_name == 'push'
       runs-on: ubuntu-latest
       needs:
          - intel-meson-build
-
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
          RELEASE_TAG: bleed
          OUTPUT_INTEL: xtb-bleed.tar.xz
-
       steps:
-      - uses: actions/checkout@v3
-
-      -  name: Install github-release
-         run: |
+         - uses: actions/checkout@v3
+         - name: Install github-release
+           run: |
             go install github.com/github-release/github-release@latest
             echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
             echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      -  name: Set environment variables
-         run: |
+         - name: Set environment variables
+           run: |
             echo "GITHUB_USER=$( echo ${{ github.repository }} | cut -d/ -f1 )" >> $GITHUB_ENV
             echo "GITHUB_REPO=$( echo ${{ github.repository }} | cut -d/ -f2 )" >> $GITHUB_ENV
-
-      -  name: Move/Create continuous tag
-         run: |
+         - name: Move/Create continuous tag
+           run: |
             git tag --force ${{ env.RELEASE_TAG }} ${{ github.sha }}
             git push --tags --force
-
-      -  name: Get Time
-         run: echo "TIME=$(date -u '+%Y/%m/%d, %H:%M')" >> $GITHUB_ENV
-
-      -  name: Check continuous release status
-         run: |
+         - name: Get Time
+           run: echo "TIME=$(date -u '+%Y/%m/%d, %H:%M')" >> $GITHUB_ENV
+         - name: Check continuous release status
+           run: |
             if ! github-release info -t ${{ env.RELEASE_TAG }} > /dev/null 2>&1; then
                echo "RELEASE_COMMAND=release" >> $GITHUB_ENV
             else
                echo "RELEASE_COMMAND=edit" >> $GITHUB_ENV
             fi
-
-      -  name: Setup continuous release
-         run: >-
-            github-release ${{ env.RELEASE_COMMAND }}
-            --tag ${{ env.RELEASE_TAG }}
-            --name "Bleeding edge version"
-            --description "$DESCRIPTION"
-            --pre-release
-         env:
+         - name: Setup continuous release
+           run: >-
+            github-release ${{ env.RELEASE_COMMAND }} --tag ${{ env.RELEASE_TAG }} --name "Bleeding edge version" --description "$DESCRIPTION" --pre-release
+           env:
             DESCRIPTION: |
                Created on ${{ env.TIME }} UTC by @${{ github.actor }} with commit ${{ github.sha }}.
                This is an automated distribution of the latest `xtb` version. This version is only minimally tested and may be unstable or even crash. Use with caution!
                https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      -  name: Download Artifacts
-         uses: actions/download-artifact@v2
-         with:
+         - name: Download Artifacts
+           uses: actions/download-artifact@v2
+           with:
             path: ${{ github.workspace }} # This will download all files
-
-      -  name: Create SHA256 checksum
-         run: |
+         - name: Create SHA256 checksum
+           run: |
             cd ${{ env.OUTPUT_INTEL }}
             sha256sum ${{ env.OUTPUT_INTEL }} > sha256.txt
-
-      -  name: Add ${{ env.OUTPUT_INTEL }} to release tag
-         run: >-
-            github-release upload
-            --tag ${{ env.RELEASE_TAG }}
-            --replace
-            --name ${{ env.OUTPUT_INTEL }}
-            --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}
-
-      -  name: Add SHA256 checksums to release tag
-         run: >-
-            github-release upload
-            --tag ${{ env.RELEASE_TAG }}
-            --replace
-            --name sha256.txt
-            --file ${{ env.OUTPUT_INTEL }}/sha256.txt
-
-
-      
+         - name: Add ${{ env.OUTPUT_INTEL }} to release tag
+           run: >-
+            github-release upload --tag ${{ env.RELEASE_TAG }} --replace --name ${{ env.OUTPUT_INTEL }} --file ${{ env.OUTPUT_INTEL }}/${{ env.OUTPUT_INTEL }}
+         - name: Add SHA256 checksums to release tag
+           run: >-
+            github-release upload --tag ${{ env.RELEASE_TAG }} --replace --name sha256.txt --file ${{ env.OUTPUT_INTEL }}/sha256.txt

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -9,18 +9,14 @@ jobs:
          fail-fast: false
          matrix:
             os: [macos-latest, ubuntu-latest]
-            fc: [gfortran-11, gfortran-12]
-            cc: [gcc-11, gcc-12]
+            version: [11, 12]
             include:
                - os: ubuntu-latest
-                 fc: gfortran-10
-                 cc: gcc-10
+                 version: 10
                - os: macos-latest
-                 fc: gfortran-13
-                 cc: gcc-13
+                 version: 13
                - os: macos-latest
-                 fc: gfortran-14
-                 cc: gcc-14
+                 version: 14
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
@@ -41,8 +37,8 @@ jobs:
            run: >-
             meson setup ${{ env.BUILD_DIR }} --buildtype=debug --warnlevel=0 -Db_coverage=true ${{ env.MESON_ARGS }}
            env:
-            FC: ${{ matrix.fc }}
-            CC: ${{ matrix.cc }}
+            FC: gfortran-${{ matrix.version }}
+            CC: gcc-${{ matrix.version }}
             MESON_ARGS: ${{ contains(matrix.os, 'macos') && '-Dlapack=openblas' || '-Dlapack=netlib' }}
          - name: Build project
            run: meson compile -C ${{ env.BUILD_DIR }}
@@ -58,17 +54,17 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-10]
-            cc: [gcc-10]
+            fc: [gfortran-12]
+            cc: [gcc-12]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
          - name: Setup Python
-           uses: actions/setup-python@v4
+           uses: actions/setup-python@v5
            with:
             python-version: 3.x
          - name: Install CMake
-           run: pip3 install ninja cmake
+           run: pip install ninja cmake
          - name: Configure build
            run: cmake -B ${{ env.BUILD_DIR }} -G Ninja
            env:
@@ -87,13 +83,13 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-11]
-            cc: [gcc-11]
+            fc: [gfortran-12]
+            cc: [gcc-12]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
          - name: Setup Python
-           uses: actions/setup-python@v4
+           uses: actions/setup-python@v5
            with:
             python-version: 3.x
          - name: Install meson
@@ -117,13 +113,13 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-10]
-            cc: [gcc-10]
+            fc: [gfortran-12]
+            cc: [gcc-12]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
          - name: Setup Python
-           uses: actions/setup-python@v4
+           uses: actions/setup-python@v5
            with:
             python-version: 3.x
          - name: Install CMake
@@ -154,7 +150,7 @@ jobs:
             shell: msys2 {0}
       steps:
          - name: Checkout code
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
          - name: Setup MSYS2 toolchain
            uses: msys2/setup-msys2@v2
            with:
@@ -178,7 +174,7 @@ jobs:
       strategy:
          fail-fast: false
          matrix:
-            os: [ubuntu-20.04]
+            os: [ubuntu-latest]
             fc: [ifort]
             cc: [icc]
       env:
@@ -188,9 +184,9 @@ jobs:
             intel-oneapi-compiler-fortran-2022.1.0 intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.1.0 intel-oneapi-mkl-2022.1.0 intel-oneapi-mkl-devel-2022.1.0 asciidoctor
       steps:
          - name: Checkout code
-           uses: actions/checkout@v3
+           uses: actions/checkout@v4
          - name: Setup Python
-           uses: actions/setup-python@v1
+           uses: actions/setup-python@v5
            with:
             python-version: 3.x
          - run: pip3 install meson ninja --user
@@ -241,7 +237,7 @@ jobs:
          RELEASE_TAG: bleed
          OUTPUT_INTEL: xtb-bleed.tar.xz
       steps:
-         - uses: actions/checkout@v3
+         - uses: actions/checkout@v4
          - name: Install github-release
            run: |
             go install github.com/github-release/github-release@latest

--- a/yamlfmt.yml
+++ b/yamlfmt.yml
@@ -1,0 +1,3 @@
+formatter:
+  type: basic
+  indent: 3


### PR DESCRIPTION
- update `gfortran` and `meson` versions

**NOTE:** The failing `CI / gcc-meson-build (macos-latest, 11)` is due to a failure in the subproject https://github.com/grimme-lab/CPCM-X, detailed [here](https://github.com/grimme-lab/CPCM-X/issues/38).