### PR TITLE
Increase threshold for lowest frequencies

### DIFF
--- a/src/detrotra.f90
+++ b/src/detrotra.f90
@@ -43,7 +43,7 @@ module xtb_detrotra
   
     nn = 0
     do ii=1, n3
-       if(eig(ii).gt.0.05) cycle  ! only lowest checked
+       if(eig(ii).gt.5.0_wp) cycle  ! only lowest checked
   
        kk=0
        do j=1,mol%n


### PR DESCRIPTION
Fixes #1203 

H2 eigvals are the following:
```
2.9933945092181844E-015   8.5529038621230392E-015   2.6862916288779701E-014   3.4268547221618851        3.4268547221618966        40.610372376753845
```