### PR TITLE
Speed-up hot path of GFN2 geometry optimization 

### DIFF
--- a/src/coulomb/klopmanohno.f90
+++ b/src/coulomb/klopmanohno.f90
@@ -507,11 +507,13 @@ subroutine getCoulombDerivsCluster(mol, itbl, gamAverage, gExp, hardness, &
 
    !$omp parallel do default(none) reduction(+:djdr, djdtr, djdL) &
    !$omp shared(mol, itbl, qvec, gExp, hardness) &
-   !$omp private(iat, jat, ish, jsh, ii, jj, iid, jid, r1, g1, gij, vec, dG, dS)
+   !$omp private(iat, jat, ish, jsh, ii, jj, iid, jid, r1, g1, gij, vec, dG, dS) &
+   !$omp collapse(2) schedule(dynamic,32)
    do iat = 1, len(mol)
-      ii = itbl(1, iat)
-      iid = mol%id(iat)
-      do jat = 1, iat-1
+      do jat = 1, len(mol)
+         if (jat >= iat) cycle
+         ii = itbl(1, iat)
+         iid = mol%id(iat)
          jj = itbl(1, jat)
          jid = mol%id(jat)
          vec(:) = mol%xyz(:, jat) - mol%xyz(:, iat)

--- a/src/coulomb/klopmanohno.f90
+++ b/src/coulomb/klopmanohno.f90
@@ -498,19 +498,21 @@ subroutine getCoulombDerivsCluster(mol, itbl, gamAverage, gExp, hardness, &
    !> Derivative of Coulomb matrix w.r.t. strain deformations
    real(wp), intent(out) :: djdL(:, :, :)
 
-   integer :: iat, jat, ish, jsh, ii, jj, iid, jid
+   integer :: iat, jat, nat, ish, jsh, ii, jj, iid, jid
    real(wp) :: r1, g1, gij, vec(3), dG(3), dS(3, 3)
 
    djdr(:, :, :) = 0.0_wp
    djdtr(:, :) = 0.0_wp
    djdL(:, :, :) = 0.0_wp
 
+   nat = len(mol) ! workaround for legacy Intel Fortran compilers
+
    !$omp parallel do default(none) reduction(+:djdr, djdtr, djdL) &
-   !$omp shared(mol, itbl, qvec, gExp, hardness) &
+   !$omp shared(mol, itbl, qvec, gExp, hardness, nat) &
    !$omp private(iat, jat, ish, jsh, ii, jj, iid, jid, r1, g1, gij, vec, dG, dS) &
    !$omp collapse(2) schedule(dynamic,32)
-   do iat = 1, len(mol)
-      do jat = 1, len(mol)
+   do iat = 1, nat
+      do jat = 1, nat
          if (jat >= iat) cycle
          ii = itbl(1, iat)
          iid = mol%id(iat)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2044,10 +2044,12 @@ subroutine atm_gradient_latp &
    !$omp parallel do default(none) reduction(+:energies, gradient, sigma, dEdcn) &
    !$omp shared(mol, r4r2, par, trans, cutoff2, c6, dc6dcn) &
    !$omp private(iat, ati, jat, atj, kat, atk, c6ij, cij, c6ik, c6jk, cik, cjk, &
-   !$omp& rij, r2ij, ktr, rik, r2ik, rjk, r2jk, scale, dE, dG, dS, dCN)
+   !$omp& rij, r2ij, ktr, rik, r2ik, rjk, r2jk, scale, dE, dG, dS, dCN) &
+   !$omp collapse(2) schedule(dynamic,32)
    do iat = 1, len(mol)
-      ati = mol%at(iat)
-      do jat = 1, iat
+      do jat = 1, len(mol)
+         if (jat > iat) cycle
+         ati = mol%at(iat)
          atj = mol%at(jat)
 
          c6ij = c6(jat,iat)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2032,7 +2032,7 @@ subroutine atm_gradient_latp &
    real(wp), intent(inout) :: sigma(:, :)
    real(wp), intent(inout) :: dEdcn(:)
 
-   integer :: iat, jat, kat, ati, atj, atk, jtr, ktr
+   integer :: iat, jat, kat, nat, ati, atj, atk, jtr, ktr
    real(wp) :: cutoff2
    real(wp) :: rij(3), rjk(3), rik(3), r2ij, r2jk, r2ik
    real(wp) :: c6ij, c6jk, c6ik, cij, cjk, cik, scale
@@ -2040,14 +2040,15 @@ subroutine atm_gradient_latp &
    real(wp), parameter :: sr = 4.0_wp/3.0_wp
 
    cutoff2 = cutoff**2
+   nat = len(mol) ! workaround for legacy Intel Fortran compilers
 
    !$omp parallel do default(none) reduction(+:energies, gradient, sigma, dEdcn) &
-   !$omp shared(mol, r4r2, par, trans, cutoff2, c6, dc6dcn) &
+   !$omp shared(mol, r4r2, par, trans, cutoff2, c6, dc6dcn, nat) &
    !$omp private(iat, ati, jat, atj, kat, atk, c6ij, cij, c6ik, c6jk, cik, cjk, &
    !$omp& rij, r2ij, ktr, rik, r2ik, rjk, r2jk, scale, dE, dG, dS, dCN) &
    !$omp collapse(2) schedule(dynamic,32)
-   do iat = 1, len(mol)
-      do jat = 1, len(mol)
+   do iat = 1, nat
+      do jat = 1, nat
          if (jat > iat) cycle
          ati = mol%at(iat)
          atj = mol%at(jat)

--- a/src/xtb/hamiltonian.f90
+++ b/src/xtb/hamiltonian.f90
@@ -631,7 +631,7 @@ subroutine build_dSDQH0_noreset(nShell, hData, selfEnergy, dSEdcn, intcut, &
    thr2 = intcut
    point = 0.0_wp
    ! call timing(t1,t3)
-   !$omp parallel do default(none) schedule(dynamic) &
+   !$omp parallel do default(none) &
    !$omp shared(nat, at, xyz, nShell, hData, selfEnergy, dSEdcn, P, Pew, &
    !$omp& H0, S, ves, vs, vd, vq, intcut, nprim, primcount, caoshell, saoshell, &
    !$omp& alp, cont) &
@@ -640,12 +640,13 @@ subroutine build_dSDQH0_noreset(nShell, hData, selfEnergy, dSEdcn, intcut, &
    !$omp& sdq,sdqg,est,alpi,alpj,ab,iprim,jprim,ip,jp,ri,rj,rij,km,shpoly,dshpoly, &
    !$omp& mli,mlj,dum,dumdum,tmp,dtmp,qtmp,il,jl,zi,zj,zetaij,hii,hjj,hav, &
    !$omp& iao,jao,ii,jj,k,pij,hij,hpij,g_xyz,itr) &
-   !$omp reduction(+:g,sigma,dhdcn)
+   !$omp reduction(+:g,sigma,dhdcn) &
+   !$omp collapse(2) schedule(dynamic,32)
    do iat = 1,nat
-      ri = xyz(:,iat)
-      izp = at(iat)
-      do jat = 1,iat-1
-         !           if (jat.eq.iat) cycle
+      do jat = 1,nat
+         if (jat <= iat) cycle
+         ri = xyz(:,iat)
+         izp = at(iat)
          jzp = at(jat)
 
          rj = xyz(:,jat)

--- a/src/xtb/hamiltonian.f90
+++ b/src/xtb/hamiltonian.f90
@@ -644,11 +644,11 @@ subroutine build_dSDQH0_noreset(nShell, hData, selfEnergy, dSEdcn, intcut, &
    !$omp collapse(2) schedule(dynamic,32)
    do iat = 1,nat
       do jat = 1,nat
-         if (jat <= iat) cycle
-         ri = xyz(:,iat)
+         if (jat >= iat) cycle
          izp = at(iat)
          jzp = at(jat)
 
+         ri = xyz(:,iat)
          rj = xyz(:,jat)
          rij = ri - rj
          rij2 =  sum( rij**2 )

--- a/src/xtb/hamiltonian.f90
+++ b/src/xtb/hamiltonian.f90
@@ -208,7 +208,7 @@ subroutine build_SDQH0(nShell, hData, nat, at, nbf, nao, xyz, trans, selfEnergy,
    ! --- Aufpunkt for moment operator
    point = 0.0_wp
 
-   !$omp parallel do default(none) schedule(dynamic) &
+   !$omp parallel do default(none) &
    !$omp shared(nat, xyz, at, nShell, hData, selfEnergy, caoshell, saoshell, &
    !$omp& nprim, primcount, alp, cont, intcut, trans, point) &
    !$omp private (iat,jat,izp,ci,ra,rb,saw, &
@@ -216,11 +216,13 @@ subroutine build_SDQH0(nShell, hData, nat, at, nbf, nao, xyz, trans, selfEnergy,
    !$omp& jsh,jshmax,jshtyp,jcao,naoj,jptyp,ss,dd,qq,shpoly, &
    !$omp& est,alpi,alpj,ab,iprim,jprim,ip,jp,il,jl,hii,hjj,km,zi,zj,zetaij,hav, &
    !$omp& mli,mlj,tmp,tmp1,tmp2,iao,jao,ii,jj,k,ij,itr) &
-   !$omp shared(sint,dpint,qpint,H0,H0_noovlp)
+   !$omp shared(sint,dpint,qpint,H0,H0_noovlp) &
+   !$omp collapse(2) schedule(dynamic,32)
    do iat = 1, nat
-      ra(1:3) = xyz(1:3,iat)
-      izp = at(iat)
-      do jat = 1, iat-1
+      do jat = 1, nat
+         if (jat >= iat) cycle
+         ra(1:3) = xyz(1:3,iat)
+         izp = at(iat)
          jzp = at(jat)
          do ish = 1, nShell(izp)
             ishtyp = hData%angShell(ish,izp)
@@ -431,7 +433,7 @@ subroutine build_dSDQH0(nShell, hData, selfEnergy, dSEdcn, intcut, nat, nao, nbf
    thr2 = intcut
    point = 0.0_wp
    ! call timing(t1,t3)
-   !$omp parallel do default(none) schedule(dynamic) &
+   !$omp parallel do default(none) &
    !$omp shared(nat, at, xyz, trans, nShell, hData, selfEnergy, dSEdcn, P, Pew, &
    !$omp& ves, vs, vd, vq, intcut, nprim, primcount, caoshell, saoshell, alp, cont) &
    !$omp private(iat,jat,ixyz,izp,ci,rij2,jzp,ish,ishtyp, &
@@ -439,13 +441,14 @@ subroutine build_dSDQH0(nShell, hData, selfEnergy, dSEdcn, intcut, nat, nao, nbf
    !$omp& sdq,sdqg,est,alpi,alpj,ab,iprim,jprim,ip,jp,ri,rj,rij,km,shpoly,dshpoly, &
    !$omp& mli,mlj,dum,dumdum,tmp,stmp,dtmp,qtmp,il,jl,zi,zj,zetaij,hii,hjj,hav, &
    !$omp& iao,jao,ii,jj,k,pij,hij,hpij,g_xyz,itr) &
-   !$omp reduction(+:g,sigma,dhdcn)
+   !$omp reduction(+:g,sigma,dhdcn) &
+   !$omp collapse(2) schedule(dynamic,32)
    do iat = 1,nat
-      ri = xyz(:,iat)
-      izp = at(iat)
-      do jat = 1,iat-1
-         !           if (jat.eq.iat) cycle
+      do jat = 1,nat
+         if (jat >= iat) cycle
+         ri = xyz(:,iat)
          jzp = at(jat)
+         izp = at(iat)
 
          do ish = 1,nShell(izp)
             ishtyp = hData%angShell(ish,izp)


### PR DESCRIPTION
This PR improves parallelization for GFN2 geometry optimization. It affects other types of calculations too.

Achieved speed-up is **30%**. Gradients are **2x** faster!

For 578 atom structure, before the patch:
```
 total:
 * wall-time:     0 d,  0 h,  1 min, 11.680 sec
 *  cpu-time:     0 d,  0 h,  3 min,  7.524 sec
 * ratio c/w:     2.616 speedup
 SCF:
 * wall-time:     0 d,  0 h,  0 min, 13.534 sec
 *  cpu-time:     0 d,  0 h,  0 min, 41.212 sec
 * ratio c/w:     3.045 speedup
 ANC optimizer:
 * wall-time:     0 d,  0 h,  0 min, 57.390 sec
 *  cpu-time:     0 d,  0 h,  2 min, 25.103 sec
 * ratio c/w:     2.528 speedup

normal termination of xtb

real 1m11.740s
user 3m5.985s
sys 0m1.572s
```

After the patch:
```
 total:
 * wall-time:     0 d,  0 h,  0 min, 48.779 sec
 *  cpu-time:     0 d,  0 h,  2 min, 51.122 sec
 * ratio c/w:     3.508 speedup
 SCF:
 * wall-time:     0 d,  0 h,  0 min, 11.737 sec
 *  cpu-time:     0 d,  0 h,  0 min, 42.249 sec
 * ratio c/w:     3.600 speedup
 ANC optimizer:
 * wall-time:     0 d,  0 h,  0 min, 36.377 sec
 *  cpu-time:     0 d,  0 h,  2 min,  8.025 sec
 * ratio c/w:     3.519 speedup

normal termination of xtb

real 0m48.971s
user 2m50.138s
sys 0m1.012s
```

Command for testing:
```
xtb --input model.xtb model.xyz -P 4 --gfn 2 --opt vtight --alpb water --cycles 5
```

model.xtb (nothing interesing, to be honest):
```
$opt
    engine=rf
$end
$alpb
    kernel=still
    grid=tight
$end
```

Build type: CMake, Release, gfortran-14, Intel MKL, no march (can get extra speed-up), enabled debug info.