### PR TITLE
Remove unused gammas

### DIFF
--- a/src/solv/cosmo.f90
+++ b/src/solv/cosmo.f90
@@ -135,9 +135,6 @@ module xtb_solv_cosmo
    real(wp), parameter :: ah1 = 3._wp/(4.0_wp*w)
    real(wp), parameter :: ah3 = -1._wp/(4.0_wp*w3)
 
-   !> Surface tension (in au)
-   real(wp), parameter :: gammas = 1.0e-5_wp
-
    !> Salt screening
    real(wp), parameter :: kappaConst = 0.7897e-3_wp
 

--- a/src/solv/gbsa.f90
+++ b/src/solv/gbsa.f90
@@ -206,9 +206,6 @@ module xtb_solv_gbsa
    real(wp), parameter :: ah1 = 3._wp/(4.0_wp*w)
    real(wp), parameter :: ah3 = -1._wp/(4.0_wp*w3)
 
-   !> Surface tension (in au)
-   real(wp), parameter :: gammas = 1.0e-5_wp
-
    !> Salt screening
    real(wp), parameter :: kappaConst = 0.7897e-3_wp
 


### PR DESCRIPTION
This parameter are not used anywhere in code and therefore can be easily removed.