### PR TITLE
Licen -> License

### DIFF
--- a/src/anharmlib.f90
+++ b/src/anharmlib.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 module xtb_anharmlib

--- a/src/broyden.f90
+++ b/src/broyden.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 ! Modified Boryden mixer according to

--- a/src/broyden.f90
+++ b/src/broyden.f90
@@ -28,8 +28,8 @@
 ! df = previous |dF>
 ! u = previous |u>
 ! a = a matrix
-! Note: The modified Broyden method works on the INPUT charges of the sc
-! the difference produced by the SCC step. Especially the INPUT charge o
+! Note: The modified Broyden method works on the INPUT charges of the scf iteration, and
+! the difference produced by the SCC step. Especially the INPUT charge of the previous
 ! iteration is needed, which is usually not stored!
 module xtb_broyden
 contains

--- a/src/constr.f90
+++ b/src/constr.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine constralltors(n,at,xyz)

--- a/src/eqrot.f90
+++ b/src/eqrot.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/src/fragment.f90
+++ b/src/fragment.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine mrec(molcount,xyz,cn,bond,nat,at,molvec)

--- a/src/geosum.f90
+++ b/src/geosum.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine geosum(n,ic,xyzin)

--- a/src/getname.f90
+++ b/src/getname.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 

--- a/src/ifind.f90
+++ b/src/ifind.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 integer function ifind(x,n,xx)

--- a/src/intmodes.f90
+++ b/src/intmodes.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 module xtb_intmodes

--- a/src/lindh.f90
+++ b/src/lindh.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine getvdwxy(rx,ry,rz, c66, s6,r0, vdw)

--- a/src/locmode.f90
+++ b/src/locmode.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/matinv.f90
+++ b/src/matinv.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine smatinv (a,ldm,n,d)

--- a/src/neighbor.f90
+++ b/src/neighbor.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 

--- a/src/onetri.f90
+++ b/src/onetri.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 module xtb_onetri
    use xtb_mctc_accuracy, only : wp

--- a/src/oniom.f90
+++ b/src/oniom.f90
@@ -11,7 +11,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !> Implementaion of the ONIOM method

--- a/src/pocketscan.f90
+++ b/src/pocketscan.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !******************************************

--- a/src/pocketscan.f90
+++ b/src/pocketscan.f90
@@ -61,7 +61,7 @@ subroutine pocketscan(n,at,xyz,nout)
       call ncoord_d3(n,at,coord,cn,500.0d0)
       dum=-1.0d0
       do i=1,n
-         if(abs(cn(i)-cn0(i)).gt.dum) dum=abs(cn(i)-cn0(i)) ! clash ch
+         if(abs(cn(i)-cn0(i)).gt.dum) dum=abs(cn(i)-cn0(i)) ! clash check
       enddo
       if(dum.gt.cthr) then
          ierr=ierr+1
@@ -94,7 +94,7 @@ subroutine pocketscan(n,at,xyz,nout)
       call ncoord_d3(n,at,coord,cn,500.0d0)
       dum=-1.0d0
       do i=1,n
-         if(abs(cn(i)-cn0(i)).gt.dum) dum=abs(cn(i)-cn0(i)) ! clash ch
+         if(abs(cn(i)-cn0(i)).gt.dum) dum=abs(cn(i)-cn0(i)) ! clash check
       enddo
       if(dum.gt.cthr) then
          ierr=ierr+1
@@ -143,8 +143,8 @@ subroutine pocketrotation(n,at,xyz,cma,trfm,ifrag,npath,xyzpath)
       if(splitlist(i).eq.ifrag) then
          turncrd0(1:3,i)=xyz(1:3,i)-cma(1:3) ! part that is rotated
       else
-         addcrd(1:3,i)=xyz(1:3,i)-cma(1:3) ! part that is fixed and si
-         ! cma is added here, simply to have a simpler addition later
+         addcrd(1:3,i)=xyz(1:3,i)-cma(1:3) ! part that is fixed and simply added to the zeros of turncrd to yield the new coord
+         ! cma is added here, simply to have a simpler addition later on
       endif
    enddo
    turncrd0=matmul(trfm,turncrd0)

--- a/src/printmold.f90
+++ b/src/printmold.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !cccccccccccccccccccccccccccccccc

--- a/src/printmold.f90
+++ b/src/printmold.f90
@@ -69,7 +69,7 @@ subroutine printmold(ncent,nmo,nbf,xyz,at,cmo,eval,occ,thr,basis)
    do i = 1,ncent
       atyp = toSymbol(at(i))
       z=at(i)
-      ! atom character, running number, nuclear charge, x,y,z coordin
+      ! atom character, running number, nuclear charge, x,y,z coordinates
       write (iwfn,'(a2,2i6,3E22.14)') &
          &   atyp,i,z,xyz(1,i),xyz(2,i),xyz(3,i)
    enddo
@@ -124,11 +124,11 @@ subroutine printmold(ncent,nmo,nbf,xyz,at,cmo,eval,occ,thr,basis)
       dum=0
       write(iwfn,*) eval(i)
       write(iwfn,'(A)',advance='no') 'Spin= '
