### PR TITLE
Avoid division by zero in disp module

### DIFF
--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -84,7 +84,11 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
          norm = norm + gw
          dnorm = dnorm + 2*wf*(reference_cn(iref, ati) - cn(iat)) * gw
       end do
-      if (norm /= 0.0_wp) norm = 1.0_wp / norm
+      if (norm > 1e-32_wp) then
+         norm = 1.0_wp / norm
+      else
+         norm = 0.0_wp
+      end if
       do iref = 1, number_of_references(ati)
          expw = weight_cn(wf, cn(iat), reference_cn(iref, ati))
          expd = 2*wf*(reference_cn(iref, ati) - cn(iat)) * expw

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -95,8 +95,8 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
 
          gwk = expw * norm
          if (norm == 0.0_wp) then
-            if (maxval(reference_cn(:number_of_references(ati), ati)) &
-               & == reference_cn(iref, ati)) then
+            if (abs(maxval(reference_cn(:number_of_references(ati), ati)) &
+               & - reference_cn(iref, ati)) < 1e-12_wp) then
                gwk = 1.0_wp
             else
                gwk = 0.0_wp

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -90,7 +90,7 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
          expd = 2*wf*(reference_cn(iref, ati) - cn(iat)) * expw
 
          gwk = expw * norm
-         if (gwk == 0.0_wp) then
+         if (norm == 0.0_wp) then
             if (maxval(reference_cn(:number_of_references(ati), ati)) &
                & == reference_cn(iref, ati)) then
                gwk = 1.0_wp

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -84,7 +84,7 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
          norm = norm + gw
          dnorm = dnorm + 2*wf*(reference_cn(iref, ati) - cn(iat)) * gw
       end do
-      if (norm > 1e-32_wp) then
+      if (norm > 1e-80_wp) then
          norm = 1.0_wp / norm
       else
          norm = 0.0_wp
@@ -880,7 +880,7 @@ elemental function weight_cn(wf,cn,cnref) result(cngw)
    intrinsic :: exp
 
    val = -wf * ( cn - cnref )**2
-   if (val < -70.0_wp) then ! technically, exp(-70) -> 3.97545e-31
+   if (val < -200.0_wp) then ! technically, exp(-200) -> 1.383897e-87
      cngw = 0.0_wp
    else
      cngw = exp ( val )

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -84,13 +84,13 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
          norm = norm + gw
          dnorm = dnorm + 2*wf*(reference_cn(iref, ati) - cn(iat)) * gw
       end do
-      norm = 1.0_wp / norm
+      if (norm /= 0.0_wp) norm = 1.0_wp / norm
       do iref = 1, number_of_references(ati)
          expw = weight_cn(wf, cn(iat), reference_cn(iref, ati))
          expd = 2*wf*(reference_cn(iref, ati) - cn(iat)) * expw
 
          gwk = expw * norm
-         if (gwk /= gwk) then
+         if (gwk == 0.0_wp) then
             if (maxval(reference_cn(:number_of_references(ati), ati)) &
                & == reference_cn(iref, ati)) then
                gwk = 1.0_wp
@@ -101,9 +101,6 @@ subroutine weight_references(nat, atoms, wf, cn, gwvec, gwdcn)
          gwvec(iref, iat) = gwk
 
          dgwk = expd*norm-expw*dnorm*norm**2
-         if (dgwk /= dgwk) then
-            dgwk = 0.0_wp
-         endif
          gwdcn(iref, iat) = dgwk
 
       end do

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -876,8 +876,16 @@ end subroutine deriv_atm_triple
 elemental function weight_cn(wf,cn,cnref) result(cngw)
    real(wp),intent(in) :: wf, cn, cnref
    real(wp) :: cngw
+   real(wp) :: val
    intrinsic :: exp
-   cngw = exp ( -wf * ( cn - cnref )**2 )
+
+   val = -wf * ( cn - cnref )**2
+   if (val < -70.0_wp) then ! technically, exp(-70) -> 3.97545e-31
+     cngw = 0.0_wp
+   else
+     cngw = exp ( val )
+   end if
+
 end function weight_cn
 
 

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -457,7 +457,7 @@ pure elemental function cngw(wf,cn,cnref)
    intrinsic :: exp
 
    val = -wf * ( cn - cnref )**2
