### PR TITLE
Increase maximum number of arguments for `rdblock`

### DIFF
--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -98,7 +98,7 @@ module xtb_setmod
 !  Let's choose something different from 42 that is not dividable by 10... ;)
 !  Happy debugging!
    integer,private,parameter :: p_str_length = 48
-   integer,private,parameter :: p_arg_length = 24
+   integer,private,parameter :: p_arg_length = 48
 
    public
 


### PR DESCRIPTION
Number of comma-separated values for, e.g., `$thermo` `temperatures` entries was limited to 24. Since this does not really affect the total `xtb` memory consumption, I'd just increase it to prevent issues like in #1158.

Fixes #1158.