### PR TITLE
Remove `gcc-11` from CI on macOS as it got removed from the images

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -9,10 +9,12 @@ jobs:
          fail-fast: false
          matrix:
             os: [macos-latest, ubuntu-latest]
-            version: [11, 12]
+            version: [12]
             include:
                - os: ubuntu-latest
                  version: 10
+               - os: ubuntu-latest
+                 version: 11
                - os: macos-latest
                  version: 13
                - os: macos-latest


### PR DESCRIPTION
- remove `gcc-11`

Based on the following announcement:
https://github.com/actions/runner-images/issues/10213