### PR TITLE
Fix reduced mass calculation

### DIFF
--- a/src/freq/io.f90
+++ b/src/freq/io.f90
@@ -22,7 +22,7 @@ module xtb_freq_io
    private
 
    public :: writeHessianOut, rdhess, wrhess, write_tm_vibspectrum
-   public :: g98fake, g98fake2
+   public :: g98fake, g98fake2, rddipd
 
 contains
 
@@ -78,10 +78,8 @@ contains
       real(wp), intent(out) :: h(nat3, nat3)
       character(len=*), intent(in) :: fname
       integer :: iunit, i, j, mincol, maxcol
-      character(len=5) :: adum
       character(len=80) :: a80
 
-      !     write(*,*) 'Reading Hessian <',trim(fname),'>'
       call open_file(iunit, fname, 'r')
 50    read (iunit, '(a)') a80
       if (index(a80, '$hessian') /= 0) then
@@ -99,6 +97,50 @@ contains
 
 300   return
    end subroutine rdhess
+
+   subroutine rddipd(nat3,dipd,fname)
+   implicit none
+   integer, intent(in)  :: nat3
+   real(wp),intent(out) :: dipd(3,nat3)
+   character(len=*),intent(in) :: fname
+   integer  :: iunit,i,j
+   character(len=80) :: a80
+
+   call open_file(iunit,fname,'r')
+50 read(iunit,'(a)') a80
+   if(index(a80,'$dipgrad').ne.0)then
+      do i=1,nat3
+         read(iunit,*)(dipd(j,i),j=1,3)
+      enddo
+      call close_file(iunit)
+      goto 300
+   endif
+   goto 50
+
+300 return
+   end subroutine rddipd
+
+   subroutine wrdipd(nat3,dipd,fname)
+   use xtb_lin, only : lin
+   implicit none
+   integer, intent(in) :: nat3
+   real(wp),intent(in) :: dipd(3,nat3)
+   character(len=*),intent(in) :: fname
+   integer iunit,i
+   character(len=5)  :: adum
+   character(len=80) :: a80
+
+   adum='   '
+   call open_file(iunit,fname,'w')
+   a80='$dipd'
+   write(iunit,'(a)')a80
+   do i=1,nat3
+      write(iunit,'(a5,3f15.10)')adum,dipd(1:3,i)
+   enddo
+   call close_file(iunit)
+
+   end subroutine wrdipd
+
 
    subroutine write_tm_vibspectrum(ich, n3, freq, ir_int, raman_activity, temp, v_incident)
       use xtb_setparam

--- a/src/freq/io.f90
+++ b/src/freq/io.f90
@@ -49,14 +49,17 @@ contains
    end subroutine writeHessianOut
 
    subroutine wrhess(nat3, h, fname)
-      !> Arguments
+      ! Arguments
       integer, intent(in)                 :: nat3
       real(wp), intent(in)                :: h(nat3 * (nat3 + 1) / 2)
       character(len=*), intent(in)        :: fname
-      !> Local variables
+      ! Local variables
       integer                             :: iunit
       integer                             :: i, j, mincol, maxcol
       character(len=80)                   :: a80
+
+      ! ## Writing TURBOMOLE hessian files ##
+      ! For format and examples, see `rdhess`
 
       call open_file(iunit, fname, 'w')
       ! Write header
@@ -77,11 +80,36 @@ contains
    end subroutine wrhess
 
    subroutine rdhess(nat3, h, fname)
-      integer, intent(in) :: nat3
-      real(wp), intent(out) :: h(nat3, nat3)
-      character(len=*), intent(in) :: fname
+      integer, intent(in) :: nat3            ! number of atoms * 3 (dimension of the hessian matrix)
+      real(wp), intent(out) :: h(nat3, nat3) ! hessian matrix
+      character(len=*), intent(in) :: fname  ! name of the file that contains the hessian matrix
       integer :: iunit, i, j, mincol, maxcol
       character(len=80) :: a80