-   if (val < -70.0_wp) then ! technically, exp(-70) -> 3.97545e-31
+   if (val < -200.0_wp) then ! technically, exp(-200) -> 1.383897e-87
      cngw = 0.0_wp
    else
      cngw = exp ( val )
@@ -624,7 +624,7 @@ subroutine d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,c6abns)
             norm = norm + cngw(twf,covcn(i),dispm%cn(ii,ia))
          enddo
       enddo
-      if (norm > 1e-32_wp) then
+      if (norm > 1e-80_wp) then
          norm = 1._wp / norm
       else
          norm = 0.0_wp
@@ -901,7 +901,7 @@ subroutine pbc_d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,refc6)
             norm = norm + cngw(twf,covcn(i),dispm%cn(ii,ia))
          enddo
       enddo
-      if (norm > 1e-32_wp) then
+      if (norm > 1e-80_wp) then
          norm = 1._wp / norm
       else
          norm = 0.0_wp
@@ -1015,7 +1015,7 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
             dnorm = dnorm + 2*twf*(dispm%cn(iref, ati) - cn(iat)) * gw
          enddo
       end do
-      if (norm > 1e-32_wp) then
+      if (norm > 1e-80_wp) then
          norm = 1.0_wp / norm
       else
          norm = 0.0_wp

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -1034,8 +1034,8 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
 
          gwk = expw * norm
          if (norm == 0.0_wp) then
-            if (maxval(dispm%cn(:dispm%nref(ati), ati)) &
-               & == dispm%cn(iref, ati)) then
+            if (abs(maxval(dispm%cn(:dispm%nref(ati), ati)) &
+               & - dispm%cn(iref, ati)) < 1e-12_wp) then
                gwk = 1.0_wp
             else
                gwk = 0.0_wp

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -1007,7 +1007,7 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
             dnorm = dnorm + 2*twf*(dispm%cn(iref, ati) - cn(iat)) * gw
          enddo
       end do
-      norm = 1.0_wp / norm
+      if (norm /= 0.0_wp) norm = 1.0_wp / norm
       ! acc loop vector private(expw, expd)
       do iref = 1, dispm%nref(ati)
          expw = 0.0_wp
@@ -1021,7 +1021,7 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
          enddo
 
          gwk = expw * norm
-         if (gwk /= gwk) then
+         if (gwk == 0.0_wp) then
             if (maxval(dispm%cn(:dispm%nref(ati), ati)) &
                & == dispm%cn(iref, ati)) then
                gwk = 1.0_wp
@@ -1033,9 +1033,6 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
          zerovec(iref, iat) = zeta(g_a,gi,dispm%q(iref,ati)+zi,zi) * gwk
 
          dgwk = expd*norm-expw*dnorm*norm**2
-         if (dgwk /= dgwk) then
-            dgwk = 0.0_wp
-         endif
          zetadcn(iref, iat) = zeta(g_a,gi,dispm%q(iref,ati)+zi,q(iat)+zi) * dgwk
          zetadq(iref, iat) = dzeta(g_a,gi,dispm%q(iref,ati)+zi,q(iat)+zi) * gwk
          zerodcn(iref, iat) = zeta(g_a,gi,dispm%q(iref,ati)+zi,zi) * dgwk

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -1021,7 +1021,7 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
          enddo
 
          gwk = expw * norm
-         if (gwk == 0.0_wp) then
+         if (norm == 0.0_wp) then
             if (maxval(dispm%cn(:dispm%nref(ati), ati)) &
                & == dispm%cn(iref, ati)) then
                gwk = 1.0_wp

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -624,17 +624,18 @@ subroutine d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,c6abns)
             norm = norm + cngw(twf,covcn(i),dispm%cn(ii,ia))
          enddo
       enddo
-      norm = 1._wp / norm
+      if (norm > 1e-32_wp) then
+         norm = 1._wp / norm
+      else
+         norm = 0.0_wp
+      end if
       do ii = 1, dispm%nref(ia)
          k = itbl(ii,i)
          do iii = 1, dispm%ncount(ii,ia)
             twf = iii*wf
             gw(k) = gw(k) + cngw(twf,covcn(i),dispm%cn(ii,ia)) * norm
          enddo
