### PR TITLE
Fix multiple open of xtbscreen.xyz in local.f90 (xtb/iff test)

### DIFF
--- a/src/local.f90
+++ b/src/local.f90
@@ -494,14 +494,12 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis,r
          enddo
       enddo
       new=k
-
-      if(set%pr_local) then 
-      call close_file(iscreen)
-      end if
       deallocate(wbo)
 
-
    endif
+
+   if(set%pr_local) call close_file(iscreen)
+
    !ccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
    !> If the normal xtb mode is used with --lmo, set%pr_local is true and


### PR DESCRIPTION
By some reason, at https://github.com/grimme-lab/xtb/blob/c3cfd38d6753f92a07a916a47a52114af9e6b989/src/local.f90#L278 `xtbscreen.xyz` was opened at first scope level, but the file was closed at second scope level, and therefore, if the following check was failed:
https://github.com/grimme-lab/xtb/blob/c3cfd38d6753f92a07a916a47a52114af9e6b989/src/local.f90#L360
the close statement does not work for `xtbscreen.xyz` and then, at the next iteration, this file was opened at the second time.