+
+      ! ## Parsing TURBOMOLE hessian files ##
+      ! Can be read in with this subroutine by calling:
+      ! call rdhess(n3, h, "hessian")
+      ! Example of a hessian file from TURBOMOLE (written to disk during execution of `aoforce`)
+      ! $hessian (projected)
+      !     0.7481372492   0.0000000000   0.0000000830  -0.3740686579   0.0000000000
+      !     0.2665999127  -0.3740685913   0.0000000000  -0.2665999957
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !     0.0000000830   0.0000000000   0.4436161882   0.2073710893   0.0000000000
+      !    -0.2218080645  -0.2073711723   0.0000000000  -0.2218081237
+      !    -0.3740686579   0.0000000000   0.2073710893   0.3969513659   0.0000000000
+      !    -0.2369855336  -0.0228827080   0.0000000000   0.0296144443
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !     0.2665999127   0.0000000000  -0.2218080645  -0.2369855336   0.0000000000
+      !     0.2059073550  -0.0296143791   0.0000000000   0.0159007095
+      !    -0.3740685913   0.0000000000  -0.2073711723  -0.0228827080   0.0000000000
+      !    -0.0296143791   0.3969512993   0.0000000000   0.2369855514
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !     0.0000000000   0.0000000000   0.0000000000   0.0000000000
+      !    -0.2665999957   0.0000000000  -0.2218081237   0.0296144443   0.0000000000
+      !     0.0159007095   0.2369855514   0.0000000000   0.2059074142
+      ! $end
 
       h = 0.0_wp
       call open_file(iunit, fname, 'r')
@@ -102,11 +130,29 @@ contains
    end subroutine rdhess
 
    subroutine rddipd(nat3,dipd,fname)
-      integer, intent(in)  :: nat3
-      real(wp),intent(out) :: dipd(3,nat3)
-      character(len=*),intent(in) :: fname
+      integer, intent(in)  :: nat3         ! number of atoms * 3 (dimension of the hessian matrix)
+      real(wp),intent(out) :: dipd(3,nat3) ! dipole gradient matrix
+      character(len=*),intent(in) :: fname ! name of the file that contains the dipole gradient matrix
       integer  :: iunit,i,j
       character(len=80) :: a80
+
+      ! ## Parsing TURBOMOLE dipole moment gradient files ##
+      ! Can be read in with this subroutine by calling:
+      ! call rddipd(n3, dipd, "dipgrad")
+      ! Example of a dipole gradient file from TURBOMOLE (written to disk during execution of `aoforce`)
+      ! ```
+      ! $dipgrad          cartesian dipole gradients
+      !   -.55590957957556D+00  -.13474468786800D-11  0.19553268509540D-11
+      !   0.94497121874554D-12  -.41804517132353D+00  0.42665391608598D-11
+      !   -.51049455461472D-11  -.93995447836050D-12  -.45647662656399D+00
+      !   0.27795478978935D+00  0.15487821610555D-11  0.39622398334096D-01
+      !   -.28030504003640D-11  0.20902258565859D+00  -.26693334081688D-11
+      !   -.92060828461747D-02  0.12989300394917D-12  0.22823831328057D+00
+      !   0.27795478978374D+00  -.20133528237558D-12  -.39622398336052D-01
+      !   0.18580791816185D-11  0.20902258566247D+00  -.15972057526910D-11
+      !   0.92060828512799D-02  0.81006147441132D-12  0.22823831328096D+00
+      ! $end
+      ! ```
 
       dipd=0.0_wp
       call open_file(iunit,fname,'r')
@@ -126,6 +172,9 @@ contains
       integer iunit,i
       character(len=5)  :: adum
       character(len=80) :: a80
+
+      ! ## Writing dipole gradient files ##
+      ! For format and examples, see `rddipd`
 
       adum='   '
       call open_file(iunit,fname,'w')

