### PR TITLE
Solvation printout, fix for #1185

### DIFF
--- a/src/gfnff/calculator.f90
+++ b/src/gfnff/calculator.f90
@@ -284,7 +284,7 @@ subroutine singlepoint(self, env, mol, chk, printlevel, restart, &
       if (.not.set%silent.and.allocated(solvation)) then
          write(env%unit,outfmt) "total w/o Gsolv   ", &
             &  results%e_total-results%g_solv, "Eh   "
-         write(env%unit,outfmt) "total w/o Gsasa/hb", &
+         write(env%unit,outfmt) "w/o Gsasa/hb/shift", &
             &  results%e_total-results%g_sasa-results%g_hb-results%g_shift, "Eh   "
       endif
       write(env%unit,outfmt) "gradient norm     ", results%gnorm,  "Eh/a0"

--- a/src/xtb/calculator.f90
+++ b/src/xtb/calculator.f90
@@ -321,7 +321,7 @@ subroutine singlepoint(self, env, mol, chk, printlevel, restart, &
       write(env%unit,'(9x,53(":"))')
       write(env%unit,outfmt) "total energy      ", results%e_total,"Eh   "
       if (.not.set%silent.and.allocated(self%solvation)) then
-         write(env%unit,outfmt) "total w/o Gsasa/hb", &
+         write(env%unit,outfmt) "w/o Gsasa/hb/shift", &
             &  results%e_total-results%g_sasa-results%g_hb-results%g_shift, "Eh   "
       endif
       write(env%unit,outfmt) "gradient norm     ", results%gnorm,  "Eh/a0"


### PR DESCRIPTION
This fixed #1185 by now explicitly stating that the second energy is also without Gshift. Due to the formatting the total energy part has to be removed. Does anyone have better ideas how to possibly handle that?