### PR TITLE
Remove symbol length variable

### DIFF
--- a/src/io/reader/genformat.f90
+++ b/src/io/reader/genformat.f90
@@ -19,7 +19,7 @@ module xtb_io_reader_genformat
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_convert
    use xtb_mctc_strings
-   use xtb_mctc_symbols, only : toNumber, symbolLength
+   use xtb_mctc_symbols, only : toNumber
    use xtb_mctc_systools
    use xtb_pbc_tools
    use xtb_type_molecule

--- a/src/io/reader/orca.f90
+++ b/src/io/reader/orca.f90
@@ -18,7 +18,7 @@
 module xtb_io_reader_orca
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_convert
-   use xtb_mctc_symbols, only : toNumber, symbolLength
+   use xtb_mctc_symbols, only : toNumber
    use xtb_type_molecule
    use xtb_pbc_tools
    use xtb_type_reader

--- a/src/io/reader/turbomole.f90
+++ b/src/io/reader/turbomole.f90
@@ -20,7 +20,7 @@ module xtb_io_reader_turbomole
    use xtb_mctc_constants
    use xtb_mctc_convert
    use xtb_mctc_resize
-   use xtb_mctc_symbols, only : toNumber, symbolLength
+   use xtb_mctc_symbols, only : toNumber
    use xtb_pbc_tools
    use xtb_readin, getline => strip_line
    use xtb_type_molecule

--- a/src/mctc/resize.f90
+++ b/src/mctc/resize.f90
@@ -76,7 +76,7 @@ end subroutine resizeInt
 pure subroutine resizeChar(var, n)
 
    !> TODO
-   character(len=*), allocatable, intent(inout) :: var(:)
+   character(len=:), allocatable, intent(inout) :: var(:)
 
    !> TODO
    integer, intent(in), optional :: n
@@ -92,7 +92,8 @@ pure subroutine resizeChar(var, n)
       else
          length = currentLength + currentLength/2 + 1
       endif
-      allocate(tmp(length), mold=var)
+      allocate(character(len=len(var)) :: tmp(length))
+      tmp(:) = repeat(' ', len(var))
       tmp(:currentLength) = var(:currentLength)
       deallocate(var)
       call move_alloc(tmp, var)
@@ -102,7 +103,8 @@ pure subroutine resizeChar(var, n)
       else
          length = 64
       endif
-      allocate(var(length), source=' ')
+      allocate(character(len=80) :: var(length))
+      var(:) = repeat(' ', 80)
    endif
 
 end subroutine resizeChar

--- a/src/mctc/symbols.f90
+++ b/src/mctc/symbols.f90
@@ -21,7 +21,6 @@ module xtb_mctc_symbols
    implicit none
    private
 
-   public :: symbolLength
    public :: symbolToNumber, numberToSymbol, numberToLcSymbol
    public :: toNumber, toSymbol, toLcSymbol, getIdentity
 
@@ -31,10 +30,6 @@ module xtb_mctc_symbols
       module procedure :: getIdentityNumber
       module procedure :: getIdentitySymbol
    end interface getIdentity
-
-
-   !> Maximum allowed length of element symbols
-   integer, parameter :: symbolLength = 4
 
 
    !> Periodic system of elements

--- a/src/mctc/symbols.f90
+++ b/src/mctc/symbols.f90
@@ -251,11 +251,11 @@ subroutine getIdentitySymbol(nId, identity, symbol)
    !> Chemical identity
    integer, intent(out) :: identity(:)
 
-   character(len=symbolLength), allocatable :: sTmp(:)
+   character(len=:), allocatable :: sTmp(:)
    integer :: nAt, iAt, iId
 
    nAt = size(identity)
-   allocate(sTmp(nAt))
+   allocate(character(len=len(symbol)) :: sTmp(nAt))
    nId = 0
    do iAt = 1, nAt
       iId = findSymbol(sTmp(:nId), symbol(iAt))
@@ -322,7 +322,7 @@ end function findNumber
 pure subroutine appendSymbol(list, nList, symbol)
 
    !> List of element symbols
