### PR TITLE
Fix ubuntu-latest CI and introduce Arm validation

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -60,6 +60,7 @@ jobs:
             os: [ubuntu-latest, ubuntu-24.04-arm]
             fc: [gfortran-14]
             cc: [gcc-14]
+            build: [Release, Debug]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
@@ -70,7 +71,7 @@ jobs:
          - name: Install CMake
            run: pip install ninja cmake
          - name: Configure build
-           run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=Release
+           run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build }}
            env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -101,6 +101,10 @@ jobs:
            uses: actions/setup-python@v5
            with:
             python-version: 3.x
+         - name: Install OpenBLAS (ubuntu-latest)
+           if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
+           run: |
+            sudo apt-get install libopenblas-dev
          - name: Install meson
            run: pip3 install meson==0.62.0 ninja cmake
          - name: Configure build
@@ -131,6 +135,10 @@ jobs:
            uses: actions/setup-python@v5
            with:
             python-version: 3.x
+         - name: Install OpenBLAS (ubuntu-latest)
+           if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
+           run: |
+            sudo apt-get install libopenblas-dev
          - name: Install CMake
            run: pip3 install ninja cmake
          - name: Configure build

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -60,7 +60,7 @@ jobs:
             os: [ubuntu-latest, ubuntu-24.04-arm]
             fc: [gfortran-14]
             cc: [gcc-14]
-            build: [Release, Debug]
+            build: [Release]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -57,7 +57,7 @@ jobs:
       strategy:
          fail-fast: false
          matrix:
-            os: [ubuntu-latest]
+            os: [ubuntu-latest, ubuntu-24.04-arm]
             fc: [gfortran-14]
             cc: [gcc-14]
       steps:

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -70,7 +70,7 @@ jobs:
          - name: Install CMake
            run: pip install ninja cmake
          - name: Configure build
-           run: cmake -B ${{ env.BUILD_DIR }} -G Ninja
+           run: cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_BUILD_TYPE=Release
            env:
             FC: ${{ matrix.fc }}
             CC: ${{ matrix.cc }}

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -31,6 +31,10 @@ jobs:
             echo "PKG_CONFIG_PATH=/usr/local/opt/openblas/lib/pkgconfig" >> $GITHUB_ENV
             echo "LDFLAGS=-L/opt/homebrew/opt/openblas/lib" >> $GITHUB_ENV
             echo "CPPFLAGS=-I/opt/homebrew/opt/openblas/include" >> $GITHUB_ENV
+         - name: Install OpenBLAS (ubuntu-latest)
+           if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
+           run: |
+            sudo apt-get install libopenblas-dev
          - name: Install meson
            run: pip install meson ninja cmake
          - name: Configure build

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -68,6 +68,10 @@ jobs:
            uses: actions/setup-python@v5
            with:
             python-version: 3.x
+         - name: Install OpenBLAS (ubuntu-latest)
+           if: ${{ matrix.os == 'ubuntu-latest' || contains(matrix.os, 'ubuntu-24.04') }}
+           run: |
+            sudo apt-get install libopenblas-dev
          - name: Install CMake
            run: pip install ninja cmake
          - name: Configure build

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -9,16 +9,12 @@ jobs:
          fail-fast: false
          matrix:
             os: [macos-latest, ubuntu-latest]
-            version: [12]
+            version: [12, 13, 14]
             include:
-               - os: ubuntu-latest
+               - os: ubuntu-22.04
                  version: 10
-               - os: ubuntu-latest
+               - os: ubuntu-22.04
                  version: 11
-               - os: macos-latest
-                 version: 13
-               - os: macos-latest
-                 version: 14
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
@@ -56,8 +52,8 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-12]
-            cc: [gcc-12]
+            fc: [gfortran-14]
+            cc: [gcc-14]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
@@ -85,8 +81,8 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-12]
-            cc: [gcc-12]
+            fc: [gfortran-14]
+            cc: [gcc-14]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4
@@ -115,8 +111,8 @@ jobs:
          fail-fast: false
          matrix:
             os: [ubuntu-latest]
-            fc: [gfortran-12]
-            cc: [gcc-12]
+            fc: [gfortran-14]
+            cc: [gcc-14]
       steps:
          - name: Checkout code
            uses: actions/checkout@v4

--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -15,6 +15,8 @@ jobs:
                  version: 10
                - os: ubuntu-22.04
                  version: 11
+               - os: ubuntu-24.04-arm
+                 version: 14
       steps:
          - name: Checkout code
            uses: actions/checkout@v4


### PR DESCRIPTION
Broken tests with CMake + Debug, so these build are currently disabled:
on x86_64:
```
The following tests FAILED:
	 57 - tblite/gfn1-xtb (NUMERICAL)
	 88 - xtb/docking (NUMERICAL)
	 90 - xtb/gfn0 (NUMERICAL)
	 91 - xtb/gfn1 (NUMERICAL)
	 94 - xtb/hessian (Failed)
	 95 - xtb/iff (NUMERICAL)
	101 - xtb/peeq (Failed)
	106 - xtb/vertical (Failed)
	116 - xtb/GFN0-xTB (NUMERICAL)
```
on Aarch64:
```
The following tests FAILED:
	 88 - xtb/docking (Failed)
	 93 - xtb/gfnff (Failed)
	 94 - xtb/hessian (Failed)
	106 - xtb/vertical (Failed)
	107 - xtb/wsc (Failed)
``` 