### PR TITLE
Clarified the aISS output

### DIFF
--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -199,7 +199,7 @@ contains
       write (env%unit, *) '|         Starting Energy Screening          |'
       write (env%unit, *) '=============================================='
       write (env%unit, *)
-      if (.not. fulle) write (env%unit, *) ' Fast Mode selected (recommended)'
+      if (.not. fulle) write (env%unit, *) ' No ATM term employed (recommended)'
       if (.not. fulle) write (env%unit, *) ' If ATM term should be included, use -atm option.'
       if (.not. fulle) write (env%unit, *)
 


### PR DESCRIPTION
The `fast mode` printed in the output does not refer to the `--fast` flag, but to the use of the ATM term. This was clarified with the commit.