### PR TITLE
CEH gradients

### DIFF
--- a/src/optimizer.f90
+++ b/src/optimizer.f90
@@ -1007,6 +1007,7 @@ pure subroutine solver_ssyevx(n,thr,A,U,e,fail)
    j=1
    call lapack_syevx('V','I','U',n,A,n,dum,dum,j,j,thr, &
    &           i,e,U,n,work,lwork,iwork,ifail,info)
+   fail = .false.
    if (info.ne.0) fail = .true.
 
    deallocate(iwork,work,ifail)
@@ -1033,6 +1034,7 @@ pure subroutine solver_sspevx(n,thr,A,U,e,fail)
 
    j=1
    call lapack_spevx('V','I','U',n,A,dum,dum,j,j,thr,i,e,U,n,work,iwork,ifail,info)
+   fail = .false.
    if (info.ne.0) fail = .true.
 
    deallocate(iwork,work,ifail)

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -544,7 +544,7 @@ contains
          select case (set%runtyp)
          case default
             call env%terminate('This is an internal error, please define your runtypes!')
-         case (p_run_scc, p_run_grad, p_run_opt, p_run_hess, p_run_ohess, p_run_bhess, &
+         case (p_run_prescc,p_run_scc, p_run_grad, p_run_opt, p_run_hess, p_run_ohess, p_run_bhess, &
                p_run_md, p_run_omd, p_run_path, p_run_screen, &
                p_run_modef, p_run_mdopt, p_run_metaopt)
             if (set%mode_extrun == p_ext_gfnff) then
@@ -1233,44 +1233,7 @@ contains
 
       ! ------------------------------------------------------------------------
       !  make some post processing afterward, show some timings and stuff
-      write (env%unit, '(a)')
-      write (env%unit, '(72("-"))')
-      call stop_timing_run
-      call stop_timing(1)
-      call prdate('E')
-      write (env%unit, '(72("-"))')
-      call prtiming(1, 'total')
-      call prtiming(2, 'SCF')
-      if ((set%runtyp == p_run_opt) .or. (set%runtyp == p_run_ohess) .or. &
-         &   (set%runtyp == p_run_omd) .or. (set%runtyp == p_run_metaopt)) then
-         call prtiming(3, 'ANC optimizer')
-      end if
-      if (set%runtyp == p_run_path) then
-         call prtiming(4, 'path finder')
-      end if
-      if (((set%runtyp == p_run_hess) .or. (set%runtyp == p_run_ohess) .or. (set%runtyp == p_run_bhess))) then
-         if (set%mode_extrun /= p_ext_turbomole) then
-            call prtiming(5, 'analytical hessian')
-         else
-            call prtiming(5, 'numerical hessian')
-         end if
-      end if
-      if ((set%runtyp == p_run_md) .or. (set%runtyp == p_run_omd) .or. &
-          (set%runtyp == p_run_metaopt)) then
-         call prtiming(6, 'MD')
-      end if
-      if (set%runtyp == p_run_screen) then
-         call prtiming(8, 'screen')
-      end if
-      if (set%runtyp == p_run_modef) then
-         call prtiming(9, 'mode following')
-      end if
-      if (set%runtyp == p_run_mdopt) then
-         call prtiming(10, 'MD opt.')
-      end if
-
-      write (env%unit, '(a)')
-      call terminate(0)
+      call finalize_xtb(env) 
 
    end subroutine xtbMain
 
@@ -2037,5 +2000,53 @@ contains
       call env%error("PTB not available without 'tblite'. Compiled without support for 'tblite' library.")
       call env%error("Please recompile without '-Dtblite=disabled' option or change meson setup.")
    end subroutine ptb_feature_not_implemented
+
+   !>  make some post processing afterward, show some timings and stuff
+   subroutine finalize_xtb(env)
+    
+      !> Calculation environment
+      type(TEnvironment), intent(in) :: env
+
+      write (env%unit, '(a)')
+      write (env%unit, '(72("-"))')
+      call stop_timing_run
+      call stop_timing(1)
+      call prdate('E')
+      write (env%unit, '(72("-"))')
+      call prtiming(1, 'total')
+      if (.not. set%runtyp == p_run_prescc) &
+         call prtiming(2, 'SCF')
+      if ((set%runtyp == p_run_opt) .or. (set%runtyp == p_run_ohess) .or. &
+         &   (set%runtyp == p_run_omd) .or. (set%runtyp == p_run_metaopt)) then
+         call prtiming(3, 'ANC optimizer')
+      end if
+      if (set%runtyp == p_run_path) then
+         call prtiming(4, 'path finder')
+      end if
+      if (((set%runtyp == p_run_hess) .or. (set%runtyp == p_run_ohess) .or. (set%runtyp == p_run_bhess))) then
+         if (set%mode_extrun /= p_ext_turbomole) then
+            call prtiming(5, 'analytical hessian')
+         else
+            call prtiming(5, 'numerical hessian')
+         end if
+      end if
+      if ((set%runtyp == p_run_md) .or. (set%runtyp == p_run_omd) .or. &
+          (set%runtyp == p_run_metaopt)) then
+         call prtiming(6, 'MD')
+      end if
+      if (set%runtyp == p_run_screen) then
+         call prtiming(8, 'screen')
+      end if
+      if (set%runtyp == p_run_modef) then
+         call prtiming(9, 'mode following')
+      end if
+      if (set%runtyp == p_run_mdopt) then
+         call prtiming(10, 'MD opt.')
+      end if
+
+      write (env%unit, '(a)')
+      call terminate(0)
+
+   end subroutine finalize_xtb
 
 end module xtb_prog_main

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -1199,6 +1199,7 @@ subroutine set_chrg(env,val)
 
 end subroutine set_chrg
 
+
 subroutine set_spin(env,val)
    implicit none
    character(len=*), parameter :: source = 'set_spin'

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -1031,7 +1031,8 @@ subroutine set_runtyp(typ)
    select case(typ)
    case default ! do nothing !
       call raise('E',typ//' is no valid runtyp (internal error)')
-
+   case ('prescc')
+      set%runtyp = p_run_prescc
    case('scc')
       set%runtyp = p_run_scc
 

--- a/src/setparam.f90
+++ b/src/setparam.f90
@@ -188,6 +188,7 @@ module xtb_setparam
    integer, parameter :: p_ext_ptb       = 17
    integer, parameter :: p_ext_mcgfnff   = 18
 
+   integer, parameter :: p_run_prescc  =   1
    integer, parameter :: p_run_scc    =   2
    integer, parameter :: p_run_grad   =   3
    integer, parameter :: p_run_opt    =   4

--- a/src/tblite/calculator.F90
+++ b/src/tblite/calculator.F90
@@ -492,12 +492,15 @@ subroutine num_grad_chrg(env, mol, tblite)
 
    ! write the numerical gradient to the ceh.charges.numgrad file
    call open_file(ich, 'ceh.charges.numgrad', 'w')
-   do i = 1, 3 ! cartesian axes-wise 
-      write(ich, '(3f12.6)') numgrad(i,:,:)
+   do i = 1, mol%n
+      do j = 1, mol%n
+         do k = 1, 3
+            write(ich, '(3f12.6)') numgrad(k,j,i)
+         enddo
+      enddo
    enddo
    call close_file(ich)
    write(env%unit, '(1x, a)') "CEH gradients written to ceh.charges.numgrad"
-
 
  end subroutine num_grad_chrg
  

--- a/src/tblite/calculator.F90
+++ b/src/tblite/calculator.F90
@@ -490,13 +490,13 @@ subroutine num_grad_chrg(env, mol, tblite)
    enddo
    !$omp end parallel do
 
-   ! write the numerical gradient to the ceh.grad file
-   call open_file(ich, 'ceh.grad', 'w')
+   ! write the numerical gradient to the ceh.charges.numgrad file
+   call open_file(ich, 'ceh.charges.numgrad', 'w')
    do i = 1, 3 ! cartesian axes-wise 
       write(ich, '(3f12.6)') numgrad(i,:,:)
    enddo
    call close_file(ich)
-   write(env%unit, '(1x, a)') "CEH gradients written to ceh.grad"
+   write(env%unit, '(1x, a)') "CEH gradients written to ceh.charges.numgrad"
 
 
  end subroutine num_grad_chrg

--- a/src/tblite/calculator.F90
+++ b/src/tblite/calculator.F90
@@ -60,7 +60,14 @@ module xtb_tblite_calculator
    private
 
    public :: TTBLiteCalculator, TTBLiteInput, newTBLiteCalculator, newTBLiteWavefunction
-   public :: get_ceh
+   public :: get_ceh, num_grad_chrg
+
+   type, private :: ceh
+      !> numerical gradients
+      logical :: grad
+      !> step size for numerical gradients
+      real(wp) :: step = 0.00001_wp
+   endtype
 
    !> Input for tblite library
    type :: TTBLiteInput
@@ -77,7 +84,7 @@ module xtb_tblite_calculator
       !> Colorful output
       logical :: color = .false.
       !> CEH charges
-      logical :: ceh = .false.
+      type(ceh), allocatable :: ceh
    end type TTBLiteInput
 
    !> Calculator interface for xTB based methods
@@ -250,10 +257,11 @@ subroutine newTBLiteWavefunction(env, mol, calc, chk)
             type(context_type) :: ctx
 
             ctx%solver = lapack_solver(lapack_algorithm%gvd)
-            ctx%terminal = context_terminal(calc%color)
 
-            write (env%unit, '(1x,a)') escape(ctx%terminal%cyan) // "Calculation of CEH charges" // &
-               & escape(ctx%terminal%reset)
+            ! temporary turn off colorful output
+            ! ctx%terminal = context_terminal(calc%color)
+            ! write (env%unit, '(0x,a)') escape(ctx%terminal%cyan) // "Calculation of CEH charges" // &
+            !    & escape(ctx%terminal%reset)
 
             call ceh_singlepoint(ctx, calc%tblite, struc, wfn, calc%accuracy, 1)
          end block
@@ -387,7 +395,7 @@ end subroutine get_spin_constants
 #endif
 
 !> get CEH charges via tblite
-subroutine get_ceh(env,mol,tblite)
+subroutine get_ceh(env,mol,tblite, ceh_chrg)
 
    use xtb_propertyoutput, only : print_charges
 
@@ -399,6 +407,9 @@ subroutine get_ceh(env,mol,tblite)
 
    !> tblite input
    type(TTBLiteInput), intent(in) :: tblite
+
+   !> CEH charges, if present assumed the numerical gradients are requested
+   real(wp), allocatable, optional, intent(out) :: ceh_chrg(:)
 
    !> initialize temporary calculator for CEH
    type(TTBLiteCalculator) :: calc_ceh
@@ -414,22 +425,83 @@ subroutine get_ceh(env,mol,tblite)
    tblite_ceh = tblite        ! copy the tblite input
    tblite_ceh%method = "ceh" 
 #if WITH_TBLITE
-   write(env%unit, '(a)') repeat('-', 36)
+
+   if (.not. present(ceh_chrg)) &
+      write(env%unit, '(1x, a, /, a)') "Calculation of CEH charges",repeat('-', 36)
    
    call newTBLiteCalculator(env, mol, calc_ceh, tblite_ceh)
    call newTBLiteWavefunction(env, mol, calc_ceh, chk_ceh)
+   
+   if (present(ceh_chrg)) then
+      allocate(ceh_chrg(mol%n))
+      ceh_chrg = chk_ceh%tblite%qat(:,1)  
+   else
+      ! create ceh.charges file !
+      call open_file(ich, 'ceh.charges', 'w') 
+      call print_charges(ich, mol%n, chk_ceh%tblite%qat(:,1))
+      call close_file(ich)
+      write(env%unit, '(1x, a)') "CEH charges written to ceh.charges"
+   endif
 
-   ! create ceh.charges file !
-   call open_file(ich, 'ceh.charges', 'w') 
-   call print_charges(ich, mol%n, chk_ceh%tblite%qat(:,1))
-   call close_file(ich)
-
-   write(env%unit, '(1x, a, /, a, /)') "CEH charges written to ceh.charges", repeat('-', 36)
 #else
     call feature_not_implemented(env)
 #endif
 
 end subroutine get_ceh
+
+!> get numerical gradients for charges
+subroutine num_grad_chrg(env, mol, tblite)
+   !> Calculation environment
+   type(TEnvironment), intent(inout) :: env
+   
+   !> Molecular structure data
+   type(TMolecule), intent(inout) :: mol
+   
+   !> step size for numerical gradients
+   type(TTBLiteInput), intent(in) :: tblite
+   
+   !> numerical gradients
+   real(wp) :: numgrad(3, mol%n, mol%n)
+   
+   real(wp), allocatable, dimension(:) :: cehr, cehl
+   !
+   integer :: i,j,k, ich
+
+   real(wp) :: step, step2 ! for numerical gradient
+   
+   numgrad=0.0_wp
+   step = tblite%ceh%step
+   step2 = 0.5_wp / step
+   call get_ceh(env,mol,tblite)
+   
+   !$omp parallel do private(j,cehr,cehl) shared(env, numgrad, mol, tblite, step, step2) 
+   do i = 1, mol%n
+      do j = 1, 3
+         mol%xyz(j,i) = mol%xyz(j,i) + step
+         call get_ceh(env, mol, tblite, cehr)
+
+         mol%xyz(j,i) = mol%xyz(j,i) - 2*step
+         call get_ceh(env, mol, tblite, cehl)
+         
+         numgrad(j,i,:) = step2 * (cehr - cehl) ! numerical gradient
+         mol%xyz(j,i) = mol%xyz(j,i) + step ! reset the coordinates
+         
+      enddo
+   enddo
+   !$omp end parallel do
+
+   ! write the numerical gradient to the ceh.grad file
+   call open_file(ich, 'ceh.grad', 'w')
+   do i = 1, 3 ! cartesian axes-wise 
+      write(ich, '(3f12.6)') numgrad(i,:,:)
+   enddo
+   call close_file(ich)
+   write(env%unit, '(1x, a)') "CEH gradients written to ceh.grad"
+
+
+ end subroutine num_grad_chrg
+ 
+
 
 #if ! WITH_TBLITE
 subroutine feature_not_implemented(env)


### PR DESCRIPTION
The implementation of the numerical charge gradients `num_grad_chrg` (for CEH).
The output is written to **ceh.grad**.
@lukaswittmann, please be careful with the [output](https://github.com/grimme-lab/xtb/blob/1186b5a4b3338a78e6ebe4e95d7dec924c536e90/src/tblite/calculator.F90#L495-L497) format.