### PR TITLE
Fix some warnings

### DIFF
--- a/src/constrain_pot.f90
+++ b/src/constrain_pot.f90
@@ -104,9 +104,9 @@ subroutine qpothess2(fix,n,at,xyz,h)
    ! calculate hessian
    do i = 1, fix%n !loop over all atoms
       ii = (fix%atoms(i)-1)*3
-      do k = 1, 3  !loop diagonal elements (xyz components)
-         do j = 1, fix%n !inner loop for sum over all atoms
-            if (i.ne.j) then
+      do j = 1, fix%n !inner loop for sum over all atoms
+         if (i.ne.j) then
+            do k = 1, 3  !loop diagonal elements (xyz components)
                rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
                r  = norm2(rij)
                r2 = r*r
@@ -123,9 +123,11 @@ subroutine qpothess2(fix,n,at,xyz,h)
                   iikl = lin(ii+k,ii+l)
                   h(iikl) = h(iikl) + 2.0_wp*fix%fc*r0*dx*dy/r3
                enddo !end loop same-atom block-diagonal elements
-            endif
-         enddo !end inner loop for sum over all atoms
-         do j = i+1, fix%n !loop over the rest (mixed atoms)
+            enddo !end loop diagonal elements (xyz components)
+         endif
+      enddo !end inner loop for sum over all atoms
+      do j = i+1, fix%n !loop over the rest (mixed atoms)
+         do k = 1, 3  !loop diagonal elements (xyz components)
             rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
             r  = norm2(rij)
             r2 = r*r
@@ -147,8 +149,8 @@ subroutine qpothess2(fix,n,at,xyz,h)
                   h(ikjm) = h(ikjm) - 2.0_wp*fix%fc*r0*dx*dy/r3
                endif
             enddo
-         enddo
-      enddo !end loop diagonal elements (xyz components)
+         enddo !end loop diagonal elements (xyz components)
+       enddo
    enddo !end loop atoms
 
 contains

--- a/src/constrain_pot.f90
+++ b/src/constrain_pot.f90
@@ -106,14 +106,14 @@ subroutine qpothess2(fix,n,at,xyz,h)
       ii = (fix%atoms(i)-1)*3
       do j = 1, fix%n !inner loop for sum over all atoms
          if (i.ne.j) then
+            rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
+            r  = norm2(rij)
+            r2 = r*r
+            r3 = r2*r
+            ij = lin(i-1,j-1)+1
+            r0 = fix%val(ij)
+            dr = r-r0
             do k = 1, 3  !loop diagonal elements (xyz components)
-               rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
-               r  = norm2(rij)
-               r2 = r*r
-               r3 = r2*r
-               ij = lin(i-1,j-1)+1
-               r0 = fix%val(ij)
-               dr = r-r0
                dx = xyz(k,fix%atoms(i))-xyz(k,fix%atoms(j))
                dx2 = dx*dx
                iik = lin(ii+k,ii+k)
@@ -127,23 +127,22 @@ subroutine qpothess2(fix,n,at,xyz,h)
          endif
       enddo !end inner loop for sum over all atoms
       do j = i+1, fix%n !loop over the rest (mixed atoms)
+         rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
+         r  = norm2(rij)
+         r2 = r*r
+         r3 = r2*r
+         ij = lin(i-1,j-1)+1
+         r0 = fix%val(ij)
+         dr = r-r0
+         jj = (fix%atoms(j)-1)*3
          do k = 1, 3  !loop diagonal elements (xyz components)
-            rij = xyz(:,fix%atoms(j))-xyz(:,fix%atoms(i))
-            r  = norm2(rij)
-            r2 = r*r
-            r3 = r2*r
-            ij = lin(i-1,j-1)+1
-            r0 = fix%val(ij)
-            dr = r-r0
-            jj = (fix%atoms(j)-1)*3
+            dx = xyz(k,fix%atoms(i))-xyz(k,fix%atoms(j))
             do m = 1, 3
                if (k.eq.m) then !same component case
-                  dx = xyz(k,fix%atoms(i))-xyz(k,fix%atoms(j))
                   dx2 = dx*dx
                   ijk = lin(ii+k,jj+k)
                   h(ijk) = h(ijk) - 2.0_wp*fix%fc*(1.0_wp+dx2/r2-dx2*dr/r3-r0/r)
                else !different component case
-                  dx = xyz(k,fix%atoms(i))-xyz(k,fix%atoms(j))
                   dy = xyz(m,fix%atoms(i))-xyz(m,fix%atoms(j))
                   ikjm = lin(ii+k,jj+m)
                   h(ikjm) = h(ikjm) - 2.0_wp*fix%fc*r0*dx*dy/r3

--- a/src/gfnff/frag_hess.f90
+++ b/src/gfnff/frag_hess.f90
@@ -29,16 +29,10 @@ module xtb_gfnff_fraghess
         integer, intent(in)  :: start
         integer, intent(in)  :: goal
         integer, intent(in)  :: numnb
-        integer, intent(in)  :: neighbours(20, nspin)
+        integer, intent(in)  :: neighbours(numnb, nspin, 1)
         real(wp), intent(in) :: input_distances(nspin, nspin)
         logical, intent(out) :: visited(nspin)
         integer, intent(out) :: precessor(nspin)
-        integer  :: current
-        integer  :: neighbour
-        integer  :: i_neighbours
-        integer  :: bonds
-        real(wp) :: alt_dist
-        real(wp) :: distance(nspin)
       end function shortest_distance
       subroutine eigsort4(lab,u,ew)
          use xtb_mctc_accuracy, only : sp

--- a/src/gfnff/frag_hess.f90
+++ b/src/gfnff/frag_hess.f90
@@ -40,14 +40,12 @@ module xtb_gfnff_fraghess
         real(wp) :: alt_dist
         real(wp) :: distance(nspin)
       end function shortest_distance
-      subroutine eigsort4(lab,ew,u)
+      subroutine eigsort4(lab,u,ew)
          use xtb_mctc_accuracy, only : sp
          implicit none
-         integer  :: ii,k, j, i
-         real(sp) :: pp, hilf
-         integer  :: lab
-         real(sp) :: ew(lab)
-         real(sp) :: u(lab,lab)
+         integer,  intent(in)    :: lab
+         real(sp), intent(inout) :: u(lab,lab)
+         real(sp), intent(inout) :: ew(lab)
       end subroutine eigsort4
     end interface
 
@@ -486,9 +484,9 @@ subroutine eigsort4(lab,u,ew)
    integer  :: ii,k, j, i
    real(sp) :: pp, hilf
 
-   integer, intent(in)    :: lab
-   real(sp), intent(inout) :: ew(lab)
+   integer,  intent(in)    :: lab
    real(sp), intent(inout) :: u(lab,lab)
+   real(sp), intent(inout) :: ew(lab)
 
    do ii = 2, lab
       i = ii - 1

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -1068,7 +1068,7 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
            hbH=jat
            hbA=iat
          else
-           write(*,'(10x,"No H-atom found in this bond ",i0,1x,i0)'), iat,jat
+           write(*,'(10x,"No H-atom found in this bond ",i0,1x,i0)') iat,jat
            return
          end if
 


### PR DESCRIPTION
Closes #1136
Closes #1137
Closes #1138

I have reordered cycles in constrain_pot.f90 and optimize them a little bit.

In frag_hess.f90 the interfaces were written improperly. With this patch, it is fixed.