-!    --- okay, if we run out of numerical precision, gw(k) will be NaN.
-!        In case it is NaN, it will not match itself! So we can rescue
-!        this exception. This can only happen for very high CNs.
-         if (gw(k).ne.gw(k)) then
+         if (norm == 0.0_wp) then
             if (maxval(dispm%cn(:dispm%nref(ia),ia)).eq.dispm%cn(ii,ia)) then
                gw(k) = 1.0_wp
             else
@@ -900,17 +901,18 @@ subroutine pbc_d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,refc6)
             norm = norm + cngw(twf,covcn(i),dispm%cn(ii,ia))
          enddo
       enddo
-      norm = 1._wp / norm
+      if (norm > 1e-32_wp) then
+         norm = 1._wp / norm
+      else
+         norm = 0.0_wp
+      end if
       do ii = 1, dispm%nref(ia)
          k = itbl(ii,i)
          do iii = 1, dispm%ncount(ii,ia)
             twf = iii*wf
             gw(k) = gw(k) + cngw(twf,covcn(i),dispm%cn(ii,ia)) * norm
          enddo
-!    --- okay, if we run out of numerical precision, gw(k) will be NaN.
-!        In case it is NaN, it will not match itself! So we can rescue
-!        this exception. This can only happen for very high CNs.
-         if (gw(k).ne.gw(k)) then
+         if (norm == 0.0_wp) then
             if (maxval(dispm%cn(:dispm%nref(ia),ia)).eq.dispm%cn(ii,ia)) then
                gw(k) = 1.0_wp
             else

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -452,10 +452,16 @@ pure elemental function cngw(wf,cn,cnref)
    !$acc routine seq
    real(wp),intent(in) :: wf,cn,cnref
    real(wp)            :: cngw ! CN-gaussian-weight
+   real(wp)            :: val
 
    intrinsic :: exp
 
-   cngw = exp ( -wf * ( cn - cnref )**2 )
+   val = -wf * ( cn - cnref )**2
+   if (val < -70.0_wp) then ! technically, exp(-70) -> 3.97545e-31
+     cngw = 0.0_wp
+   else
+     cngw = exp ( val )
+   end if
 
 end function cngw
 

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -636,7 +636,8 @@ subroutine d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,c6abns)
             gw(k) = gw(k) + cngw(twf,covcn(i),dispm%cn(ii,ia)) * norm
          enddo
          if (norm == 0.0_wp) then
-            if (maxval(dispm%cn(:dispm%nref(ia),ia)).eq.dispm%cn(ii,ia)) then
+            if (abs(maxval(dispm%cn(:dispm%nref(ia),ia)) &
+               & - dispm%cn(ii,ia)) < 1e-12_wp) then
                gw(k) = 1.0_wp
             else
                gw(k) = 0.0_wp
@@ -913,7 +914,8 @@ subroutine pbc_d4(dispm,nat,ndim,at,wf,g_a,g_c,covcn,gw,refc6)
             gw(k) = gw(k) + cngw(twf,covcn(i),dispm%cn(ii,ia)) * norm
          enddo
          if (norm == 0.0_wp) then
-            if (maxval(dispm%cn(:dispm%nref(ia),ia)).eq.dispm%cn(ii,ia)) then
+            if (abs(maxval(dispm%cn(:dispm%nref(ia),ia)) &
+               & - dispm%cn(ii,ia)) < 1e-12_wp) then
                gw(k) = 1.0_wp
             else
                gw(k) = 0.0_wp

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -1007,7 +1007,11 @@ subroutine weight_references(dispm, nat, atoms, g_a, g_c, wf, q, cn, zeff, gam, 
             dnorm = dnorm + 2*twf*(dispm%cn(iref, ati) - cn(iat)) * gw
          enddo
       end do
-      if (norm /= 0.0_wp) norm = 1.0_wp / norm
+      if (norm > 1e-32_wp) then
+         norm = 1.0_wp / norm
+      else
+         norm = 0.0_wp
+      end if
       ! acc loop vector private(expw, expd)
       do iref = 1, dispm%nref(ati)
          expw = 0.0_wp


### PR DESCRIPTION
Instead of having `Inf` in `norm` after dividing by itself (when equals 0.0), now `norm` equals 0.0 and therefore `gwk` will equal 0.0 as well as `dgwk`.   