-   character(len=*), allocatable, intent(inout) :: list(:)
+   character(len=:), allocatable, intent(inout) :: list(:)
 
    !> Current occupied size of list
    integer, intent(inout) :: nList

--- a/src/mctc/symbols.f90
+++ b/src/mctc/symbols.f90
@@ -246,7 +246,7 @@ subroutine getIdentitySymbol(nId, identity, symbol)
    integer, intent(out) :: nId
 
    !> Element symbols
-   character(len=symbolLength), intent(in) :: symbol(:)
+   character(len=*), intent(in) :: symbol(:)
 
    !> Chemical identity
    integer, intent(out) :: identity(:)

--- a/src/type/identitymap.f90
+++ b/src/type/identitymap.f90
@@ -19,7 +19,6 @@
 module xtb_type_identitymap
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_resize, only : resize
-   use xtb_mctc_symbols, only : symbolLength
    use xtb_type_molecule, only : TMolecule
    implicit none
    private
@@ -44,7 +43,7 @@ module xtb_type_identitymap
       integer, allocatable :: num(:)
 
       !> Element symbols for each id
-      character(len=symbolLength), allocatable :: sym(:)
+      character(len=:), allocatable :: sym(:)
 
       !> Maps from id to its atoms
       type(TAtomicMap), allocatable :: map(:)
@@ -121,7 +120,7 @@ subroutine initIdentityMapFromArrays(self, id, sym, num)
    integer, intent(in) :: num(:)
 
    !> Element symbols for each atom
-   character(len=symbolLength), intent(in) :: sym(:)
+   character(len=:), allocatable, intent(in) :: sym(:)
 
    integer :: nAt, nId
    integer :: iId, iAt, thisAt, initialSize, nMp
@@ -132,7 +131,7 @@ subroutine initIdentityMapFromArrays(self, id, sym, num)
 
    allocate(self%map(nId))
    allocate(self%num(nId))
-   allocate(self%sym(nId))
+   allocate(character(len=len(sym)) :: self%sym(nId))
 
    initialSize = nAt / nId + 1
    allocate(pos(initialSize))

--- a/src/type/molecule.f90
+++ b/src/type/molecule.f90
@@ -35,7 +35,7 @@ module xtb_type_molecule
    use mctc_io_structure, only : structure_type, new_structure
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_boundaryconditions, only : boundaryCondition
-   use xtb_mctc_symbols, only : toNumber, toSymbol, symbolLength, getIdentity
+   use xtb_mctc_symbols, only : toNumber, toSymbol, getIdentity
    use xtb_type_wsc
    use xtb_type_topology
    use xtb_type_fragments
@@ -74,7 +74,7 @@ module xtb_type_molecule
       integer  :: boundaryCondition = boundaryCondition%cluster
 
       !> Element symbols
-      character(len=symbolLength), allocatable :: sym(:)
+      character(len=:), allocatable :: sym(:)
 
       !> Ordinal numbers
       integer, allocatable :: at(:)
@@ -224,7 +224,6 @@ subroutine initMolecule &
    logical, intent(in), optional :: pbc(:)
 
    integer, allocatable :: id(:)
-   character(len=symbolLength), allocatable :: sTmp(:)
    integer :: nAt, nId, iAt, iId
 
    nAt = min(size(at, dim=1), size(xyz, dim=2), size(sym, dim=1))
@@ -297,11 +296,11 @@ subroutine initMoleculeNumbers &
    real(wp), intent(in), optional :: lattice(3, 3)
    logical, intent(in), optional :: pbc(3)
 
-   character(len=4), allocatable :: sym(:)
+   character(len=:), allocatable :: sym(:)
    integer :: nAt
 
    nAt = min(size(at, dim=1), size(xyz, dim=2))
-   allocate(sym(nAt))
+   allocate(character(len=len(toSymbol(1))) :: sym(nAt))
    sym(:) = toSymbol(at(:nAt))
 
    call init(mol, at, sym, xyz, chrg, uhf, lattice, pbc)
