### PR TITLE
Fixing aISS distance constrain fix

### DIFF
--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -1052,6 +1052,7 @@ contains
 
       !> Read the constrain again with new xyz only if necessary
       if (constraint_xyz) then
+         nconstr=0 !Reset number of constraints for distance, angle, and dihedral
          call read_userdata(xcontrol, env, mol)
          call constrain_xTB_gff(env, mol)
       end if
@@ -1108,6 +1109,7 @@ contains
 !            deallocate(wpot(i)%list)
             if(allocated(wpot(i)%list)) deallocate(wpot(i)%list)
          end do
+         nconstr=0 !Reset number of constraints for distance, angle, and dihedral
          call read_userdata(xcontrol, env, mol)
          call constrain_xTB_gff(env, mol)
       end if

--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -240,7 +240,9 @@ contains
       if (optlvl == 'gfn0') fnv = xfind(p_fname_param_gfn0)
       if (optlvl == 'gfn1') fnv = xfind(p_fname_param_gfn1)
       call newCalculator(env, comb, calc, fnv, restart, acc)
+      call env%checkpoint("Could not setup single-point calculator")
       call initDefaults(env, calc, comb, gsolvstate_iff)
+      call env%checkpoint("Could not setup defaults")
       write(*,*) 'initialization done'
 
       select type (calc)


### PR DESCRIPTION
Fixed a bug that caused crashes during the aISS procedure when distances, angles, or dihedral angles were constrained.