### PR TITLE
Define types of all variables 

### DIFF
--- a/src/axis_trafo.f90
+++ b/src/axis_trafo.f90
@@ -20,6 +20,7 @@ module xtb_axis
 contains
   subroutine axis(numat,nat,xyz,aa,bb,cc)
     use xtb_splitparam
+    implicit integer (i-n)
     implicit double precision (a-h,o-z)
     dimension xyz(3,numat)
     integer nat(numat)
@@ -237,6 +238,7 @@ end subroutine axis2
 
   subroutine axisvec(numat,nat,xyz,aa,bb,cc,evec)
     use xtb_splitparam
+    implicit integer (i-n)
     implicit double precision (a-h,o-z)
     dimension xyz(3,numat)
     integer nat(numat)

--- a/src/basic_geo.f90
+++ b/src/basic_geo.f90
@@ -454,6 +454,7 @@ contains
 
       subroutine vsc1(a,scale,tol)
          use xtb_mctc_accuracy, only : wp
+      implicit integer (i-n)
       implicit double precision (a-h,o-z)
       dimension a(3)
 

--- a/src/constr.f90
+++ b/src/constr.f90
@@ -1108,6 +1108,7 @@ end subroutine crprod
 
 subroutine vsc1(a,scale,tol)
    use xtb_mctc_accuracy, only : wp
+   implicit integer (i-n)
    implicit double precision (a-h,o-z)
    dimension a(3)
 

--- a/src/drsp.f
+++ b/src/drsp.f
@@ -33,6 +33,7 @@ c     end
 
       SUBROUTINE RSP(A,N,MATZ,W,Z)
          use xtb_mctc_accuracy, only : wp
+      IMPLICIT INTEGER (I-N)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
       DIMENSION A(n*(n+1)/2),  W(n), Z(n,n)  
       DIMENSION :: FV1(2*n),FV2(2*n)
@@ -115,6 +116,7 @@ C
       END
 
       SUBROUTINE TQL2(NM,N,D,E,Z,IERR,EPS)
+      IMPLICIT INTEGER (I-N)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
 C               ===== PROCESSED BY AUGMENT, VERSION 4N =====
 C     APPROVED FOR VAX 11/780 ON MAY 6,1980.  J.D.NEECE
@@ -284,6 +286,7 @@ C                EIGENVALUE AFTER 30 ITERATIONS **********
 C     ********** LAST CARD OF TQL2 **********
       END
       SUBROUTINE TQLRAT(N,D,E2,IERR,EPS)
+      IMPLICIT INTEGER (I-N)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
 C               ===== PROCESSED BY AUGMENT, VERSION 4N =====
 C     APPROVED FOR VAX 11/780 ON MAY 6,1980.  J.D.NEECE
@@ -416,6 +419,7 @@ C                EIGENVALUE AFTER 30 ITERATIONS **********
 C     ********** LAST CARD OF TQLRAT **********
       END
       SUBROUTINE TRBAK3(NM,N,NV,A,M,Z)
+      IMPLICIT INTEGER (I-N)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
 C               ===== PROCESSED BY AUGMENT, VERSION 4N =====
 C     APPROVED FOR VAX 11/780 ON MAY 6,1980.  J.D.NEECE
@@ -500,6 +504,7 @@ C
 C     ********** LAST CARD OF TRBAK3 **********
       END
       SUBROUTINE TRED3(N,NV,A,D,E,E2,EPS,ETA)
+      IMPLICIT INTEGER (I-N)
       IMPLICIT DOUBLE PRECISION (A-H,O-Z)
 C               ===== PROCESSED BY AUGMENT, VERSION 4N =====
 C     APPROVED FOR VAX 11/780 ON MAY 6,1980.  J.D.NEECE

--- a/src/elem.f90
+++ b/src/elem.f90
@@ -17,6 +17,7 @@
 
 
 subroutine elem(key1, nat)