@@ -467,7 +466,8 @@ subroutine allocate_molecule(self,n)
    self%n = n
    allocate( self%id(n),          source = 0 )
    allocate( self%at(n),          source = 0 )
-   allocate( self%sym(n),         source = '    ' )
+   allocate( character(len=80) :: self%sym(n))
+   self%sym(:) = repeat(' ', 80)
    allocate( self%xyz(3,n),       source = 0.0_wp )
    allocate( self%abc(3,n),       source = 0.0_wp )
    allocate( self%dist(n,n),      source = 0.0_wp )

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -680,7 +680,6 @@ subroutine test_gfnff_pbc(error)
    use xtb_type_data, only : scc_results
    use xtb_type_environment, only : TEnvironment, init
    use xtb_type_restart, only : TRestart
-   use xtb_mctc_symbols, only : symbolLength
 
    use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
 
@@ -701,7 +700,7 @@ subroutine test_gfnff_pbc(error)
     real(wp), allocatable :: gradient(:, :)
     real(wp), allocatable :: xyztmp(:,:), lattmp(:,:)
     integer, allocatable :: attmp(:)
-    character(len=symbolLength), allocatable :: symtmp(:)
+    character(len=4), allocatable :: symtmp(:)
     logical, parameter :: pbc(3) = [.true., .true., .true. ]
     ! structures from X23, mcVOL22, and GFN-FF for Ln/An paper
     character(len=*), parameter :: pbc_strucs(3) = [&
@@ -840,7 +839,7 @@ subroutine test_gfnff_pbc(error)
     allocate(symtmp(2*mol%n))
     symtmp = mol%sym
     deallocate(mol%sym)
-    allocate(mol%sym(2*mol%n))
+    allocate(character(len=len(symtmp)) :: mol%sym(2*mol%n))
     mol%sym(1:mol%n)= symtmp
     mol%sym(mol%n+1:2*mol%n) = symtmp
     ! lattice
@@ -889,7 +888,6 @@ subroutine test_gfnff_LnAn_H(error)
    use xtb_type_data, only : scc_results
    use xtb_type_environment, only : TEnvironment, init
    use xtb_type_restart, only : TRestart
-   use xtb_mctc_symbols, only : symbolLength
 
    use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
 
@@ -911,7 +909,7 @@ subroutine test_gfnff_LnAn_H(error)
     real(wp), allocatable :: gradient(:, :)
     real(wp), allocatable :: xyztmp(:,:), lattmp(:,:)
     integer, allocatable :: attmp(:)
-    character(len=symbolLength), allocatable :: symtmp(:)
+    character(len=4), allocatable :: symtmp(:)
     logical, parameter :: pbc(3) = [.true., .true., .true. ]
     ! structures from X23, mcVOL22, and GFN-FF for Ln/An paper
     character(len=*), parameter :: struc(1) = ["Ce_0a7745"]

--- a/test/unit/test_hessian.f90
+++ b/test/unit/test_hessian.f90
@@ -25,7 +25,6 @@ module test_hessian
    use xtb_type_param
    use xtb_type_data
    use xtb_type_environment
-   use xtb_mctc_symbols, only : symbolLength
 
    use xtb_xtb_calculator, only : TxTBCalculator
    use xtb_main_setup, only : newXTBCalculator, newWavefunction
@@ -53,7 +52,7 @@ subroutine test_gfn1_hessian(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 3
    real(wp),parameter :: thr = 1.0e-7_wp
-   character(len=*), parameter :: sym(nat) = [character(len=symbolLength) :: "O", "H", "H"]
+   character(len=*), parameter :: sym(nat) = ["O", "H", "H"]
    real(wp), parameter :: xyz(3, nat) = reshape([&
       & 0.00000000000000_wp,    0.00000000034546_wp,    0.18900383618455_wp, &
       & 0.00000000000000_wp,    1.45674735348811_wp,   -0.88650486059828_wp, &
@@ -149,7 +148,7 @@ subroutine test_gfn2_hessian(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 3
    real(wp),parameter :: thr = 1.0e-7_wp
-   character(len=*), parameter :: sym(nat) = [character(len=symbolLength) :: "O", "H", "H"]
+   character(len=*), parameter :: sym(nat) = ["O", "H", "H"]
    real(wp), parameter :: xyz(3, nat) = reshape([&
       & 0.00000000000000_wp,   -0.00000000077760_wp,    0.18829790750029_wp, &
       & 0.00000000000000_wp,    1.45987612440076_wp,   -0.88615189669760_wp, &

--- a/test/unit/test_vertical.f90
+++ b/test/unit/test_vertical.f90
@@ -24,7 +24,6 @@ module test_vertical
    use xtb_type_data
    use xtb_type_environment
    use xtb_vertical, only : vfukui
-   use xtb_mctc_symbols, only : symbolLength
 
    use xtb_xtb_calculator, only : TxTBCalculator
    use xtb_main_setup, only : newXTBCalculator, newWavefunction
@@ -52,7 +51,7 @@ subroutine test_gfn1_fukui(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 4
    real(wp),parameter :: thr = 1.0e-2_wp
-   character(len=*), parameter :: sym(nat) = [character(len=symbolLength) :: "B", "F", "F", "F"]
+   character(len=*), parameter :: sym(nat) = ["B", "F", "F", "F"]
    real(wp), parameter :: xyz(3, nat) = reshape([&
       & -4.41826178485383_wp, 2.18219865869875_wp, -0.29163266946828_wp, &
       & -3.14927320876938_wp, 1.86405526998014_wp,  1.78831473195343_wp, &
@@ -103,7 +102,7 @@ subroutine test_gfn2_fukui(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 4
    real(wp),parameter :: thr = 1.0e-2_wp
-   character(len=*), parameter :: sym(nat) = [character(len=symbolLength) :: "B", "F", "F", "F"]
+   character(len=*), parameter :: sym(nat) = ["B", "F", "F", "F"]
    real(wp), parameter :: xyz(3, nat) = reshape([&
       & -4.41826178485383_wp, 2.18219865869875_wp, -0.29163266946828_wp, &
       & -3.14927320876938_wp, 1.86405526998014_wp,  1.78831473195343_wp, &


### PR DESCRIPTION
Alternative approach to #1172 

This PR removes symbolLength variable from xtb_mctc_symbols module and changes behaviour to use dynamically sized strings.

Fixed the following error for CMake debug build on Aarch64 (as well as #1172):
```
At line 243 of file /home/runner/work/xtb/xtb/src/mctc/symbols.f90
Fortran runtime error: Actual string length does not match the declared one for dummy argument 'symbol' (1/4)

Error termination. Backtrace:
#0  0xff0d6362d44b in ???
#1  0xff0d6362e277 in ???
#2  0xff0d6362e7cb in ???
#3  0xab6d17e20527 in __xtb_mctc_symbols_MOD_getidentitysymbol
	at /home/runner/work/xtb/xtb/src/mctc/symbols.f90:243
#4  0xab6d17fb8c17 in __xtb_type_molecule_MOD_initmolecule
	at /home/runner/work/xtb/xtb/src/type/molecule.f90:263
#5  0xab6d17fb5bf7 in __xtb_type_molecule_MOD_initmoleculesymbols
	at /home/runner/work/xtb/xtb/src/type/molecule.f90:330
#6  0xab6d17ab537f in test_gfn1_hessian
	at /home/runner/work/xtb/xtb/test/unit/test_hessian.f90:116
#7  0xab6d179c9d4f in run_unittest
	at /home/runner/work/xtb/xtb/test/unit/main.f90:169
#8  0xab6d179ca1e7 in run_testsuite
	at /home/runner/work/xtb/xtb/test/unit/main.f90:149
#9  0xab6d179c8c27 in tester
	at /home/runner/work/xtb/xtb/test/unit/main.f90:103
#10  0xab6d179ca2cf in main
	at /home/runner/work/xtb/xtb/test/unit/main.f90:20
```