--- a/src/freq/io.f90
+++ b/src/freq/io.f90
@@ -22,7 +22,7 @@ module xtb_freq_io
    private
 
    public :: writeHessianOut, rdhess, wrhess, write_tm_vibspectrum
-   public :: g98fake, g98fake2, rddipd
+   public :: g98fake, g98fake2, rddipd, wrdipd
 
 contains
 
@@ -140,7 +140,6 @@ contains
    call close_file(iunit)
 
    end subroutine wrdipd
-
 
    subroutine write_tm_vibspectrum(ich, n3, freq, ir_int, raman_activity, temp, v_incident)
       use xtb_setparam

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -110,7 +110,7 @@ subroutine numhess( &
    real(wp),allocatable :: xyzsave(:,:)
    real(wp),allocatable :: pold(:)
    real(wp),allocatable :: dipd(:,:), dalphadr(:,:), dalphadq(:,:)
-   real(wp),allocatable :: amass(:)
+   real(wp),allocatable :: amass_au(:), amass_amu(:)
    real(wp) :: asq, gamsq
 
    type(TMolecule) :: tmol
@@ -127,9 +127,9 @@ subroutine numhess( &
    res%n3true = n3-3*freezeset%n
 
    allocate(hss(n3*(n3+1)/2),hsb(n3*(n3+1)/2),h(n3,n3),htb(n3,n3),hbias(n3,n3), &
-      & gl(3,mol%n),isqm(n3),xyzsave(3,mol%n),dipd(3,n3), &
+      & gl(3,mol%n),isqm(n3),xyzsave(3,mol%n),dipd(3,n3), amass_amu(n3), &
       & pold(n3),nb(20,mol%n),indx(mol%n),molvec(mol%n),bond(mol%n,mol%n), &
-      & freq_scal(n3),fc_tb(n3),fc_bias(n3),amass(n3), h_dummy(n3,n3), izero(n3))
+      & freq_scal(n3),fc_tb(n3),fc_bias(n3),amass_au(n3), h_dummy(n3,n3), izero(n3))
 
    if (set%elprop == p_elprop_alpha) then
       allocate(dalphadr(6,n3), source = 0.0_wp)
@@ -265,8 +265,8 @@ subroutine numhess( &
          ia = indx(a)
          do ic = 1, 3
             ii = (ia-1)*3+ic
-            isqm(ii)=1.0_wp/sqrt(atmass(ia))
-            amass(ii)=isqm(ii)/sqrt(amutoau)
+            amass_amu(ii)=1.0_wp/sqrt(atmass(ia))
+            amass_au(ii)=amass_amu(ii)/sqrt(amutoau)
          enddo
       enddo
       do a = 1, nonfrozh
@@ -314,8 +314,8 @@ subroutine numhess( &
       do ia = 1, mol%n
          do ic = 1, 3
             ii = (ia-1)*3+ic
-            isqm(ii)=1.0_wp/sqrt(atmass(ia))
-            amass(ii)=isqm(ii)/sqrt(amutoau)
+            amass_amu(ii)=1.0_wp/sqrt(atmass(ia))
+            amass_au(ii)=amass_amu(ii)/sqrt(amutoau)
         enddo
       enddo
    endif
@@ -372,7 +372,7 @@ subroutine numhess( &
    do i=1,n3
       do j=1,i
          k=k+1
-         res%hess(j,i)=hss(k)*isqm(i)*isqm(j)*scalh
+         res%hess(j,i)=hss(k)*amass_amu(i)*amass_amu(j)*scalh
          res%hess(i,j)=res%hess(j,i)
       enddo
    enddo
@@ -382,7 +382,7 @@ subroutine numhess( &
       do i=1,n3
          do j=1,i
             k=k+1
-            hbias(j,i)=hsb(k)*isqm(i)*isqm(j)*scalh
+            hbias(j,i)=hsb(k)*amass_amu(i)*amass_amu(j)*scalh
             hbias(i,j)=hbias(j,i)
          enddo
       enddo
@@ -488,17 +488,15 @@ subroutine numhess( &
    k=0
    do i=1,n3
       if(res%freq(i).lt.set%mode_vthr) res%lowmode=i
-      xsum=0
-      k=k+1
+      xsum = 0.0_wp
+      k = k + 1
       do ia=1,mol%n
          do ic=1,3
             ii = (ia-1)*3+ic
-            xsum=xsum+atmass(ia)*res%hess(ii,i)**2
-            !> %MM: CAUTION: Shouldn't this be "amass" instead of "atmass"? -> Would then be the reciprocal value
-            !>               of the mass and thus correspond to the definition in 2) below.
+            xsum = xsum + (amass_amu(ii))**2 * (res%hess(ii,i))**2
          enddo
       enddo
-      res%rmass(i)=xsum
+      res%rmass(i)= 1.0_wp / xsum
    enddo
 
    !--- IR intensity ---! (holds in a similar fashion also for Raman)
@@ -531,7 +529,7 @@ subroutine numhess( &
       do k = 1, 3
          sum2 = 0.0_wp
          do j = 1, n3
-            sum2 = sum2 + dipd(k,j)*(res%hess(j,i)*amass(j))
+            sum2 = sum2 + dipd(k,j)*(res%hess(j,i)*amass_au(j))
          end do
          trdip(k) = sum2
       end do
@@ -543,7 +541,7 @@ subroutine numhess( &
          do k = 1,6
             sum2 = 0.0_wp
             do j = 1, n3
-               sum2 = sum2 + (res%hess(j,i)*amass(j))*dalphadr(k,j)
+               sum2 = sum2 + (res%hess(j,i)*amass_au(j))*dalphadr(k,j)
             enddo
             dalphadq(k,i) = sum2
          enddo

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -398,8 +398,6 @@ subroutine numhess( &
       return
    end if
 
-   
-
    if (set%runtyp.eq.p_run_bhess) then
       call rescale_freq(n3,htb,res%hess,hbias,res%freq,fc_tb,fc_bias,freq_scal)
    else


### PR DESCRIPTION
- fix the calculation of the reduced mass to consistent with reference calculations in other implementations as well as DFT reference data (see issue #367)
- more consistent variable names to avoid exploiting variables for different purposes (`isqm` serves also as scratch variable in a later part of the code)
- closes #367
- took Psi4 implementation https://github.com/psi4/psi4/blob/0df59280773a86f7ae1f6cc577731074a0fbaad9/psi4/driver/qcdb/vib.py#L582 as reference and documentation from: https://gaussian.com/vib/

**Normalization** is a relatively straightforward process. Before it is printed out, each of the `3N` elements of `l_{\text{CART},k,i}` is scaled by the normalization factor `N_i` for that particular vibrational mode. The normalization is defined by:

$$
N_i = \sqrt{ \left( \sum_k \left[ l_{\text{CART},k,i} \right]^2 \right)^{-1} }, \quad k = 1 \dots 3N \quad \text{(Eq. 12)}
$$

**Reduced mass** $\mu_i$ for the vibrational mode is calculated similarly ($k = 1 \dots 3N$):

$$
\mu_i = \left( \sum_k \left[ l_{\text{CART},k,i} \right]^2 \right)^{-1}
= \left( \sum_k \left( \frac{l_{\text{MWC},k,i}}{\sqrt{m_k}} \right)^2 \right)^{-1}
= N_i^2 \quad \text{(Eq. 13)}
$$

Note that since $D$ is orthonormal, and we can (and do) choose $L$ to be orthonormal, then $l$ is orthonormal as well.

Since $$D^\top D = I$$ and $$L^\top L = I$$, it follows that $$I = (DL)^\top (DL) = L^\top D^\top D L = L^\top L = I $$