+   implicit integer (i-n)
    implicit double precision (a-h,o-z)
    character(len=*) :: key1
    character(len=2) :: e

--- a/src/esp.f
+++ b/src/esp.f
@@ -308,6 +308,7 @@
 
       subroutine propa0(a,b,etaij4,etakl4,iff1,iff2,ind1,ind2)
       use xtb_intpack
+      implicit integer(i-n)
       implicit real*8(a-h,o-z)
 ! aufpunkte
       real*8 a(3),b(3)
@@ -362,6 +363,7 @@
 
       subroutine propa1(aname,c,nnn,gama,e,dd,va)
       use xtb_intpack
+      implicit integer(i-n)
       implicit real*8(a-h,o-z)
       external aname
 ! aufpunkte,ref point,intarray

--- a/src/geosum.f90
+++ b/src/geosum.f90
@@ -211,6 +211,7 @@ end subroutine
 !-------------------------------------------------
 
 subroutine rmblank(as,re)
+   implicit integer (i-n)
    character(len=*) as
    character(len=*) re
 
@@ -227,6 +228,7 @@ subroutine rmblank(as,re)
 end subroutine rmblank
 
 subroutine xbangle(xyz,angle)
+   implicit integer (i-n)
    implicit double precision (a-h,o-z)
    dimension xyz(3,3)
    !********************************************************************
@@ -255,6 +257,7 @@ subroutine xbangle(xyz,angle)
    return
 end subroutine xbangle
 subroutine xdihed(xyz,angle)
+   implicit integer (i-n)
    implicit double precision (a-h,o-z)
    dimension xyz(3,4)
    !********************************************************************

--- a/src/intpack.f90
+++ b/src/intpack.f90
@@ -82,6 +82,7 @@ end subroutine pola
 !! --------------------------------------------------------------[SAW1710]-
 !     changed do loops, replaced spaceships
 subroutine prola(aname,a,b,etaij4,etakl4,iff1,iff2,va,nt)
+   implicit integer(i-n)
    implicit real(wp)(a-h,o-z)
    external aname
    ! aufpunkte,ref point,intarray
@@ -294,6 +295,7 @@ end subroutine prola
 !! --------------------------------------------------------------[SAW1710]-
 !     changed do loops, replaced spaceships
 subroutine propa(aname,a,b,c,etaij4,etakl4,iff1,iff2,va,nt)
+   implicit integer(i-n)
    implicit real(wp)(a-h,o-z)
    external aname
    ! aufpunkte,ref point,intarray
@@ -1026,6 +1028,7 @@ subroutine opap4(l,m,n,gc,v,rc)
    !
    !     written by s. brode in april,1984
    !
+   implicit integer (i-n)
    implicit real(wp) (a-h,o-z)
    logical :: lodd,modd,nodd,leven,meven,neven
    real(wp)  :: v(1),rc(3),rca(3),rcb(3),srcab(3),o(25)
@@ -1324,6 +1327,7 @@ end subroutine opap4
 
 
 subroutine fmc(mvar,xvar,expmx,fmch)
+   implicit integer (i-n)
    implicit real(wp) (a-h,o-z)
    m=mvar
    x=xvar
@@ -1400,6 +1404,7 @@ end subroutine fmc
 
       subroutine opaa0(l,m,n,ga,v,d)
 !           electronic part of potential
+      implicit integer(i-n)
       implicit real*8(a-h,o-z)
       dimension v(*),d(*),fnu(7),fn(7),fd(7),dp(3)
       data fn /1.d0,1.d0,2.d0,6.d0,24.d0,120.d0, &
@@ -1431,6 +1436,7 @@ end subroutine fmc
 
 
       double precision function aainer(l,m,n,d,dp,fnu,fn,fd)
+      implicit integer(i-n)
       implicit real*8(a-h,o-z)
       dimension  d(*),dp(*),fnu(*),fn(*),fd(*)
       integer u,v,w,uvwt,rstt,uvwth

