### PR TITLE
Fix ICE for ifx 2024.1.0

### DIFF
--- a/src/constrain_pot.f90
+++ b/src/constrain_pot.f90
@@ -187,6 +187,7 @@ subroutine constrain_dist(fix,n,at,xyz,g,e)
       mm = 2*m-1
       i = fix%atoms(mm)
       j = fix%atoms(mm+1)
+      if (i == j) cycle ! workaround for ifx 2024.1.0
       r0= fix%val(m)
       rij=xyz(:,j)-xyz(:,i)
       r = norm2(rij)


### PR DESCRIPTION
This patch fixes Internal Compiler Error (ICE) of ifx 2024.1.0.

Discussion about this ICE is available here: https://community.intel.com/t5/Intel-Fortran-Compiler/xtb-ICE-during-compilation-of-constrain-pot-f90/m-p/1632218/highlight/true#M173722

Shortly, during compilation one can obtain the following message:
```
          #0 0x00000000023916e2
          #1 0x00000000023f5bc7
          #2 0x00000000023f5cf0
          #3 0x00007f232544fb50
          #4 0x0000000004394b15
          #5 0x0000000004395724
          #6 0x0000000004394bd1
          #7 0x0000000004391eec
          #8 0x000000000439099c
          #9 0x000000000438ffe2
         #10 0x000000000339c5af
         #11 0x000000000339c42d
         #12 0x000000000272fcd5
         #13 0x00000000023452ed
         #14 0x0000000002736dbd
         #15 0x000000000234505d
         #16 0x000000000272ea2a
         #17 0x000000000232eacf
         #18 0x000000000232cf52
         #19 0x00000000022d97eb
         #20 0x00000000024b171c
         #21 0x00007f232543bd85 __libc_start_main + 229
         #22 0x00000000021134e9

xtb/src/constrain_pot.f90: error #5633: **Internal compiler error: segmentation violation signal raised** Please report this error along with the circumstances in which it occurred in a Software Problem Report.  Note: File and line given may not be explicit cause of this error.
compilation aborted for xtb/src/constrain_pot.f90 (code 3)
```

This patch does not fix other issues related to ifx builds