### PR TITLE
Fix exit condition in calc_distances

### DIFF
--- a/src/main/geometry.f90
+++ b/src/main/geometry.f90
@@ -381,8 +381,8 @@ subroutine calc_distances(n,at,xyz,bond,maxdist,ndist,dist,id, &
          jat = at(j)
          r  = sqrt(sum((xyz(:,i)-xyz(:,j))**2))
          if (bond(j,i).gt.0) then
-            m = m+1
             if (m.ge.maxdist) exit get_dist
+            m = m+1
             ndel(iat,jat) = ndel(iat,jat)+1
             maxdel(iat,jat) = max(maxdel(iat,jat),r)
             mindel(iat,jat) = min(mindel(iat,jat),r)


### PR DESCRIPTION
Probably affects #621

Before patch, one distance were skipped between atoms `# N` and `# N-1`. For single-bonded systems (like H2) it is critical since it means that they were not bounded and then a lot of artefacts happen. 

Fixes #850. Changes in output:
```diff
  * 1 selected distances

      #   Z          #   Z                                           value/Å
-     0   0      0   0                                     0.0000000 (max)
+     1   1 H        2   1 H                                       0.7769870 (max)

- * 0 distinct bonds (by element types)
+ * 1 distinct bonds (by element types)

    Z      Z             #   av. dist./Å        max./Å        min./Å
+   1 H    1 H           1     0.7769870     0.7769870     0.7769870
```