### PR TITLE
Initialize default variable for avoiding extra comma in json

### DIFF
--- a/src/main/json.F90
+++ b/src/main/json.F90
@@ -193,6 +193,7 @@ contains
       character(len=*), parameter :: jfmta = '(3x,''"'',a,''": ['')'
       integer :: i, j
       logical :: first
+      first = .false.
       write (ijson, jfmta) 'bond orders'
       do i = 1, mol%n - 1
          do j = i, mol%n


### PR DESCRIPTION
Fixes #1274