-      write(iwfn,'(A)',advance='yes') 'Alpha' ! for now just conside
+      write(iwfn,'(A)',advance='yes') 'Alpha' ! for now just consider RHF case
       write(iwfn,'(A)',advance='no') 'Occup= '
       write(iwfn,'(F14.8)') occ(i)
       !now coefficients
-      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy
+      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy,xz,yz ; f: xxx, yyy, zzz, xxy, xxz, yyx, yyz, xzz, yzz, xyz
       do j=1,nbf
          write(iwfn,*) j,cmo(j,i)
       enddo
@@ -176,7 +176,7 @@ subroutine printumold(ncent,nmo,nbf,xyz,at,cmoa,cmob,evala,&
    do i = 1,ncent
       atyp = toSymbol(at(i))
       z=at(i)
-      ! atom character, running number, nuclear charge, x,y,z coordin
+      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy,xz,yz ; f: xxx, yyy, zzz, xxy, xxz, yyx, yyz, xzz, yzz, xyz
       write (iwfn,'(a2,2i6,3E22.14)') &
          &   atyp,i,z,xyz(1,i),xyz(2,i),xyz(3,i)
    enddo
@@ -233,7 +233,7 @@ subroutine printumold(ncent,nmo,nbf,xyz,at,cmoa,cmob,evala,&
       write(iwfn,'(A)',advance='no') 'Occup= '
       write(iwfn,'(F14.8)') occa(i)
       !now coefficients
-      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy
+      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy,xz,yz ; f: xxx, yyy, zzz, xxy, xxz, yyx, yyz, xzz, yzz, xyz
       do j=1,nbf
          write(iwfn,*) j,cmoa(j,i)
       enddo
@@ -249,7 +249,7 @@ subroutine printumold(ncent,nmo,nbf,xyz,at,cmoa,cmob,evala,&
       write(iwfn,'(A)',advance='no') 'Occup= '
       write(iwfn,'(F14.8)') occb(i)
       !now coefficients
-      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy
+      ! a notion: for l>0, the ordering is p: x,y,z ; d: xx,yy,zz,xy,xz,yz ; f: xxx, yyy, zzz, xxy, xxz, yyx, yyz, xzz, yzz, xyz
       do j=1,nbf
          write(iwfn,*) j,cmob(j,i)
       enddo
@@ -258,7 +258,7 @@ subroutine printumold(ncent,nmo,nbf,xyz,at,cmoa,cmob,evala,&
    call close_file(iwfn)
 end subroutine
 
-! this routine gives character s,p,d etc. if angular momentum is given a
+! this routine gives character s,p,d etc. if angular momentum is given as input (i.e., 0,1,2 etc.)
 subroutine ang2chr(iang,chr,skip)
    implicit none
    character*1, intent( out ) :: chr

--- a/src/prmat.f90
+++ b/src/prmat.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
       subroutine preig(io,occ,f,e,istart,norbs)

--- a/src/rabguess.f90
+++ b/src/rabguess.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/rabguess.f90
+++ b/src/rabguess.f90
@@ -40,9 +40,9 @@ subroutine rabguess(n,at,xyz,cn,dcn,nsrb,srblist,shift,rab,grab)
    real*8 ra,rb,k1,k2,den,ff,p(4,2)
 
    !     fitted on PBExa-3c geom set by SG, 9/2018
-   !     H B C N O F SI P S CL GE AS SE BR SN SB TE I together (and for glo
+   !     H B C N O F SI P S CL GE AS SE BR SN SB TE I together (and for glob par)
    !     and rest one element at a time, LN taken as av. of La and Hf
-   !     about 15-20 reference molecules per element (about 30-40 data poin
+   !     about 15-20 reference molecules per element (about 30-40 data points per fit
    !     parameter)
    ! electronegativity (started from Pauling values)
    ! base radius

--- a/src/rmrottr.f90
+++ b/src/rmrottr.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 

--- a/src/rmsd.f90
+++ b/src/rmsd.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/src/shiftlp.f90
+++ b/src/shiftlp.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 ! shift the LP=protonation position to an "empty" region

--- a/src/vertical.f90
+++ b/src/vertical.f90
@@ -11,7 +11,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 !-----------------------------------------------------------------------

--- a/src/wrmodef.f90
+++ b/src/wrmodef.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine wrmodef(typ,n,at,xyzin,wbo,rmass,freq,u,udum,vthr,linear)

--- a/src/zmatpr.f90
+++ b/src/zmatpr.f90
@@ -12,7 +12,7 @@
 ! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ! GNU Lesser General Public License for more details.
 !
-! You should have received a copy of the GNU Lesser General Public Licen
+! You should have received a copy of the GNU Lesser General Public License
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 subroutine zmatpr(nat,at,geo,na,nb,nc,molnum)


### PR DESCRIPTION
By some reason (most probably F77->F90 conversion), all lines were cut to 72 symbols, while some strings had more than 72 symbols. This patch fixes those lines.