--- a/src/lindh.f90
+++ b/src/lindh.f90
@@ -147,6 +147,7 @@ Subroutine Trsn(xyz,nCent,Tau,Bt,lWrite,lWarn,Label,dBt,ldB)
    !                                                                      *
    ! R.Lindh May-June '96                                                 *
    !***********************************************************************
+   Implicit Integer (i-n)
    Implicit Real*8 (a-h,o-z)
    !     include "common/real.inc"
    !comdeck real.inc $Revision: 2002.3 $
@@ -342,6 +343,7 @@ Subroutine Trsn(xyz,nCent,Tau,Bt,lWrite,lWarn,Label,dBt,ldB)
 End      subroutine
 
 Subroutine Strtch(xyz,nCent,Avst,B,lWrite,Label,dB,ldB)
+   Implicit Integer (i-n)
    Implicit Real*8 (a-h,o-z)
    !      include "common/real.inc"
    !comdeck real.inc $Revision: 2002.3 $
@@ -426,6 +428,7 @@ End subroutine
 
 !fordeck bend $Revision: 5.3 $
 Subroutine Bend(xyz,nCent,Fir,Bf,lWrite,lWarn,Label,dBf,ldB)
+   Implicit Integer (i-n)
    Implicit Real*8  (a-h,o-z)
    !      include "common/real.inc"
    !comdeck real.inc $Revision: 2002.3 $

--- a/src/local.f90
+++ b/src/local.f90
@@ -650,6 +650,7 @@ subroutine mocent(n,ndim,ihomo,x,s,qmo,xcen,aoat2)
 end subroutine mocent
 
 SUBROUTINE lmosort(ncent,ihomo,imo,imem,qmo)
+   IMPLICIT INTEGER(I-N)
    IMPLICIT REAL*8(A-H,O-Z)
    dimension qmo(ncent,ihomo)
    dimension imem(ncent)
@@ -675,6 +676,7 @@ SUBROUTINE lmosort(ncent,ihomo,imo,imem,qmo)
 end subroutine lmosort
 
 SUBROUTINE lmosort2(n,eps,d,ecent)
+   IMPLICIT INTEGER(I-N)
    IMPLICIT REAL*8(A-H,O-Z)
    dimension d(n,n), eps(n), ecent(n,3)
 

--- a/src/lopt.f90
+++ b/src/lopt.f90
@@ -33,6 +33,7 @@ subroutine lopt(init, n, no, accr, op, d)
    use xtb_mctc_accuracy, only : wp
    use xtb_setparam
 
+   implicit integer(i-n)
    implicit real(wp)(a-h,o-z)
 
    logical init

--- a/src/makel.f90
+++ b/src/makel.f90
@@ -25,6 +25,7 @@
 subroutine makel(nao, s, can, clo)
    use xtb_mctc_lapack, only: lapack_syev
    use xtb_mctc_blas, only: blas_gemm
+   implicit integer (i - n)
    implicit real * 8(a - h, o - z)
    dimension s(nao, nao)
    dimension can(nao, nao)
@@ -67,6 +68,7 @@ end subroutine makel
 subroutine umakel(nao, s, cana, canb, cloa, clob)
    use xtb_mctc_lapack, only: lapack_syev
    use xtb_mctc_blas, only: blas_gemm
+   implicit integer (i-n)
    implicit real * 8(a - h, o - z)
    dimension s(nao, nao)
    dimension cana(nao, nao)

--- a/src/model_hessian.f90
+++ b/src/model_hessian.f90
@@ -2657,6 +2657,7 @@ end module xtb_modelhessian
       use xtb_gfnff_topology, only : TGFFTopology
       use xtb_gfnff_neighbor, only : TNeigh
       use xtb_type_timer
