### PR TITLE
Allocate set%ffnb dynamically.

### DIFF
--- a/src/gfnff/gfnff_ini.f90
+++ b/src/gfnff/gfnff_ini.f90
@@ -2450,10 +2450,12 @@ subroutine gfnff_topo_changes(env, neigh)
    integer :: int_tmp(40)
    integer :: i,j,idx,iTr,d1,d2,numnb,nnb
 
-   ! check if hardcoded size of ffnb is still up to date
-   if (size(set%ffnb, dim=1).ne.neigh%numnb) call env%error('The array set%ffnb has not been adjusted to changes in neigh%numnb.', source)
    ! only do something if there are changes stored in set%ffnb
-   if(set%ffnb(1,1).ne.-1) then
+   if(allocated(set%ffnb)) then
+      ! check if hardcoded size of ffnb is still up to date
+      if (size(set%ffnb, dim=1).ne.neigh%numnb) call env%error('The array set%ffnb has not been adjusted to changes in neigh%numnb.', source)
+      ! there should not be any "-1" in set%ffnb anymore, if it was set up correctly
+      if (any(set%ffnb.eq.-1)) call env%error('GFN-FF neighbor list could not be adjusted!', source)
       d2=size(set%ffnb, dim=2)
       do i=1, d2
          if (set%ffnb(1,i).eq.-1) exit

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -1510,15 +1510,11 @@ subroutine alloc_ffnb(env, fname)
    character(len=*),intent(in)  :: fname
    character(len=*), parameter :: source = 'alloc_ffnb'
    character(len=:),allocatable :: line
-   integer :: copy, err
-   integer :: id, ie
-   logical :: is_ffnb_block
-   ! character,private,parameter :: flag = '$' ! is defined for this module
-   integer :: n_changes ! number of atoms that neigh%nb should be adjusted for
 
-   copy=-1 ! do not copy the control file
-   n_changes = 0
-   is_ffnb_block = .false.
+   integer :: id, ie, err
+   logical :: is_ffnb_block = .false.
+   integer :: copy = -1
+   integer :: n_changes = 0 ! number of atoms that neigh%nb should be adjusted for
 
    call open_file(id,fname,'r')
    if (id.eq.-1) then

--- a/src/setparam.f90
+++ b/src/setparam.f90
@@ -517,9 +517,8 @@ module xtb_setparam
    !> PTB settings
    type(TPTBSetup) :: ptbsetup
    !> GFN-FF manual setup of nb list via xcontrol
-   !  allows a maximum of 164 atoms neighbors to be changed
    !  ffnb(42,i) stores the number of neighbors of atom i
-   integer :: ffnb(42,164) = -1
+   integer, allocatable :: ffnb(:,:)
    end type TSet
 
    type(TSet) :: set


### PR DESCRIPTION
The array used for the adjustment of the GFN-FF neighbor list (set%ffnb) is now allocated dynamically.
The first dimension is always the maximum number of neighbors allowed in GFN-FF (42 since 6.7.1) and the second dimension is the number of atoms that the neighbor list should be adjusted for.