### PR TITLE
Update OpenMP parallelization in WSC to avoid data-races

### DIFF
--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -54,12 +54,6 @@ subroutine generate_wsc(mol,wsc)
    call wsc%allocate(mol%n,rep)
 
 ! ------------------------------------------------------------------------
-! initialize
-! ------------------------------------------------------------------------
-   allocate( lattr(3,wsc%cells),      source = 0 )
-   allocate( dist(wsc%cells),         source = 0.0_wp )
-   allocate( trans(wsc%cells),        source = .true. )
-! ------------------------------------------------------------------------
 ! Create the Wigner-Seitz Cell (WSC)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
@@ -69,6 +63,10 @@ subroutine generate_wsc(mol,wsc)
    !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
    !$omp shared(mol,wsc,rep) &
    !$omp private(mindist,minpos,nmindist,nminpos)
+
+   allocate( lattr(3,wsc%cells),      source = 0 )
+   allocate( dist(wsc%cells),         source = 0.0_wp )
+   allocate( trans(wsc%cells),        source = .true. )
 
    ! Each WSC of one atom consists of n atoms
    !$omp do collapse(2) schedule(dynamic,32)

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -127,6 +127,7 @@ subroutine generate_wsc(mol,wsc)
       end do
    end do
    !$omp end do
+   deallocate(lattr, dist, trans)
    !$omp end parallel
 
 end subroutine generate_wsc

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -64,11 +64,6 @@ subroutine generate_wsc(mol,wsc)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
    wsc%itbl= 0
-!$omp parallel default(none) &
-!$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
-!$omp shared(mol,wsc,rep) &
-!$omp shared(mindist,minpos,nmindist,nminpos)
-!$omp do schedule(dynamic)
    ! Each WSC of one atom consists of n atoms
    do ii=1,mol%n
       do jj=1,mol%n
@@ -123,7 +118,5 @@ subroutine generate_wsc(mol,wsc)
          endif
       end do
    end do
-!$omp enddo
-!$omp endparallel
 
 end subroutine generate_wsc

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -64,12 +64,12 @@ subroutine generate_wsc(mol,wsc)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
    wsc%itbl= 0
+   ! Each WSC of one atom consists of n atoms
 !$omp parallel do default(none) &
 !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
 !$omp shared(mol,wsc,rep) &
-!$omp private(mindist,minpos,nmindist,nminpos)
+!$omp private(mindist,minpos,nmindist,nminpos) &
 !$omp collapse(2) schedule(dynamic,32)
-   ! Each WSC of one atom consists of n atoms
    do ii=1,mol%n
       do jj=1,mol%n
          !if (ii.eq.jj) cycle
@@ -123,7 +123,5 @@ subroutine generate_wsc(mol,wsc)
          endif
       end do
    end do
-!$omp enddo
-!$omp endparallel
 
 end subroutine generate_wsc

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -72,9 +72,6 @@ subroutine generate_wsc(mol,wsc)
    !$omp do collapse(2) schedule(dynamic,32)
    do ii=1,mol%n
       do jj=1,mol%n
-         lattr = 0
-         dist = 0.0_wp
-         trans = .true.
          !if (ii.eq.jj) cycle
          ! find according neighbours
          c=0

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -60,7 +60,7 @@ subroutine generate_wsc(mol,wsc)
    wsc%itbl= 0
 
    !$omp parallel default(none) &
-   !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
+   !$omp private(ii,jj,aa,bb,cc,wc,c,dist,trans,t,lattr,rw) &
    !$omp shared(mol,wsc,rep) &
    !$omp private(mindist,minpos,nmindist,nminpos)
 

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -64,11 +64,11 @@ subroutine generate_wsc(mol,wsc)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
    wsc%itbl= 0
-!$omp parallel default(none) &
+!$omp parallel do default(none) &
 !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
 !$omp shared(mol,wsc,rep) &
 !$omp private(mindist,minpos,nmindist,nminpos)
-!$omp do schedule(dynamic)
+!$omp collapse(2) schedule(dynamic,32)
    ! Each WSC of one atom consists of n atoms
    do ii=1,mol%n
       do jj=1,mol%n

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -67,7 +67,7 @@ subroutine generate_wsc(mol,wsc)
 !$omp parallel default(none) &
 !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
 !$omp shared(mol,wsc,rep) &
-!$omp shared(mindist,minpos,nmindist,nminpos)
+!$omp private(mindist,minpos,nmindist,nminpos)
 !$omp do schedule(dynamic)
    ! Each WSC of one atom consists of n atoms
    do ii=1,mol%n

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -74,6 +74,9 @@ subroutine generate_wsc(mol,wsc)
    !$omp do collapse(2) schedule(dynamic,32)
    do ii=1,mol%n
       do jj=1,mol%n
+         lattr = 0
+         dist = 0.0_wp
+         trans = .true.
          !if (ii.eq.jj) cycle
          ! find according neighbours
          c=0

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -29,7 +29,7 @@ subroutine generate_wsc(mol,wsc)
 !  Variables
 ! ------------------------------------------------------------------------
    integer  :: rep(3)
-   integer  :: ii,jj,ich
+   integer  :: ii,jj
    integer  :: aa,bb,cc
    integer  :: c,wc
    integer  :: minpos

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -64,12 +64,14 @@ subroutine generate_wsc(mol,wsc)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
    wsc%itbl= 0
+
+   !$omp parallel default(none) &
+   !$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
+   !$omp shared(mol,wsc,rep) &
+   !$omp private(mindist,minpos,nmindist,nminpos)
+
    ! Each WSC of one atom consists of n atoms
-!$omp parallel do default(none) &
-!$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
-!$omp shared(mol,wsc,rep) &
-!$omp private(mindist,minpos,nmindist,nminpos) &
-!$omp collapse(2) schedule(dynamic,32)
+   !$omp do collapse(2) schedule(dynamic,32)
    do ii=1,mol%n
       do jj=1,mol%n
          !if (ii.eq.jj) cycle
@@ -123,5 +125,7 @@ subroutine generate_wsc(mol,wsc)
          endif
       end do
    end do
+   !$omp end do
+   !$omp end parallel
 
 end subroutine generate_wsc

--- a/src/generate_wsc.f90
+++ b/src/generate_wsc.f90
@@ -64,6 +64,11 @@ subroutine generate_wsc(mol,wsc)
 ! ------------------------------------------------------------------------
    wsc%at  = 0
    wsc%itbl= 0
+!$omp parallel default(none) &
+!$omp private(ii,jj,wc,c,dist,trans,t,lattr,rw) &
+!$omp shared(mol,wsc,rep) &
+!$omp shared(mindist,minpos,nmindist,nminpos)
+!$omp do schedule(dynamic)
    ! Each WSC of one atom consists of n atoms
    do ii=1,mol%n
       do jj=1,mol%n
@@ -118,5 +123,7 @@ subroutine generate_wsc(mol,wsc)
          endif
       end do
    end do
+!$omp enddo
+!$omp endparallel
 
 end subroutine generate_wsc


### PR DESCRIPTION
This PR removed data-races from shared minpos/mindist/nminloc/nmindist. Now, `wsc` and `peeq` tests should be repeatable.

