### PR TITLE
Fix gradient evaluation when one of coordinates is close to another

### DIFF
--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -717,7 +717,11 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
          ! SCC terms
          !eh1 = autoev*(shellShift(ishell) + shellShift(jshell))
          !H1 = -S(j,i)*eh1*0.5_wp
-         H(j,i) = H0(k)*evtoau/S(j,i)
+         if (H0(k) .eq. 0.0_wp) then
+            H(j,i) = 0.0_wp
+         else
+            H(j,i) = H0(k)*evtoau/S(j,i)
+         end if
          H(i,j) = H(j,i)
       enddo
       call build_dSDQH0_noreset(xtbData%nShell, xtbData%hamiltonian, selfEnergy, &

--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -592,11 +592,6 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
       iat=basis%aoat2(ii)
       do jj=1,ii-1
          jat=basis%aoat2(jj)
-         if(abs(S(jj,ii)).lt.neglect) then
-            S(jj,ii)=0.0_wp
-            S(ii,jj)=0.0_wp
-            cycle
-         endif
          nmat=nmat+1
          matlist(1,nmat)=ii
          matlist(2,nmat)=jj

--- a/test/unit/test_gfn2.f90
+++ b/test/unit/test_gfn2.f90
@@ -299,11 +299,11 @@ subroutine test_gfn2gbsa_api(error)
 
    call check_(error, hl_gap, 3.408607724814_wp, thr=1e-5_wp)
    call check_(error, energy,-22.002501380096_wp, thr=thr)
-   call check_(error, norm2(gradient),0.19441977481008E-01_wp, thr=thr)
+   call check_(error, norm2(gradient),0.19366866479022E-01_wp, thr=thr)
    call check_(error, gradient(1,1), .9038674439127e-02_wp, thr=thr)
    call check_(error, gradient(3,2),-.1394693523214e-02_wp, thr=thr)
    call check_(error, gradient(3,11),-gradient(3,10), thr=thr)
-   call check_(error, gradient(1,8),0.22890674680144E-02_wp, thr=thr)
+   call check_(error, gradient(1,8),0.17878350605942E-02_wp, thr=thr)
 
 end subroutine test_gfn2gbsa_api
 
@@ -1080,7 +1080,7 @@ subroutine test_gfn2_wbo(error)
    ! check  scc !
    call check_(error, energy, -33.314958144107_wp, thr=thr)
    call check_(error, norm2(gradient), 0.018945181484_wp, thr=thr)
-   call check_(error, hl_gap, 1.805948277212_wp, thr=thr)
+   call check_(error, hl_gap, 1.805948321662_wp, thr=thr)
 
 
    ! check wbo !


### PR DESCRIPTION
Fix #986 

If one of coordinates close to another in another atom, S(ii,jj) tends to zero, at the same time corresponding H0 is also tends to zero and therefore H0(k)/S(ii,jj) is constant. But since S(ii,jj) was skipped, the H(ii,jj) becomes zero that is incorrect. 