### PR TITLE
Fix flicking xtb/gfnff test

### DIFF
--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4142,9 +4142,7 @@ subroutine es_grad_sigma(mol, topo, nlist, rTrans, gTrans, xtmp, cf, &
    real(wp), allocatable :: amatdL(:, :, :)
    real(wp), allocatable :: atrace(:, :)
    allocate(amatdr(3,mol%n,mol%n), amatdL(3,3,mol%n), source = 0.0_wp)
-   allocate(atrace(3, mol%n))
-   amatdr = 0.0_wp
-   amatdL = 0.0_wp
+   allocate(atrace(3, mol%n), source = 0.0_wp)
 
    ! new routine from D4 for calculating derivatives
    call get_damat_3d(mol, topo, cf, xtmp, rTrans, gTrans, amatdr, amatdL, atrace)

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -4140,10 +4140,8 @@ subroutine es_grad_sigma(mol, topo, nlist, rTrans, gTrans, xtmp, cf, &
    real(wp), allocatable :: dXvecdr(:,:,:)
    real(wp), allocatable :: amatdr(:, :, :)
    real(wp), allocatable :: amatdL(:, :, :)
-   integer :: m
    real(wp), allocatable :: atrace(:, :)
-   m = mol%n+topo%nfrag
-   allocate(amatdr(3,mol%n,m), amatdL(3,3,m), source = 0.0_wp)
+   allocate(amatdr(3,mol%n,mol%n), amatdL(3,3,mol%n), source = 0.0_wp)
    allocate(atrace(3, mol%n))
    amatdr = 0.0_wp
    amatdL = 0.0_wp


### PR DESCRIPTION
This patch fixes flicking gfnff test that sometimes happens on MacOS runners due to out-of-memory access. 

As I can see, there should be an additional term related to topology constraints, however, it was never implemented for gradients.