### PR TITLE
Initialize some variables for xtb/iff test

### DIFF
--- a/src/iff/iff_prepare.f90
+++ b/src/iff/iff_prepare.f90
@@ -124,6 +124,8 @@ contains
 
       allocate (cn(mol%n), g(3, mol%n))
 
+      er = 0.0_wp
+
       set%pr_lmo = .true.
       set%silent = .true.
 

--- a/src/local.f90
+++ b/src/local.f90
@@ -153,8 +153,9 @@ subroutine local(nat,at,nbf,nao,ihomo,xyz,z,focc,s,p,cmo,eig,q,etot,gbsa,basis,r
       qhl(1:nat,2)=0
    endif
 
-   allocate(cca(nao*nao),xcen(n),lneigh(4,n),aneigh(2,n))
-   allocate(d(n,n),ecent(n,4),eiga(n),qcent(n,3),ecent2(n,4))
+   allocate(lneigh(4,n),aneigh(2,n), source=0)
+   allocate(cca(nao*nao),xcen(n), source=0.0_wp)
+   allocate(d(n,n),ecent(n,4),eiga(n),qcent(n,3),ecent2(n,4), source=0.0_wp)
 
    ! do only occ. ones
    cca=0

--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -765,6 +765,7 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
       call getCoordinationNumber(mol, trans, 40.0_wp, cnType%cov, &
          & cn, dcndr, dcndL)
       call latp%getLatticePoints(trans, 60.0_wp)
+      dum = 0.0_wp
       call d4_gradient(mol, xtbData%dispersion%dispm, trans, &
          &  xtbData%dispersion%dpar, scD4%g_a, scD4%g_c, &
          &  scD4%wf, 60.0_wp, 40.0_wp, cn, dcndr, dcndL, wfn%q, &

--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -256,6 +256,7 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
    eat  = 0.0_wp
    egap = 0.0_wp
    molpol = 0.0_wp
+   sigma = 0.0_wp
 
    pr   = prlevel.gt.1
    minpr= prlevel.gt.0


### PR DESCRIPTION
I have initialized some variables with zeros.

- `er` for later `call goedecker_chrgeq` where `er` is `inout`,
- `sigma` for later `call repulsionEnGrad` where `sigma` is `inout`,
- `dum` for later `call d4_gradient` where `energy=dum` is `inout`,
- arrays in local.f90 mostly for `ecent` by similar reasons