### PR TITLE
Init some variables in relaxation engine

### DIFF
--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -1254,7 +1254,14 @@ subroutine inertial_relax &
    if (optcell) then
       lat_apar = opt%astart
       lat_time_step = opt%lat_time_step
+   else
+      lat_apar = 0.0_wp
+      lat_time_step = 0.0_wp
    endif
+
+   lat_gnorm = 0.0_wp
+   lat_speed = 0.0_wp
+   lat_power = 0.0_wp
 
    ! get current gradient norm
    gnorm = sqrt(ddot(3*mol%n,gradient,1,gradient,1))


### PR DESCRIPTION
At 
https://github.com/grimme-lab/xtb/blob/41059b44d84a07dfd99a051e4409ef654faca939/src/relaxation_engine.f90#L1418-L1419
the reading of uninitialized variable may generate SIGFPE. This patch defines `lat_gnorm` as well as other variables related to optimization of cells to avoid such behaviour.