### PR TITLE
Fix xtb/docking test

### DIFF
--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -966,6 +966,7 @@ contains
       call generateFileName(fin_name, 'best', '', comb%ftype)
       call open_file(ifinal, fin_name, 'w')
       call writeMolecule(comb, ifinal, energy=final_e(1))
+      call close_file(ifinal)
       !If not xyz then best.xyz is written to not have api break
       if(comb%ftype /= 1)then
          call open_file(ifinal, 'best.xyz', 'w')
@@ -975,8 +976,8 @@ contains
             write (ifinal, '(a4,2x,3f20.14)') comb%sym(j), xyz_opt(1, j, 1)*autoang, &
             &                                 xyz_opt(2, j, 1)*autoang, xyz_opt(3, j, 1)*autoang
          end do
+         call close_file(ifinal)
       end if
-      call close_file(ifinal)
 
 
       call delete_file(set%opt_logfile)

--- a/src/iff/iff_energy.f90
+++ b/src/iff/iff_energy.f90
@@ -95,9 +95,6 @@ contains
       logical :: linear, ATM, ijh, ijx
       character(len=4) :: pgroup
 
-      !> threshold
-      real(wp), parameter :: rClose = 1e-12_wp
-
       !> Initial stuff
       metal = 1
       metal(1:2) = 0
@@ -278,18 +275,16 @@ contains
             r2 = (AL1(1, i) - AL2(1, j))**2&
               &+ (AL1(2, i) - AL2(2, j))**2&
               &+ (AL1(3, i) - AL2(3, j))**2
-            if (r2 .lt. rClose) cycle
             r = sqrt(r2)
-            esl = esl + AL1(4, i)*AL2(4, j)/(r + r0tmp(jat, iat)/r)
+            esl = esl + AL1(4, i)*AL2(4, j)*r/(r*r + r0tmp(jat, iat))
          end do
 !        LP atom corrections
          do j = 1, n2
             r2 = (A2(1, j) - AL1(1, i))**2&
               &+ (A2(2, j) - AL1(2, i))**2&
               &+ (A2(3, j) - AL1(3, i))**2
-            if (r2 .lt. rClose) cycle
             r = sqrt(r2)
-            esl = esl + AL1(4, i)*q2(j)/(r + r0tmp(j, iat)/r)
+            esl = esl + AL1(4, i)*q2(j)*r/(r*r + r0tmp(j, iat))
          end do
       end do
 !     LP atom corrections
@@ -299,9 +294,8 @@ contains
             r2 = (A1(1, j) - AL2(1, i))**2&
               &+ (A1(2, j) - AL2(2, i))**2&
               &+ (A1(3, j) - AL2(3, i))**2
-            if (r2 .lt. rClose) cycle
             r = sqrt(r2)
-            esl = esl + AL2(4, i)*q1(j)/(r + r0tmp(iat, j)/r)
+            esl = esl + AL2(4, i)*q1(j)*r/(r*r + r0tmp(iat, j))
          end do
       end do
 

--- a/src/iff/iff_energy.f90
+++ b/src/iff/iff_energy.f90
@@ -95,6 +95,9 @@ contains
       logical :: linear, ATM, ijh, ijx
       character(len=4) :: pgroup
 
+      !> threshold
+      real(wp), parameter :: rClose = 1e-12_wp
+
       !> Initial stuff
       metal = 1
       metal(1:2) = 0
@@ -275,7 +278,8 @@ contains
             r2 = (AL1(1, i) - AL2(1, j))**2&
               &+ (AL1(2, i) - AL2(2, j))**2&
               &+ (AL1(3, i) - AL2(3, j))**2
-            r = dble(sqrt(real(r2)))
+            if (r2 .lt. rClose) cycle
+            r = sqrt(r2)
             esl = esl + AL1(4, i)*AL2(4, j)/(r + r0tmp(jat, iat)/r)
          end do
 !        LP atom corrections
@@ -283,7 +287,8 @@ contains
             r2 = (A2(1, j) - AL1(1, i))**2&
               &+ (A2(2, j) - AL1(2, i))**2&
               &+ (A2(3, j) - AL1(3, i))**2
-            r = dble(sqrt(real(r2)))
+            if (r2 .lt. rClose) cycle
+            r = sqrt(r2)
             esl = esl + AL1(4, i)*q2(j)/(r + r0tmp(j, iat)/r)
          end do
       end do
@@ -294,7 +299,8 @@ contains
             r2 = (A1(1, j) - AL2(1, i))**2&
               &+ (A1(2, j) - AL2(2, i))**2&
               &+ (A1(3, j) - AL2(3, i))**2
-            r = dble(sqrt(real(r2)))
+            if (r2 .lt. rClose) cycle
+            r = sqrt(r2)
             esl = esl + AL2(4, i)*q1(j)/(r + r0tmp(iat, j)/r)
          end do
       end do

