### PR TITLE
Fix L-BFGS memory accesses

### DIFF
--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -484,7 +484,6 @@ subroutine l_ancopt &
    real(sp), allocatable :: eig(:)
    real(wp), allocatable :: trafo(:,:)
    real(wp), allocatable :: hdiag(:)
-   real(wp), allocatable :: anc(:)
    real(wp), allocatable :: xyz0(:,:)
    type(convergence_log), allocatable :: avconv
 
@@ -547,7 +546,7 @@ subroutine l_ancopt &
    ! get memory, allocate single and double precision arrays separately
    nat3 = 3*mol%n
    allocate( pmode(nat3,1), hessp(nat3*(nat3+1)/2), trafo(nat3,nat3), &
-      &      hdiag(nat3), xyz0(3,mol%n), anc(nat3), xyzopt(3,mol%n), &
+      &      hdiag(nat3), xyz0(3,mol%n), xyzopt(3,mol%n), &
       &      source = 0.0_wp )
    allocate( hess(nat3,nat3), eig(nat3), source = 0.0_sp )
    ! set defaults
@@ -723,14 +722,13 @@ subroutine l_ancopt &
    enddo
 
    ! reset approximate normal coordinate system
-   anc  = 0.0_wp
    xyz0 = molopt%xyz
    esave = energy
    if (profile) call timer%measure(3)
 
    call lbfgs_relax &
       &   (env,iter,thiscycle,opt,molopt, &
-      &    chk,calc,energy,egap,gradient,sigma,nvar,hdiag,trafo,anc,xyz0, &
+      &    chk,calc,energy,egap,gradient,sigma,nvar,hdiag,trafo,xyz0, &
       &    converged,fail,timer,avconv)
 
    thiscycle = min(ceiling(thiscycle*opt%cycle_inc),2*opt%micro_cycle)
@@ -864,7 +862,7 @@ end subroutine lbfgs_step
 !  is augmented with a coordinate transformation in approximate normal coordinates
 subroutine lbfgs_relax &
       &   (env,iter,maxcycle,opt,mol, &
-      &    chk,calc,energy,egap,g_xyz,sigma,nvar,hdiag,trafo,anc,xyz0, &
+      &    chk,calc,energy,egap,g_xyz,sigma,nvar,hdiag,trafo,xyz0, &
       &    converged,fail,timer,avconv)
 
    use xtb_type_molecule
@@ -915,8 +913,6 @@ subroutine lbfgs_relax &
    real(wp), intent(in) :: hdiag(:)
    !> transformation matrix for cartesian coordinates to ANC's
    real(wp), intent(in) :: trafo(:,:)
-   !> approximate normal coordinate system
-   real(wp), intent(inout) :: anc(:)
    !> start geometry used to generate ANC's
    real(wp), intent(in) :: xyz0(:,:)
    !> timer for profiling the relaxation procedure
@@ -949,6 +945,8 @@ subroutine lbfgs_relax &
    real(wp), allocatable :: lbfgs_y(:,:)
    real(wp), allocatable :: lbfgs_rho(:)
 
+   !> approximate normal coordinate system
+   real(wp), allocatable :: anc(:)
    !  RF variables
    integer :: nvar1,npvar,npvar1
    real(sp) :: dsnrm
@@ -977,7 +975,7 @@ subroutine lbfgs_relax &
 
    memory = min(opt%memory,maxcycle)
 
-   allocate( displacement(nvar), g_anc(nvar), glast(nvar), &
+   allocate( displacement(nvar), g_anc(nvar), glast(nvar), anc(nvar), &
       &      source = 0.0_wp )
 
    if (profile) call timer%measure(4,'coordinate transformation')

--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -546,7 +546,7 @@ subroutine l_ancopt &
    ! get memory, allocate single and double precision arrays separately
    nat3 = 3*mol%n
    allocate( pmode(nat3,1), hessp(nat3*(nat3+1)/2), trafo(nat3,nat3), &
-      &      hdiag(nat3), xyz0(3,mol%n), xyzopt(3,mol%n), &
+      &      xyz0(3,mol%n), xyzopt(3,mol%n), &
       &      source = 0.0_wp )
    allocate( hess(nat3,nat3), eig(nat3), source = 0.0_sp )
    ! set defaults
@@ -579,6 +579,8 @@ subroutine l_ancopt &
          if(nvar.le.0) nvar=1
       endif
    end if
+
+   allocate( hdiag(nvar), source = 0.0_wp )
 
    ! print a nice summary with all settings and thresholds of ANCopt
    if(pr)then


### PR DESCRIPTION
This patch fixes some incorrect allocations to their proper size for using `anc` and `hdiag` variables in array statements like:

here for hdiag:
https://github.com/grimme-lab/xtb/blob/c3cfd38d6753f92a07a916a47a52114af9e6b989/src/relaxation_engine.f90#L849
(`d` and `q` have size `nvar`, while `hdiag` had size `nat3`)

here for anc:
https://github.com/grimme-lab/xtb/blob/c3cfd38d6753f92a07a916a47a52114af9e6b989/src/relaxation_engine.f90#L1053
(`displacement` has size `nvar`, while `anc` had size `nat3`)