### PR TITLE
Solvent aliases

### DIFF
--- a/src/solv/model.f90
+++ b/src/solv/model.f90
@@ -223,6 +223,32 @@ subroutine normalizeSolventName(solvent, input)
 
    solvent = lowercase(input)
 
+   !> Pick a consistent name to use for the solvents internally
+   select case(solvent)
+   case('acetonitrile','methylcyanide')
+     solvent='acetonitrile'
+   case('methylenechloride', 'dichloromethane', 'dcm', 'ch2cl2')
+     solvent='ch2cl2'
+   case('chloroform','chcl3','trichloromethane','tcm')
+     solvent='chcl3'
+   case('carbondisulfide','cs2')
+     solvent='cs2'
+   case('diethylether','ether')
+     solvent='ether'
+   case('dimethylformamide','dmf')
+     solvent='dmf'
+   case('dimethylsulfoxide','dmso')
+     solvent='dmso'
+   case('furane','furan')
+     solvent='furane'
+   case('nhexan','n-hexan','nhexane','n-hexane','hexane')
+     solvent='hexane'  
+   case('tetrahydrofuran','thf')
+     solvent='thf'
+   case('h2o','water')
+     solvent='water'
+   end select  
+     
 end subroutine normalizeSolventName
 
 


### PR DESCRIPTION
Adds additional solvent aliases for various supported solvents.

`normalizeSolventName` now chooses a consistent name to use for a given solvent internally.
 
Addresses https://github.com/grimme-lab/xtb/issues/1147