--- a/src/iff/iff_energy.f90
+++ b/src/iff/iff_energy.f90
@@ -276,7 +276,7 @@ contains
               &+ (AL1(2, i) - AL2(2, j))**2&
               &+ (AL1(3, i) - AL2(3, j))**2
             r = sqrt(r2)
-            esl = esl + AL1(4, i)*AL2(4, j)*r/(r*r + r0tmp(jat, iat))
+            esl = esl + AL1(4, i)*AL2(4, j)*r/(r2 + r0tmp(jat, iat))
          end do
 !        LP atom corrections
          do j = 1, n2
@@ -284,7 +284,7 @@ contains
               &+ (A2(2, j) - AL1(2, i))**2&
               &+ (A2(3, j) - AL1(3, i))**2
             r = sqrt(r2)
-            esl = esl + AL1(4, i)*q2(j)*r/(r*r + r0tmp(j, iat))
+            esl = esl + AL1(4, i)*q2(j)*r/(r2 + r0tmp(j, iat))
          end do
       end do
 !     LP atom corrections
@@ -295,7 +295,7 @@ contains
               &+ (A1(2, j) - AL2(2, i))**2&
               &+ (A1(3, j) - AL2(3, i))**2
             r = sqrt(r2)
-            esl = esl + AL2(4, i)*q1(j)*r/(r*r + r0tmp(iat, j))
+            esl = esl + AL2(4, i)*q1(j)*r/(r2 + r0tmp(iat, j))
          end do
       end do
 

--- a/src/iff/iff_ini.f90
+++ b/src/iff/iff_ini.f90
@@ -213,6 +213,7 @@ contains
          z1(i) = val_e(at1(i))
          k = 0
          do j = 1, n1
+            if (j .eq. i) cycle
             rr = (xyz1(1, j) - xyz1(1, i))**2 + (xyz1(2, j) - xyz1(2, i))**2 +&
               &(xyz1(3, j) - xyz1(3, i))**2
             r0 = sqrt(rr)
@@ -221,7 +222,7 @@ contains
             aj = alp0(j)**(1./3)
             rrr = 1.13*2.6*(ai + aj)*0.5/r0
             tmp = 1.0d0/(1.d0 + 6.d0*rrr**14)
-            if (j .ne. i .and. tmp .gt. 0.90 .and. r0 .lt. thr) then
+            if (tmp .gt. 0.90 .and. r0 .lt. thr) then
                k = k + 1
                neigh(k, i) = j
             end if
@@ -235,6 +236,7 @@ contains
          z2(i) = val_e(at2(i))
          k = 0
          do j = 1, n2
+            if (j .eq. i) cycle
             rr = (xyz2(1, j) - xyz2(1, i))**2 + (xyz2(2, j) - xyz2(2, i))**2 +&
               &(xyz2(3, j) - xyz2(3, i))**2
             r0 = sqrt(rr)
@@ -243,7 +245,7 @@ contains
             aj = alp0(j + n1)**(1./3)
             rrr = 1.13*2.6*(ai + aj)*0.5/r0
             tmp = 1.0d0/(1.d0 + 6.d0*rrr**14)
-            if (j .ne. i .and. tmp .gt. 0.90 .and. r0 .lt. thr) then
+            if (tmp .gt. 0.90 .and. r0 .lt. thr) then
                k = k + 1
                neigh(k, i + n1) = j
             end if

--- a/src/iff/iff_ini.f90
+++ b/src/iff/iff_ini.f90
@@ -213,11 +213,11 @@ contains
          z1(i) = val_e(at1(i))
          k = 0
          do j = 1, n1
-            if (j .eq. i) cycle
             rr = (xyz1(1, j) - xyz1(1, i))**2 + (xyz1(2, j) - xyz1(2, i))**2 +&
               &(xyz1(3, j) - xyz1(3, i))**2
             r0 = sqrt(rr)
             gab1(j, i) = 1.0d0/(r0 + 1./sqrt(gam(at1(i))*gam(at1(j))))
+            if (j .eq. i) cycle
             ai = alp0(i)**(1./3)
             aj = alp0(j)**(1./3)
             rrr = 1.13*2.6*(ai + aj)*0.5/r0
@@ -236,11 +236,11 @@ contains
          z2(i) = val_e(at2(i))
          k = 0
          do j = 1, n2
-            if (j .eq. i) cycle
             rr = (xyz2(1, j) - xyz2(1, i))**2 + (xyz2(2, j) - xyz2(2, i))**2 +&
               &(xyz2(3, j) - xyz2(3, i))**2
             r0 = sqrt(rr)
             gab2(j, i) = 1.0d0/(r0 + 1./sqrt(gam(at2(i))*gam(at2(j))))
+            if (j .eq. i) cycle
             ai = alp0(i + n1)**(1./3)
             aj = alp0(j + n1)**(1./3)
             rrr = 1.13*2.6*(ai + aj)*0.5/r0


### PR DESCRIPTION
During careful running of xtb/docking test via CMake I have found several divisions by zero and improperly closing of files. This patch resolves such issues