+      Implicit Integer (i-n)
       Implicit Real*8 (a-h, o-z)
       type(TGFFData), intent(in) :: param
       type(TGFFTopology), intent(in) :: topo

--- a/src/prmat.f90
+++ b/src/prmat.f90
@@ -95,6 +95,7 @@
       end subroutine preig2
 
       SUBROUTINE PREIG3(IO,E,NORBS)
+      IMPLICIT INTEGER (I-N)
       IMPLICIT REAL*8 (A-H,O-Z)
       DIMENSION E(*)
       N=10
@@ -118,6 +119,7 @@
       END SUBROUTINE PREIG3
 
       SUBROUTINE PRMAT(IUOUT,R,N,M,HEAD)
+      IMPLICIT INTEGER(I-N)
       REAL*8 R
       CHARACTER*(*) HEAD
       DIMENSION R(*)
@@ -209,6 +211,7 @@
       END
 
       SUBROUTINE PRMAT4(IUOUT,R,N,M,HEAD)
+      IMPLICIT INTEGER(I-N)
       REAL*4 R
       CHARACTER*(*) HEAD
       DIMENSION R(*)
@@ -300,8 +303,10 @@
       END
 
       SUBROUTINE PRMATI(IUOUT,RR,N,M,HEAD)
+      IMPLICIT INTEGER(I-N)
       CHARACTER*(*) HEAD
       integer RR(*)
+      REAL*4 R
       DIMENSION R(n*n)
 !     SUBROUTINE PRINTS MATRIX R,WHICH IS SUPPOSED
 !     TO HAVE DIMENSION N,M  WHEN M IS NONZERO AND
@@ -392,6 +397,7 @@
       END
 
       SUBROUTINE PRMATS(IUOUT,R,N,M,HEAD)
+      IMPLICIT INTEGER(I-N)
       REAL*8 R
       CHARACTER*(*) HEAD
       DIMENSION R(*)
@@ -483,6 +489,7 @@
       END
 
       subroutine preigf(io,e,norbs)
+      implicit integer (i-n)
       implicit real*8 (a-h,o-z)
       dimension e(*)
       n=6
@@ -505,6 +512,7 @@
       end subroutine preigf
 
       subroutine preigf0(io,e,norbs)
+      implicit integer (i-n)
       implicit real*8 (a-h,o-z)
       dimension e(*)
       n=6

--- a/src/rdcoord2.f90
+++ b/src/rdcoord2.f90
@@ -232,6 +232,7 @@ end subroutine readline
 subroutine rdxyz(fname,n,xyz)
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_convert, only : aatoau
+   implicit integer (i-n)
    implicit real(wp) (a-h,o-z)
    integer, intent(in)  :: n
    real(wp),intent(out) :: xyz(3,n)

--- a/src/readl.f90
+++ b/src/readl.f90
@@ -18,6 +18,7 @@
 
 subroutine readl(a1,x,n)
    use xtb_mctc_accuracy, only : wp
+   implicit integer (i-n)
    implicit real(wp) (a-h,o-z)
    character(*) a1
    dimension x(*)
@@ -36,6 +37,7 @@ end subroutine readl
 
 function readaa(a,istart,iend,iend2)
    use xtb_mctc_accuracy, only : wp
+   implicit integer (i-n)
    implicit real(wp) (a-h,o-z)
    real(wp) readaa
    character(*) a

--- a/src/rmsd.f90
+++ b/src/rmsd.f90
@@ -91,8 +91,9 @@ end subroutine
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 
 logical function ohbonded(n,m,xyz,at)
-   integer n,at(n),m
-   real*8 xyz(3,n)
+   implicit none
+   integer n,at(n),m,i
+   real*8 xyz(3,n),r
 
    ohbonded=.false.
    if(at(m).ne.1) return


### PR DESCRIPTION
This PR defines all unknown types to integer where it was necessary. Now, code can be compiled with `gfortran -fimplicit-none`.