### PR TITLE
Fix imaginary frequencies

### DIFF
--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -467,15 +467,15 @@ subroutine numhess( &
          ! for three atom systems we assume that the plane was constructed (or linear system is used)
       endif
       j=kend
-      do k=1,n3
-         if(abs(res%freq(k)).gt.0.01_wp)then
-            j=j+1
-            if(j.gt.n3) then
+      do k=1, n3
+         if (abs(res%freq(k)) > 0.01_wp) then
+            j = j + 1
+            if(j > n3) then
                call env%error('internal error while sorting hessian', source)
                return
             end if
-            h(1:n3,j)=res%hess(1:n3,k)
-            isqm(  j)=res%freq(   k)
+            h(1:n3,j) = res%hess(1:n3,k)
+            isqm(  j) = res%freq(   k)
          endif
       enddo
    end if

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -86,7 +86,7 @@ subroutine numhess( &
    real(wp) :: sum1,sum2,trdip(3),dipole(3)
    real(wp) :: trpol(3),sl(3,3)
    integer  :: n3,i,j,k,ic,jc,ia,ja,ii,jj,info,lwork,a,b,ri,rj
-   integer  :: nread,kend,lowmode
+   integer  :: nread,lowmode
    integer  :: nonfrozh
    integer  :: fixmode
    integer, allocatable :: nb(:,:)
@@ -442,31 +442,7 @@ subroutine numhess( &
    if (mol%n > 1) then
       h = 0.0_wp
       isqm = 0.0_wp
-      kend=0
-      if (freezeset%n == 0) then
-         kend=6
-         if(res%linear)then
-            kend=5
-            do i=1,kend
-               izero(i)=i
-            enddo
-            res%freq(1:kend)=0
-         endif
-         do k=1,kend
-            h(1:n3,k)=res%hess(1:n3,izero(k))
-            isqm(  k)=res%freq(izero(k))
-         enddo
-      else if (freezeset%n <= 2) then
-         ! for systems with one fixed atom, there should be 2 and 3 degrees of freedom for linear and non-linear systems, respectively
-         ! for systems with two fixed atoms, there should be 0 and 1 degrees of freedom for linear and non-linear systems, respectively
-         ! for linear systems with more than two fixed atoms, there should be 0 degrees of freedom
-         ! for non-linear systems unless one fixes three atoms defines plane, 1 degree of freedom will exist, otherwise there should be 0 degrees of freedom
-         ! anyway, the check here will become more complex and therefore it is not impemented
-         ! NOTE: it is not necessary lowest N frequencies
-         error stop "not implemented"
-         ! for three atom systems we assume that the plane was constructed (or linear system is used)
-      endif
-      j=kend
+      j = 0
       do k=1, n3
          if (abs(res%freq(k)) > 0.05_wp) then
             j = j + 1

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -86,10 +86,10 @@ subroutine numhess( &
    real(wp) :: sum1,sum2,trdip(3),dipole(3)
    real(wp) :: trpol(3),sl(3,3)
    integer  :: n3,i,j,k,ic,jc,ia,ja,ii,jj,info,lwork,a,b,ri,rj
-   integer  :: nread,lowmode
+   integer  :: nread,lowmode,nskip
    integer  :: nonfrozh
    integer  :: fixmode
-   integer  :: skiplist(6), nskip
+   integer, allocatable :: skiplist(:)
    integer, allocatable :: nb(:,:)
    integer, allocatable :: indx(:),molvec(:),izero(:)
    real(wp),allocatable :: bond(:,:)
@@ -445,6 +445,7 @@ subroutine numhess( &
       isqm = 0.0_wp
       j = 0
       nskip = 0
+      allocate(skiplist(n3), source = 0)
       do k=1, n3
          if (abs(res%freq(k)) > 0.05_wp) then
             j = j + 1
@@ -452,10 +453,6 @@ subroutine numhess( &
             isqm(  j) = res%freq(   k)
          else
             nskip = nskip + 1
-            if(nskip > 6) then
-               call env%error('internal error while sorting hessian', source)
-               return
-            end if
             skiplist(nskip) = k
          endif
       enddo
@@ -465,6 +462,7 @@ subroutine numhess( &
          isqm(  j) = 0.0_wp
          nskip = nskip - 1
       end do
+      deallocate(skiplist)
    end if
    res%hess = h
    res%freq = isqm

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -468,7 +468,7 @@ subroutine numhess( &
       endif
       j=kend
       do k=1, n3
-         if (abs(res%freq(k)) > 0.01_wp) then
+         if (abs(res%freq(k)) > 0.05_wp) then
             j = j + 1
             if(j > n3) then
                call env%error('internal error while sorting hessian', source)

--- a/src/main/property.F90
+++ b/src/main/property.F90
@@ -1199,7 +1199,7 @@ module xtb_propertyoutput
       real(wp) xx(10), sthr, temp, scale_factor
       real(wp) aa, bb, cc, vibthr, ithr
       real(wp) escf, symnum, wt, avmom, diff
-      real(wp) :: omega, maxfreq, fswitch, lnq_r, lnq_v
+      real(wp) :: omega, fswitch, lnq_r, lnq_v
       real(wp), allocatable :: et(:), ht(:), gt(:), ts(:)
       integer nn, nvib, i, j, k, n, nvib_theo, isthr
       integer, intent(out) :: nimag
@@ -1373,10 +1373,9 @@ module xtb_propertyoutput
       real(wp), intent(in) :: temp
 
       integer :: i
-      real(wp) :: maxfreq, omega, lnq_r, lnq_v, fswitch
+      real(wp) :: omega, lnq_r, lnq_v, fswitch
 
       write (iunit, '(a)')
-      maxfreq = max(300.0_wp, chg_inverted(0.99_wp, sthr))
       write (iunit, '(a8,a14,a12,10x,a12,10x,a12)') &
          "mode", "ω/cm⁻¹", "ln{qvib}", "ln{qrot}", "ln{qtot}"
       write (iunit, '(3x,72("-"))')
@@ -1385,7 +1384,6 @@ module xtb_propertyoutput
          lnq_r = lnqvib(temp, omega)
          lnq_v = lnqrot(temp, omega, avmom)
          fswitch = 1.0_wp - chg_switching(omega, sthr)
-         if (omega > maxfreq) exit
          write (iunit, '(i8,f10.2,2(f12.5,1x,"(",f6.2,"%)"),f12.5)') &
             i, omega, lnq_v, (1.0_wp - fswitch) * 100, &
             lnq_r, fswitch * 100, (1.0_wp - fswitch) * lnq_v + fswitch * lnq_r
@@ -1408,7 +1406,7 @@ module xtb_propertyoutput
       real(wp), intent(in) :: temp       !< temperature
 
       integer :: i
-      real(wp) :: maxfreq, omega, s_r, s_v, fswitch
+      real(wp) :: omega, s_r, s_v, fswitch
       real(wp) :: beta, xxmom, e, ewj, mu, RT, sthr, avmom
       beta = 1.0_wp / kB / temp ! beta in 1/Eh
       sthr = sthr_rcm * rcmtoau ! sthr in Eh
@@ -1416,7 +1414,6 @@ module xtb_propertyoutput
       avmom = avmom_si * kgtome * aatoau**2 * 1.0e+20_wp ! in me·α²
 
       write (iunit, '(a)')
-      maxfreq = max(300.0_wp, chg_inverted(0.99_wp, sthr_rcm))
       write (iunit, '(a8,a14,1x,a27,a27,a12)') &
          "mode", "ω/cm⁻¹", "T·S(HO)/kcal·mol⁻¹", "T·S(FR)/kcal·mol⁻¹", "T·S(vib)"
       write (iunit, '(3x,72("-"))')
@@ -1446,7 +1443,6 @@ module xtb_propertyoutput
          end if
          ! Head-Gordon weighting
          fswitch = 1.0_wp - chg_switching(omega, sthr)
-         if (omega > maxfreq * rcmtoau) exit
          write (iunit, '(i8,f10.2,2(f12.5,1x,"(",f6.2,"%)"),f12.5)') &
             i, omega * autorcm, -RT * s_v, (1.0_wp - fswitch) * 100, &
             -RT * s_r, fswitch * 100, -RT * ((1.0_wp - fswitch) * s_v + fswitch * s_r)


### PR DESCRIPTION
Fix #693

Instead of trying to detect how many frequencies should be rot/trans, this patch counts number of low freqs and sort them. 

For linear H2O molecule:
```
3

H 0.0 0.0 0.0
O 0.0 0.0 1.0
H 0.0 0.0 2.0
```
the diff between old behaviour and new (`--hess`):
```diff
  vibrational frequencies (cm⁻¹)
-eigval :        0.00     0.00     0.00     0.00     0.00   935.71
-eigval :      935.71  2867.70  3045.49
+eigval :    -1840.78 -1840.78   935.71   935.71  2867.70  3045.49
+eigval :        0.00     0.00     0.00
...
  vibrational frequencies (cm⁻¹)
-eigval :        0.00     0.00     0.00     0.00     0.00   935.71
-eigval :      935.71  2867.70  3045.49
+eigval :    -1840.78 -1840.78   935.71   935.71  2867.70  3045.49
+eigval :        0.00     0.00     0.00
  reduced masses (amu)
-   1:  2.69   2:  2.69   3: 14.32   4: 14.32   5: 14.32   6:  1.01   7:  1.01   8:  1.01
-   9:  2.69
+   1:  2.69   2:  2.69   3:  1.01   4:  1.01   5:  1.01   6:  2.69   7: 14.32   8: 14.32
+   9: 14.32
  IR intensities (km·mol⁻¹)
-   1:726.33   2:726.33   3:  0.00   4:  0.00   5:  0.00   6:  0.00   7:  0.00   8:  0.00
-   9:217.07
+   1:726.33   2:726.33   3:  0.00   4:  0.00   5:  0.00   6:217.07   7:  0.00   8:  0.00
+   9:  0.00
  Raman intensities (Ä⁴*amu⁻¹)
    1:  0.00   2:  0.00   3:  0.00   4:  0.00   5:  0.00   6:  0.00   7:  0.00   8:  0.00
    9:  0.00
...
           :                      SETUP                      :
           :.................................................:
           :  # frequencies                           4      :
-          :  # imaginary freq.                       0      :
+          :  # imaginary freq.                       2      :
           :  linear?                              true      :
           :  only rotor calc.                    false      :
           :  symmetry                              din      :
...
     mode    ω/cm⁻¹     T·S(HO)/kcal·mol⁻¹    T·S(FR)/kcal·mol⁻¹   T·S(vib)
    ------------------------------------------------------------------------
+       1    935.71    -0.03610 (100.00%)    -0.18483 (  0.00%)    -0.03611
+       2    935.71    -0.03610 (100.00%)    -0.18483 (  0.00%)    -0.03611
+       3   2867.70    -0.00001 (100.00%)     0.14430 (  0.00%)    -0.00001
+       4   3045.49    -0.00000 (100.00%)     0.16204 (  0.00%)    -0.00000
    ------------------------------------------------------------------------
...
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
          ::                  THERMODYNAMIC                  ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
-         :: total free energy          -5.009429056662 Eh   ::
+         :: total free energy          -5.009429056672 Eh   ::
          ::.................................................::
          :: total energy               -5.010690547588 Eh   ::
-         :: zero point energy           0.017734665620 Eh   ::
+         :: zero point energy           0.017734665611 Eh   ::
          :: G(RRHO) w/o ZPVE           -0.016473174695 Eh   ::
-         :: G(RRHO) contrib.            0.001261490926 Eh   ::
+         :: G(RRHO) contrib.            0.001261490916 Eh   ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
+imag cut-off (cm-1) :    5.00
+ found            2  significant imaginary frequencies
+ writing imag mode distorted coords to xtbhess.xyz
+ for further optimization.
```

CO.xyz:
```
2

O        1.128 0.0 0.0
C        0.0 0.0 0.0
```

The diff (running with `--ohess`):
```diff
@@ -402,7 +402,7 @@ RMS gradient         :   0.00032
 writing file <hessian>, containing the non-mass-weighted Hessian matrix in atomic units (Eₕ/Bohr²).

  vibrational frequencies (cm⁻¹)
-eigval :        0.00     0.00     0.00     0.00     0.00  2223.01
+eigval :       -5.74    -5.74  2223.01     0.00     0.00     0.00
            -------------------------------------------------
           |                Property Printout                |
            -------------------------------------------------
@@ -480,11 +480,11 @@ It seems to be the Cinfv point group
           |               Frequency Printout                |
            -------------------------------------------------
  vibrational frequencies (cm⁻¹)
-eigval :        0.00     0.00     0.00     0.00     0.00  2223.01
+eigval :       -5.74    -5.74  2223.01     0.00     0.00     0.00
  reduced masses (amu)
-   1: 13.72   2: 13.72   3: 14.29   4: 14.29   5: 14.29   6: 13.72
+   1: 13.72   2: 13.72   3: 13.72   4: 14.29   5: 14.29   6: 14.29
  IR intensities (km·mol⁻¹)
-   1:  1.84   2:  1.84   3:  0.00   4:  0.00   5:  0.00   6: 26.98
+   1:  1.84   2:  1.84   3: 26.98   4:  0.00   5:  0.00   6:  0.00
  Raman intensities (Ä⁴*amu⁻¹)
    1:  0.00   2:  0.00   3:  0.00   4:  0.00   5:  0.00   6:  0.00
  output can be read by thermo (or use thermo option).
@@ -495,11 +495,13 @@ eigval :        0.00     0.00     0.00
            -------------------------------------------------

 cin symmetry found (for desy threshold:  0.10E+00) used in thermo
+ inverting freq            1   5.7385921955661043
+ inverting freq            2   5.7384824331576896

           ...................................................
           :                      SETUP                      :
           :.................................................:
-          :  # frequencies                           1      :
+          :  # frequencies                           3      :
           :  # imaginary freq.                       0      :
           :  linear?                              true      :
           :  only rotor calc.                    false      :
@@ -512,39 +514,46 @@ cin symmetry found (for desy threshold:

     mode    ω/cm⁻¹     T·S(HO)/kcal·mol⁻¹    T·S(FR)/kcal·mol⁻¹   T·S(vib)
    ------------------------------------------------------------------------
+       1      5.74    -2.71750 (  0.02%)    -1.57666 ( 99.98%)    -1.57686
+       2      5.74    -2.71751 (  0.02%)    -1.57667 ( 99.98%)    -1.57686
+       3   2223.01    -0.00015 (100.00%)     0.06796 (  0.00%)    -0.00015
    ------------------------------------------------------------------------

    temp. (K)  partition function   enthalpy   heat capacity  entropy
                                    cal/mol     cal/K/mol   cal/K/mol   J/K/mol
- 298.15  VIB   1.00                    0.139      0.005      0.001
+ 298.15  VIB  0.134E+04             1168.810      1.993     10.578
          ROT   107.                  592.502      1.987     11.276
-         INT   107.                  592.641      1.992     11.277
+         INT  0.144E+06             1761.312      3.980     21.855
          TR   0.143E+27             1481.254      4.968     35.908
-         TOT                        2073.8949     6.9604    47.1852   197.4228
+         TOT                        3242.5660     8.9480    57.7631   241.6810

        T/K    H(0)-H(T)+PV         H(T)/Eh          T*S/Eh         G(T)/Eh
    ------------------------------------------------------------------------
-    298.15    0.330496E-02    0.836936E-02    0.224192E-01   -0.140498E-01
+    298.15    0.516736E-02    0.102579E-01    0.274451E-01   -0.171872E-01
    ------------------------------------------------------------------------

          :::::::::::::::::::::::::::::::::::::::::::::::::::::
          ::                  THERMODYNAMIC                  ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
-         :: total free energy          -6.135900073382 Eh   ::
+         :: total free energy          -6.139037456355 Eh   ::
          ::.................................................::
          :: total energy               -6.121850225907 Eh   ::
-         :: zero point energy           0.005064394619 Eh   ::
-         :: G(RRHO) w/o ZPVE           -0.019114242094 Eh   ::
-         :: G(RRHO) contrib.           -0.014049847475 Eh   ::
+         :: zero point energy           0.005090541319 Eh   ::
+         :: G(RRHO) w/o ZPVE           -0.022277771767 Eh   ::
+         :: G(RRHO) contrib.           -0.017187230448 Eh   ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
+imag cut-off (cm-1) :    5.00
+ found            2  significant imaginary frequencies
+ writing imag mode distorted coords to xtbhess.xyz
+ for further optimization.
```

For bigger system:
```diff

            -------------------------------------------------
           |               Frequency Printout                |
            -------------------------------------------------
  projected vibrational frequencies (cm⁻¹)
-eigval :       -0.00    -0.00    -0.00    -0.00     0.00     0.00
-eigval :       53.81   134.56   182.61   284.67   371.44   655.69
-eigval :      709.53   796.89   888.75   941.11   994.10  1024.29
+eigval :       53.81   134.55   182.61   284.67   371.44   655.69
+eigval :      709.53   796.89   888.74   941.11   994.10  1024.29
 eigval :     1143.84  1191.69  1270.75  1337.11  1346.31  1371.68
-eigval :     1785.08  1814.93  2775.63  2855.93  2911.01  2978.60
+eigval :     1785.08  1814.93  2775.64  2855.93  2911.01  2978.60
+eigval :        0.00     0.00     0.00     0.00     0.00     0.00
  reduced masses (amu)
-   1: 12.58   2: 13.67   3: 13.65   4: 13.11   5: 14.05   6: 13.75   7: 14.58   8:  9.29
-   9: 12.26  10: 10.39  11: 12.03  12:  8.22  13:  9.23  14: 11.13  15: 10.44  16:  5.72
-  17:  8.68  18:  8.53  19: 11.85  20:  5.45  21:  4.21  22:  2.75  23:  2.82  24:  2.00
-  25: 13.42  26: 13.48  27:  1.70  28:  1.75  29:  1.73  30:  1.73
+   1: 14.58   2:  9.29   3: 12.26   4: 10.39   5: 12.03   6:  8.22   7:  9.23   8: 11.13
+   9: 10.44  10:  5.72  11:  8.68  12:  8.53  13: 11.85  14:  5.45  15:  4.21  16:  2.75
+  17:  2.82  18:  2.00  19: 13.42  20: 13.48  21:  1.70  22:  1.75  23:  1.73  24:  1.73
+  25: 12.25  26: 12.82  27: 13.75  28: 13.97  29: 14.59  30: 13.43
  IR intensities (km·mol⁻¹)
-   1:  2.37   2:  1.24   3:  0.01   4:  3.95   5:  1.04   6:  1.92   7:  0.87   8:  8.59
-   9: 11.13  10: 20.62  11: 14.21  12:  7.87  13: 28.63  14: 31.72  15: 19.04  16: 13.81
-  17: 35.02  18:  4.17  19:170.86  20: 47.05  21: 14.71  22: 32.04  23: 15.06  24: 25.25
-  25:427.51  26:280.50  27:108.09  28: 74.70  29:  7.14  30:  2.52
+   1:  0.87   2:  8.59   3: 11.13   4: 20.62   5: 14.21   6:  7.87   7: 28.63   8: 31.72
+   9: 19.04  10: 13.81  11: 35.02  12:  4.17  13:170.86  14: 47.04  15: 14.71  16: 32.04
+  17: 15.06  18: 25.25  19:427.51  20:280.50  21:108.09  22: 74.70  23:  7.14  24:  2.52
+  25:  2.93  26:  1.59  27:  1.70  28:  0.23  29:  2.54  30:  1.52
  Raman intensities (Ä⁴*amu⁻¹)
    1:  0.00   2:  0.00   3:  0.00   4:  0.00   5:  0.00   6:  0.00   7:  0.00   8:  0.00
    9:  0.00  10:  0.00  11:  0.00  12:  0.00  13:  0.00  14:  0.00  15:  0.00  16:  0.00
@@ -989,69 +989,84 @@ c1  symmetry found (for desy threshold:

     mode    ω/cm⁻¹     T·S(HO)/kcal·mol⁻¹    T·S(FR)/kcal·mol⁻¹   T·S(vib)
    ------------------------------------------------------------------------
-       1     53.81    -1.39307 ( 57.28%)    -1.03419 ( 42.72%)    -1.23977
-       2    134.56    -0.85863 ( 98.13%)    -0.76303 (  1.87%)    -0.85684
+       1     53.81    -1.39306 ( 57.28%)    -1.03419 ( 42.72%)    -1.23977
+       2    134.55    -0.85864 ( 98.13%)    -0.76303 (  1.87%)    -0.85685
        3    182.61    -0.68621 ( 99.44%)    -0.67264 (  0.56%)    -0.68614
-       4    284.67    -0.44885 ( 99.90%)    -0.54118 (  0.10%)    -0.44894
+       4    284.67    -0.44886 ( 99.90%)    -0.54118 (  0.10%)    -0.44894
+       5    371.44    -0.32017 ( 99.97%)    -0.46239 (  0.03%)    -0.32021
+       6    655.69    -0.10828 (100.00%)    -0.29407 (  0.00%)    -0.10828
+       7    709.53    -0.08795 (100.00%)    -0.27070 (  0.00%)    -0.08795
+       8    796.89    -0.06257 (100.00%)    -0.23630 (  0.00%)    -0.06257
+       9    888.74    -0.04354 (100.00%)    -0.20399 (  0.00%)    -0.04354
+      10    941.11    -0.03533 (100.00%)    -0.18703 (  0.00%)    -0.03533
+      11    994.10    -0.02856 (100.00%)    -0.17081 (  0.00%)    -0.02856
+      12   1024.29    -0.02528 (100.00%)    -0.16195 (  0.00%)    -0.02529
+      13   1143.84    -0.01553 (100.00%)    -0.12925 (  0.00%)    -0.01554
+      14   1191.69    -0.01276 (100.00%)    -0.11711 (  0.00%)    -0.01276
+      15   1270.75    -0.00920 (100.00%)    -0.09808 (  0.00%)    -0.00920
+      16   1337.11    -0.00697 (100.00%)    -0.08300 (  0.00%)    -0.00697
+      17   1346.31    -0.00671 (100.00%)    -0.08097 (  0.00%)    -0.00671
+      18   1371.68    -0.00603 (100.00%)    -0.07544 (  0.00%)    -0.00603
+      19   1785.08    -0.00103 (100.00%)     0.00259 (  0.00%)    -0.00103
+      20   1814.93    -0.00091 (100.00%)     0.00750 (  0.00%)    -0.00091
+      21   2775.64    -0.00001 (100.00%)     0.13335 (  0.00%)    -0.00001
+      22   2855.93    -0.00001 (100.00%)     0.14180 (  0.00%)    -0.00001
+      23   2911.01    -0.00001 (100.00%)     0.14746 (  0.00%)    -0.00001
+      24   2978.60    -0.00001 (100.00%)     0.15426 (  0.00%)    -0.00001
    ------------------------------------------------------------------------

    temp. (K)  partition function   enthalpy   heat capacity  entropy
                                    cal/mol     cal/K/mol   cal/K/mol   J/K/mol
- 298.15  VIB   29.2                 2157.784     13.674     13.425
+ 298.15  VIB   29.2                 2157.786     13.674     13.425
          ROT  0.123E+06              888.752      2.981     26.273
-         INT  0.360E+07             3046.537     16.655     39.698
+         INT  0.360E+07             3046.538     16.655     39.698
          TR   0.800E+27             1481.254      4.968     39.321
-         TOT                        4527.7906    21.6227    79.0193   330.6168
+         TOT                        4527.7919    21.6227    79.0193   330.6169

        T/K    H(0)-H(T)+PV         H(T)/Eh          T*S/Eh         G(T)/Eh
    ------------------------------------------------------------------------
-    298.15    0.721549E-02    0.751504E-01    0.375446E-01    0.376058E-01
+    298.15    0.721550E-02    0.751504E-01    0.375446E-01    0.376058E-01
    ------------------------------------------------------------------------

          :::::::::::::::::::::::::::::::::::::::::::::::::::::
          ::                  THERMODYNAMIC                  ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
-         :: total free energy         -20.585323405221 Eh   ::
+         :: total free energy         -20.585323411084 Eh   ::
          ::.................................................::
-         :: total energy              -20.622929187851 Eh   ::
-         :: zero point energy           0.067934918791 Eh   ::
-         :: G(RRHO) w/o ZPVE           -0.030329136161 Eh   ::
-         :: G(RRHO) contrib.            0.037605782630 Eh   ::
+         :: total energy              -20.622929187960 Eh   ::
+         :: zero point energy           0.067934920100 Eh   ::
+         :: G(RRHO) w/o ZPVE           -0.030329143225 Eh   ::
+         :: G(RRHO) contrib.            0.037605776876 Eh   ::
          :::::::::::::::::::::::::::::::::::::::::::::::::::::
```


