### PR TITLE
Fix Fukui function for PTB and change spin-state assignment

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -550,7 +550,7 @@ contains
                p_run_modef, p_run_mdopt, p_run_metaopt)
             if (set%mode_extrun == p_ext_gfnff) then
                fnv = xfind(p_fname_param_gfnff)
-             elseif (set%mode_extrun .eq. p_ext_ptb) then
+            elseif (set%mode_extrun .eq. p_ext_ptb) then
                   fnv = xfind(p_fname_param_ptb)
             else
                if (set%gfn_method == 0) then
@@ -564,14 +564,18 @@ contains
                end if
             end if
          case (p_run_vip, p_run_vea, p_run_vipea, p_run_vfukui, p_run_vomega)
-            if (set%gfn_method == 0) then
-               fnv = xfind(p_fname_param_gfn0)
-            end if
-            if (set%gfn_method == 1) then
-               fnv = xfind(p_fname_param_gfn1)
-            end if
-            if (set%gfn_method == 2) then
-               fnv = xfind(p_fname_param_gfn2)
+            if (set%mode_extrun .eq. p_ext_ptb) then
+                  fnv = xfind(p_fname_param_ptb)
+            else
+               if (set%gfn_method == 0) then
+                  fnv = xfind(p_fname_param_gfn0)
+               end if
+               if (set%gfn_method == 1) then
+                  fnv = xfind(p_fname_param_gfn1)
+               end if
+               if (set%gfn_method == 2) then
+                  fnv = xfind(p_fname_param_gfn2)
+               end if
             end if
          end select
       end if


### PR DESCRIPTION
### Modified unpaired electron assignment
- The previous spin state assignment set the wavefunction to be open-shell for the anionic case if the original wavefunction has already been open-shell (see the relevant line of code below). If I don't have a major logic issue this seems to have been wrong in general before (`wf_an` is only a copy from the ground-state wavefunction calculated before), and the other way round would be correct (in the simplest case: a neutral closed-shell molecule becomes open-shell in the ionized case). The spin state assignment has been changed to a more reasonable logic.
```Fortran
if (mod(wf_an%wfn%nel,2).ne.0) wf_an%wfn%nopen = 1
```

- Since PTB does not allow for restarting a calculation, assigning the spin state only in the wavefunction does not have any effect. Before, the Fukui calculation crashed since `mol.uhf` didn't match the changed charge anymore (number of electrons was odd in a closed-shell calculation). Here, `mol.uhf` is changed accordingly (in the simplest case; from closed-shell to `mol.uhf=1`).
- Caution: The Fukui results for GFNn-xTB might also change since the `nopen` assignment has been changed.

### Additional changes
- enable PTB parameter loading for Fukui calculations as well
- minor formatting adjustments

Closes #1226.
