### PR TITLE
Avoid spread intrinsic

### DIFF
--- a/src/coulomb/ewald.f90
+++ b/src/coulomb/ewald.f90
@@ -139,7 +139,9 @@ pure subroutine ewaldDerivPBC3D_alp(vec, gTrans, qpc, volume, alpha, scale, &
       arg = dot_product(rik,vec)
       dtmp = -sin(arg) * expterm
       dAmat = dAmat + rik*dtmp
-      dS = spread(rik,1,3)*spread(rik,2,3)
+      dS(:, 1) = rik(1) * rik
+      dS(:, 2) = rik(2) * rik
+      dS(:, 3) = rik(3) * rik
       sigma = sigma + expterm * cos(arg) * ( &
          & - unity * (1.0_wp + rik2*falp + rik2*fqpc) &
          & + (2.0_wp/rik2 + 0.5_wp/alpha**2 + 0.5_wp*fqpc) * dS)
@@ -194,7 +196,9 @@ pure subroutine ewaldDerivPBC3D(vec, gTrans, qpc, volume, alpha, scale, &
       arg = dot_product(rik,vec)
       dtmp = -sin(arg) * expterm
       dAmat = dAmat + rik*dtmp
-      dS = spread(rik,1,3)*spread(rik,2,3)
+      dS(:, 1) = rik(1) * rik
+      dS(:, 2) = rik(2) * rik
+      dS(:, 3) = rik(3) * rik
       sigma = sigma + 0.5_wp * expterm * cos(arg) * ( &
          & - unity * (1.0_wp + rik2*fqpc) &
          & + (2.0_wp/rik2 + 0.5_wp/alpha**2 + 0.5_wp*fqpc) * dS)

--- a/src/coulomb/gaussian.f90
+++ b/src/coulomb/gaussian.f90
@@ -432,7 +432,9 @@ subroutine getCoulombDerivsCluster(mol, itbl, rad, qvec, djdr, djdtr, djdL)
                gij = 1.0_wp/(rad(ish, iid)**2 + rad(jsh, jid)**2)
                g1 = erf(sqrt(gij*r2))/sqrt(r2)
                dG(:) = (2*sqrt(gij)*exp(-gij*r2)/sqrtpi - g1) * vec/r2
-               dS(:, :) = 0.5_wp * spread(dG, 1, 3) * spread(vec, 2, 3)
+               dS(:, 1) = 0.5_wp * dG(1) * vec
+               dS(:, 2) = 0.5_wp * dG(2) * vec
+               dS(:, 3) = 0.5_wp * dG(3) * vec
                djdr(:, iat, jj+jsh) = djdr(:, iat, jj+jsh) - dG*qvec(ii+ish)
                djdr(:, jat, ii+ish) = djdr(:, jat, ii+ish) + dG*qvec(jj+jsh)
                djdtr(:, jj+jsh) = djdtr(:, jj+jsh) + dG*qvec(ii+ish)
@@ -577,7 +579,9 @@ pure subroutine getRDeriv(vec, gij, rTrans, alpha, scale, dG, dS)
       dd = + 2*gij*exp(-gij**2*r1**2)/(sqrtpi*r1**2) - erf(gij*r1)/(r1**3) &
          & - 2*alpha*exp(-arg)/(sqrtpi*r1**2) + erf(alpha*r1)/(r1**3)
       dG = dG + rij*dd
-      dS = dS + 0.5_wp * dd*spread(rij, 1, 3)*spread(rij, 2, 3)
+      dS(:, 1) = dS(:, 1) + 0.5_wp * dd * rij(1) * rij
+      dS(:, 2) = dS(:, 2) + 0.5_wp * dd * rij(2) * rij
+      dS(:, 3) = dS(:, 3) + 0.5_wp * dd * rij(3) * rij
    enddo
    dG = dG * scale
    dS = dS * scale

--- a/src/coulomb/klopmanohno.f90
+++ b/src/coulomb/klopmanohno.f90
@@ -525,7 +525,9 @@ subroutine getCoulombDerivsCluster(mol, itbl, gamAverage, gExp, hardness, &
                gij = gamAverage(hardness(ish, iid), hardness(jsh, jid))
                g1 = 1.0_wp / (r1**gExp + gij**(-gExp))
                dG(:) = -vec*r1**(gExp-2.0_wp) * g1 * g1**(1.0_wp/gExp)
-               dS(:, :) = 0.5_wp * spread(dG, 1, 3) * spread(vec, 2, 3)
+               dS(:, 1) = 0.5_wp * dG(1) * vec
+               dS(:, 2) = 0.5_wp * dG(2) * vec
+               dS(:, 3) = 0.5_wp * dG(3) * vec
                djdr(:, iat, jj+jsh) = djdr(:, iat, jj+jsh) - dG*qvec(ii+ish)
                djdr(:, jat, ii+ish) = djdr(:, jat, ii+ish) + dG*qvec(jj+jsh)
                djdtr(:, jj+jsh) = djdtr(:, jj+jsh) + dG*qvec(ii+ish)
@@ -679,7 +681,9 @@ pure subroutine getRDeriv(vec, gij, gExp, rTrans, alpha, scale, dG, dS)
       dd = -r1**(gExp-2.0_wp) * g1 * g1**(1.0_wp/gExp) &
          & - 2*alpha*exp(-arg)/(sqrtpi*r1**2) + erf(alpha*r1)/(r1**3)
       dG = dG + rij*dd
-      dS = dS + 0.5_wp * dd*spread(rij, 1, 3)*spread(rij, 2, 3)
+      dS(:, 1) = dS(:, 1) + 0.5_wp * dd * rij(1) * rij
+      dS(:, 2) = dS(:, 2) + 0.5_wp * dd * rij(2) * rij
+      dS(:, 3) = dS(:, 3) + 0.5_wp * dd * rij(3) * rij
    enddo
    dG = dG * scale
    dS = dS * scale

--- a/src/disp/coordinationnumber.f90
+++ b/src/disp/coordinationnumber.f90
@@ -283,7 +283,9 @@ subroutine ncoordNeighs(mol, neighs, neighlist, kcn, cfunc, dfunc, enscale, &
          dcndr(:, iat, jat) = dcndr(:, iat, jat) + countd
          dcndr(:, jat, iat) = dcndr(:, jat, iat) - countd
 
-         stress = spread(countd, 1, 3) * spread(rij, 2, 3)
+         stress(:, 1) = countd(1) * rij
+         stress(:, 2) = countd(2) * rij
+         stress(:, 3) = countd(3) * rij
 
          dcndL(:, :, iat) = dcndL(:, :, iat) + stress
          if (iat /= jat) then
@@ -428,7 +430,9 @@ subroutine ncoordLatP(mol, trans, cutoff, kcn, cfunc, dfunc, enscale, &
             dcndr(:, iat, jat) = dcndr(:, iat, jat) + countd
             dcndr(:, jat, iat) = dcndr(:, jat, iat) - countd
 
-            stress = spread(countd, 1, 3) * spread(rij, 2, 3)
+            stress(:, 1) = countd(1) * rij
+            stress(:, 2) = countd(2) * rij
+            stress(:, 3) = countd(3) * rij
 
             dcndL(:, :, iat) = dcndL(:, :, iat) + stress
             if (iat /= jat) then

--- a/src/disp/dftd3.f90
+++ b/src/disp/dftd3.f90
@@ -323,7 +323,9 @@ subroutine disp_gradient_latp &
 
             dE = -c6(iat, jat)*disp * 0.5_wp
             dG = -c6(iat, jat)*ddisp*rij
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+            dS(:, 1) = 0.5_wp * dG(1) * rij
+            dS(:, 2) = 0.5_wp * dG(2) * rij
+            dS(:, 3) = 0.5_wp * dG(3) * rij
 
             energies(iat) = energies(iat) + dE
             dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -647,7 +649,9 @@ subroutine disp_gradient_neigh &
 
          dE = -c6(iat, jat)*disp * 0.5_wp
          dG = -c6(iat, jat)*ddisp*rij
-         dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+         dS(:, 1) = 0.5_wp * dG(1) * rij
+         dS(:, 2) = 0.5_wp * dG(2) * rij
+         dS(:, 3) = 0.5_wp * dG(3) * rij
 
          energies(iat) = energies(iat) + dE
          dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -841,8 +845,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    dG(:, 1) = -dGr * rij
-   dG(:, 2) = +dGr * rij 
-   dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3)
+   dG(:, 2) = +dGr * rij
+   dS(:, 1) = 0.5_wp * dGr * rij(1) * rij
+   dS(:, 2) = 0.5_wp * dGr * rij(2) * rij
+   dS(:, 3) = 0.5_wp * dGr * rij(3) * rij
 
    ! Derivative w.r.t. i-k distance
    dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
@@ -850,8 +856,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    dG(:, 1) = -dGr * rik + dG(:, 1)
-   dG(:, 3) = +dGr * rik 
-   dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS
+   dG(:, 3) = +dGr * rik
+   dS(:, 1) = 0.5_wp * dGr * rik(1) * rik + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rik(2) * rik + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rik(3) * rik + dS(:, 3)
 
    ! Derivative w.r.t. j-k distance
    dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
@@ -860,7 +868,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    dG(:, 2) = -dGr * rjk + dG(:, 2)
    dG(:, 3) = +dGr * rjk + dG(:, 3)
-   dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS
+   dS(:, 1) = 0.5_wp * dGr * rjk(1) * rjk + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rjk(2) * rjk + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rjk(3) * rjk + dS(:, 3)
 
    ! CN derivative
    dc9 = 0.5_wp*c9*(dc6ij/c6ij+dc6ik/c6ik)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -1428,7 +1428,9 @@ subroutine disp_gradient_neigh &
 
          dE = -c6(iat, jat)*disp * 0.5_wp
          dG = -c6(iat, jat)*ddisp*rij
-         dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+         dS(:, 1) = 0.5_wp * dG(1) * rij
+         dS(:, 2) = 0.5_wp * dG(2) * rij
+         dS(:, 3) = 0.5_wp * dG(3) * rij
 
          energies(iat) = energies(iat) + dE
          dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -1906,7 +1908,9 @@ subroutine disp_gradient_latp &
 
             dE = -c6(iat, jat)*disp * 0.5_wp
             dG = -c6(iat, jat)*ddisp*rij
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+            dS(:, 1) = 0.5_wp * dG(1) * rij
+            dS(:, 2) = 0.5_wp * dG(2) * rij
+            dS(:, 3) = 0.5_wp * dG(3) * rij
 
             energies(iat) = energies(iat) + dE
             dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -2275,8 +2279,8 @@ subroutine atm_gradient_latp_gpu &
    !   & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik)) / (rrr3*rrr2)
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    !dG(:, 1) = -dGr * rij
-   !dG(:, 2) = +dGr * rij 
-   !dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3)
+   !dG(:, 2) = +dGr * rij
+   !dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3) !< perf: do not use spread
 
    !! Derivative w.r.t. i-k distance
    !dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
@@ -2284,8 +2288,8 @@ subroutine atm_gradient_latp_gpu &
    !   & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij)) / (rrr3*rrr2)
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    !dG(:, 1) = -dGr * rik + dG(:, 1)
-   !dG(:, 3) = +dGr * rik 
-   !dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS
+   !dG(:, 3) = +dGr * rik
+   !dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS !< perf: do not use spread
 
    !! Derivative w.r.t. j-k distance
    !dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
@@ -2294,7 +2298,7 @@ subroutine atm_gradient_latp_gpu &
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    !dG(:, 2) = -dGr * rjk + dG(:, 2)
    !dG(:, 3) = +dGr * rjk + dG(:, 3)
-   !dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS
+   !dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS !< perf: do not use spread
 
    !! CN derivative
    !dc9 = 0.5_wp*c9*(dc6dcn(iat,jat)/c6ij+dc6dcn(iat,kat)/c6ik)
@@ -2386,8 +2390,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    dG(:, 1) = -dGr * rij
-   dG(:, 2) = +dGr * rij 
-   dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3)
+   dG(:, 2) = +dGr * rij
+   dS(:, 1) = 0.5_wp * dGr * rij(1) * rij
+   dS(:, 2) = 0.5_wp * dGr * rij(2) * rij
+   dS(:, 3) = 0.5_wp * dGr * rij(3) * rij
 
    ! Derivative w.r.t. i-k distance
    dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
@@ -2395,8 +2401,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    dG(:, 1) = -dGr * rik + dG(:, 1)
-   dG(:, 3) = +dGr * rik 
-   dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS
+   dG(:, 3) = +dGr * rik
+   dS(:, 1) = 0.5_wp * dGr * rik(1) * rik + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rik(2) * rik + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rik(3) * rik + dS(:, 3)
 
    ! Derivative w.r.t. j-k distance
    dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
@@ -2405,7 +2413,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    dG(:, 2) = -dGr * rjk + dG(:, 2)
    dG(:, 3) = +dGr * rjk + dG(:, 3)
-   dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS
+   dS(:, 1) = 0.5_wp * dGr * rjk(1) * rjk + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rjk(2) * rjk + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rjk(3) * rjk + dS(:, 3)
 
    ! CN derivative
    dc9 = 0.5_wp*c9*(dc6ij/c6ij+dc6ik/c6ik)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2280,7 +2280,7 @@ subroutine atm_gradient_latp_gpu &
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    !dG(:, 1) = -dGr * rij
    !dG(:, 2) = +dGr * rij
-   !dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3) !< perf: do not use spread
+   !dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3) !< GCC perf: do not use spread
 
    !! Derivative w.r.t. i-k distance
    !dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
@@ -2289,7 +2289,7 @@ subroutine atm_gradient_latp_gpu &
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    !dG(:, 1) = -dGr * rik + dG(:, 1)
    !dG(:, 3) = +dGr * rik
-   !dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS !< perf: do not use spread
+   !dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS !< GCC perf: do not use spread
 
    !! Derivative w.r.t. j-k distance
    !dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
@@ -2298,7 +2298,7 @@ subroutine atm_gradient_latp_gpu &
    !dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    !dG(:, 2) = -dGr * rjk + dG(:, 2)
    !dG(:, 3) = +dGr * rjk + dG(:, 3)
-   !dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS !< perf: do not use spread
+   !dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS !< GCC perf: do not use spread
 
    !! CN derivative
    !dc9 = 0.5_wp*c9*(dc6dcn(iat,jat)/c6ij+dc6dcn(iat,kat)/c6ik)

--- a/src/freq/project.f90
+++ b/src/freq/project.f90
@@ -105,8 +105,10 @@ subroutine projectHessian(hessian, mol, removeTrans, removeRot)
       do iat = 1, mol%n
          vec(:) = mol%xyz(:, iat) - center
          r2 = vec(1)**2 + vec(2)**2 + vec(3)**2
-         inertia(:, :) = inertia + mol%atmass(iat) &
-            & * (unity*r2 - spread(vec, 1, 3)*spread(vec, 2, 3))
+         inertia(:, :) = inertia + mol%atmass(iat) * unity * r2
+         inertia(:, 1) = inertia(:, 1) - mol%atmass(iat) * vec(1) * vec
+         inertia(:, 2) = inertia(:, 2) - mol%atmass(iat) * vec(2) * vec
+         inertia(:, 3) = inertia(:, 3) - mol%atmass(iat) * vec(3) * vec
       end do
 
       call eigvec3x3(inertia, moments, axes)

--- a/src/gfnff/gdisp0.f90
+++ b/src/gfnff/gdisp0.f90
@@ -325,7 +325,9 @@ subroutine d3_gradient(dispm, nat, at, xyz, npair, pairlist, zeta_scale, radii, 
 
       dE = -c6(iat, jat)*disp * 0.5_wp
       dG = -c6(iat, jat)*ddisp*rij
-      dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+      dS(:, 1) = 0.5_wp * dG(1) * rij
+      dS(:, 2) = 0.5_wp * dG(2) * rij
+      dS(:, 3) = 0.5_wp * dG(3) * rij
 
       energies(iat) = energies(iat) + dE
       dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -470,7 +472,9 @@ subroutine disp_gradient_latp &
 
             dE = -c6(iat, jat)*disp * 0.5_wp
             dG = -c6(iat, jat)*ddisp*rij
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+            dS(:, 1) = 0.5_wp * dG(1) * rij
+            dS(:, 2) = 0.5_wp * dG(2) * rij
+            dS(:, 3) = 0.5_wp * dG(3) * rij
 
             energies(iat) = energies(iat) + dE
             dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -555,7 +559,9 @@ subroutine disp_gradient_latp_inter &
 
             dE = -c6(iat, jat)*disp * 0.5_wp
             dG = -c6(iat, jat)*ddisp*rij
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+            dS(:, 1) = 0.5_wp * dG(1) * rij
+            dS(:, 2) = 0.5_wp * dG(2) * rij
+            dS(:, 3) = 0.5_wp * dG(3) * rij
 
             energies(iat) = energies(iat) + dE
             dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -640,7 +646,9 @@ subroutine disp_gradient_latp_intra &
 
             dE = -c6(iat, jat)*disp * 0.5_wp
             dG = -c6(iat, jat)*ddisp*rij
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+            dS(:, 1) = 0.5_wp * dG(1) * rij
+            dS(:, 2) = 0.5_wp * dG(2) * rij
+            dS(:, 3) = 0.5_wp * dG(3) * rij
 
             energies(iat) = energies(iat) + dE
             dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -974,7 +982,9 @@ subroutine disp_gradient_neigh &
 
          dE = -c6(iat, jat)*disp * 0.5_wp
          dG = -c6(iat, jat)*ddisp*rij
-         dS = spread(dG, 1, 3) * spread(rij, 2, 3) * 0.5_wp
+         dS(:, 1) = 0.5_wp * dG(1) * rij
+         dS(:, 2) = 0.5_wp * dG(2) * rij
+         dS(:, 3) = 0.5_wp * dG(3) * rij
 
          energies(iat) = energies(iat) + dE
          dEdcn(iat) = dEdcn(iat) - dc6dcn(iat, jat) * disp
@@ -1167,8 +1177,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    dG(:, 1) = -dGr * rij
-   dG(:, 2) = +dGr * rij 
-   dS(:, :) = 0.5_wp * dGr * spread(rij, 1, 3) * spread(rij, 2, 3)
+   dG(:, 2) = +dGr * rij
+   dS(:, 1) = 0.5_wp * dGr * rij(1) * rij
+   dS(:, 2) = 0.5_wp * dGr * rij(2) * rij
+   dS(:, 3) = 0.5_wp * dGr * rij(3) * rij
 
    ! Derivative w.r.t. i-k distance
    dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
@@ -1176,8 +1188,10 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
       & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij)) / (rrr3*rrr2)
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    dG(:, 1) = -dGr * rik + dG(:, 1)
-   dG(:, 3) = +dGr * rik 
-   dS(:, :) = 0.5_wp * dGr * spread(rik, 1, 3) * spread(rik, 2, 3) + dS
+   dG(:, 3) = +dGr * rik
+   dS(:, 1) = 0.5_wp * dGr * rik(1) * rik + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rik(2) * rik + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rik(3) * rik + dS(:, 3)
 
    ! Derivative w.r.t. j-k distance
    dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
@@ -1186,7 +1200,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    dG(:, 2) = -dGr * rjk + dG(:, 2)
    dG(:, 3) = +dGr * rjk + dG(:, 3)
-   dS(:, :) = 0.5_wp * dGr * spread(rjk, 1, 3) * spread(rjk, 2, 3) + dS
+   dS(:, 1) = 0.5_wp * dGr * rjk(1) * rjk + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr * rjk(2) * rjk + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr * rjk(3) * rjk + dS(:, 3)
 
    ! CN derivative
    dc9 = 0.5_wp*c9*(dc6ij/c6ij+dc6ik/c6ik)

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -383,7 +383,9 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
          t27=t26*(1.5d0*t8+1.0d0)/t19
          r3 =(xyz(:,iat)-xyz(:,jat)+neigh%transVec(:,iTr))*t27 
          vec = xyz(:,iat)-xyz(:,jat)+neigh%transVec(:,iTr)
-         sigma = sigma -(spread(r3, 1, 3)*spread(vec, 2, 3))
+         sigma(:,1) = sigma(:,1) - r3(1) * vec
+         sigma(:,2) = sigma(:,2) - r3(2) * vec
+         sigma(:,3) = sigma(:,3) - r3(3) * vec
          g(:,iat)=g(:,iat)-r3
          g(:,jat)=g(:,jat)+r3
        enddo
@@ -1000,7 +1002,9 @@ subroutine egbond(i,iat,jat,iTr,rab,rij,drij,drijdcn,n,at,xyz,e,g,sigma,neigh,ra
          g(2,iat)=g(2,iat)+t5
          g(3,iat)=g(3,iat)+t6
          dEdcn(iat) = dEdcn(iat) + yy*drijdcn(1)
-         sigma = sigma + spread(dg,1,3)*spread(vrab,2,3)
+         sigma(:,1) = sigma(:,1) + dg(1)*vrab
+         sigma(:,2) = sigma(:,2) + dg(2)*vrab
+         sigma(:,3) = sigma(:,3) + dg(3)*vrab
 
          t4=yy*(dx/rab)
          t5=yy*(dy/rab)
@@ -1017,7 +1021,9 @@ subroutine egbond(i,iat,jat,iTr,rab,rij,drij,drijdcn,n,at,xyz,e,g,sigma,neigh,ra
          do k=1,n !3B gradient 
             dg= drij(:,k)*yy
             g(:,k)=g(:,k)+dg
-            sigma = sigma + spread(dg,1,3)*spread(vrab,2,3)
+            sigma(:,1) = sigma(:,1) + dg(1)*vrab
+            sigma(:,2) = sigma(:,2) + dg(2)*vrab
+            sigma(:,3) = sigma(:,3) + dg(3)*vrab
          enddo
 
 end subroutine egbond
@@ -1094,7 +1100,9 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
          g(2,iat)=g(2,iat)+t5
          g(3,iat)=g(3,iat)+t6
          dEdcn(iat) = dEdcn(iat) + yy*drijdcn(1)
-         sigma = sigma + spread(dg,1,3)*spread(vrab,2,3)
+         sigma(:,1) = sigma(:,1) + dg(1)*vrab
+         sigma(:,2) = sigma(:,2) + dg(2)*vrab
+         sigma(:,3) = sigma(:,3) + dg(3)*vrab
 
          t4=yy*(dx/rab)
          t5=yy*(dy/rab)
@@ -1110,7 +1118,9 @@ subroutine egbond_hb(i,iat,jat,iTr,rab,rij,drij,drijdcn,hb_cn,hb_dcn,n,at,xyz,e,
          do k=1,n !3B gradient
             dg= drij(:,k)*yy
             g(:,k)=g(:,k)+dg
-            sigma = sigma + spread(dg,1,3)*spread(vrab,2,3)
+            sigma(:,1) = sigma(:,1) + dg(1)*vrab
+            sigma(:,2) = sigma(:,2) + dg(2)*vrab
+            sigma(:,3) = sigma(:,3) + dg(3)*vrab
          end do
 
          zz=dum*neigh%vbond(2,i)*dr**2*t1
@@ -1205,8 +1215,10 @@ subroutine dncoord_erf(nat,at,xyz,rcov,cn,dcn,thr,topo,neigh,dcndL)
          dcn(:,iat,jat)= dtmp*rij/r + dcn(:,iat,jat)
          dcn(:,jat,iat)=-dtmp*rij/r + dcn(:,jat,iat)
          dcn(:,iat,iat)=-dtmp*rij/r + dcn(:,iat,iat)
-        
-         stress = spread(dtmp*rij/r, 1, 3) * spread(rij, 2, 3)
+
+         stress(:, 1) = rij(1) * dtmp*rij/r
+         stress(:, 2) = rij(2) * dtmp*rij/r
+         stress(:, 3) = rij(3) * dtmp*rij/r
          dcndL(:, :, iat) = dcndL(:, :, iat) + stress
          if (iat.ne.jat.or.iTrH.ne.iTrB) then
            dcndL(:, :, jat) = dcndL(:, :, jat) + stress
@@ -3732,7 +3744,9 @@ subroutine ncoordNeighs(mol, neighs, neighlist, kcn, cfunc, dfunc, enscale, &
          dcndr(:, iat, jat) = dcndr(:, iat, jat) + countd
          dcndr(:, jat, iat) = dcndr(:, jat, iat) - countd
 
-         stress = spread(countd, 1, 3) * spread(rij, 2, 3)
+         stress(:, 1) = countd(1) * rij
+         stress(:, 2) = countd(2) * rij
+         stress(:, 3) = countd(3) * rij
 
          dcndL(:, :, iat) = dcndL(:, :, iat) + stress
          if (iat /= jat) then
@@ -3892,7 +3906,9 @@ subroutine ncoordLatP(mol, ntrans, trans, cutoff, kcn, cfunc, dfunc, enscale, &
             dcndr(:, iat, jat) = dcndr(:, iat, jat) + countd
             dcndr(:, jat, iat) = dcndr(:, jat, iat) - countd
 
-            stress = spread(countd, 1, 3) * spread(rij, 2, 3)
+            stress(:, 1) = countd(1) * rij
+            stress(:, 2) = countd(2) * rij
+            stress(:, 3) = countd(3) * rij
 
             dcndL(:, :, iat) = dcndL(:, :, iat) + stress
             if (iat.ne.jat.or.itr.ne.1) then
@@ -4433,7 +4449,9 @@ subroutine get_damat_dir_3d(rij, gam, alp, trans, dg, ds)
       gtmp = +2*gam*exp(-r2*gam2)/(sqrtpi*r2) - erf(r1*gam)/(r2*r1)
       atmp = -2*alp*exp(-r2*alp2)/(sqrtpi*r2) + erf(r1*alp)/(r2*r1)
       dg(:) = dg + (gtmp + atmp) * vec
-      ds(:, :) = ds + (gtmp + atmp) * spread(vec, 1, 3) * spread(vec, 2, 3)
+      ds(:, 1) = ds(:, 1) + (gtmp + atmp) * vec(1) * vec
+      ds(:, 2) = ds(:, 2) + (gtmp + atmp) * vec(2) * vec
+      ds(:, 3) = ds(:, 3) + (gtmp + atmp) * vec(3) * vec
    end do
 
 end subroutine get_damat_dir_3d
@@ -4465,8 +4483,12 @@ subroutine get_damat_rec_3d(rij, vol, alp, trans, dg, ds)
       etmp = fac * exp(-0.25_wp*g2/alp2)/g2
       dtmp = -sin(gv) * etmp
       dg(:) = dg + dtmp * vec
-      ds(:, :) = ds + etmp * cos(gv) &
-         & * ((2.0_wp/g2 + 0.5_wp/alp2) * spread(vec, 1, 3)*spread(vec, 2, 3) - unity)
+      ds(:, 1) = ds(:, 1) + etmp * cos(gv) &
+         & * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(1) * vec - unity(:,1))
+      ds(:, 2) = ds(:, 2) + etmp * cos(gv) &
+         & * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(2) * vec - unity(:,2))
+      ds(:, 3) = ds(:, 3) + etmp * cos(gv) &
+         & * ((2.0_wp/g2 + 0.5_wp/alp2) * vec(3) * vec - unity(:,3))
    end do
 
 end subroutine get_damat_rec_3d

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -2450,9 +2450,15 @@ subroutine abhgfnff_eg2new(n,A,B,H,iTrA,iTrB,nbb,at,xyz,q,sqrab, &
          gdr(1:3,A) = gdr(1:3,A) + ga(1:3)
          gdr(1:3,B) = gdr(1:3,B) + gb(1:3)
          gdr(1:3,H) = gdr(1:3,H) + gh(1:3)
-         sigma=sigma+mcf_ehb*spread(ga,1,3)*spread(xyz(:,A)+neigh%transVec(1:3,iTrA),2,3)
-         sigma=sigma+mcf_ehb*spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
-         sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
+         sigma(:,1)=sigma(:,1)+mcf_ehb*ga(1)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+         sigma(:,2)=sigma(:,2)+mcf_ehb*ga(2)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+         sigma(:,3)=sigma(:,3)+mcf_ehb*ga(3)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+         sigma(:,1)=sigma(:,1)+mcf_ehb*gb(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+         sigma(:,2)=sigma(:,2)+mcf_ehb*gb(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+         sigma(:,3)=sigma(:,3)+mcf_ehb*gb(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+         sigma(:,1)=sigma(:,1)+mcf_ehb*gh(1)* xyz(:,H)
+         sigma(:,2)=sigma(:,2)+mcf_ehb*gh(2)* xyz(:,H)
+         sigma(:,3)=sigma(:,3)+mcf_ehb*gh(3)* xyz(:,H)
          return
       endif
 
@@ -2468,14 +2474,22 @@ subroutine abhgfnff_eg2new(n,A,B,H,iTrA,iTrB,nbb,at,xyz,q,sqrab, &
       end do
 
       ! sigma according to gdr above
-      sigma=sigma+mcf_ehb*spread(ga,1,3)*spread(xyz(:,A)+neigh%transVec(1:3,iTrA),2,3)
-      sigma=sigma+mcf_ehb*spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*ga(1)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*ga(2)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*ga(3)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gb(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gb(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gb(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gh(1)* xyz(:,H)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gh(2)* xyz(:,H)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gh(3)* xyz(:,H)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
          call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          vecDum = neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
-         sigma=sigma+mcf_ehb*spread(gnb(:,i),1,3)*spread(xyz(:,inb)+vecDum,2,3)
+         sigma(:,1)=sigma(:,1)+mcf_ehb*gnb(1,i)*(xyz(:,inb)+vecDum)
+         sigma(:,2)=sigma(:,2)+mcf_ehb*gnb(2,i)*(xyz(:,inb)+vecDum)
+         sigma(:,3)=sigma(:,3)+mcf_ehb*gnb(3,i)*(xyz(:,inb)+vecDum)
       enddo
 
 end subroutine abhgfnff_eg2new

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -3091,10 +3091,18 @@ subroutine abhgfnff_eg3(n,A,B,H,iTrA,iTrB,C,iTrC,at,xyz,q,sqrab,srab,energy,&
       gdr(1:3,kk) = gdr(1:3,kk)+gangl(1:3,kk)*bterm
       gdr(1:3,ll) = gdr(1:3,ll)+gangl(1:3,ll)*bterm
       ! sigma
-      sigma=sigma+mcf_ehb*spread(ga,1,3)*spread(xyz(:,A)+neigh%transVec(1:3,iTrA),2,3)
-      sigma=sigma+mcf_ehb*spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
-      sigma=sigma+mcf_ehb*spread(gnb,1,3)*spread(xyz(:,C)+neigh%transVec(1:3,iTrC),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*ga(1)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*ga(2)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*ga(3)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gb(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gb(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gb(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gh(1)* xyz(:,H)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gh(2)* xyz(:,H)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gh(3)* xyz(:,H)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gnb(1)*(xyz(:,C)+neigh%transVec(1:3,iTrC))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gnb(2)*(xyz(:,C)+neigh%transVec(1:3,iTrC))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gnb(3)*(xyz(:,C)+neigh%transVec(1:3,iTrC))
       ! torsion part
       do i = 1,ntors
          ii =tlist(1,i)
@@ -3105,23 +3113,51 @@ subroutine abhgfnff_eg3(n,A,B,H,iTrA,iTrB,C,iTrC,at,xyz,q,sqrab,srab,energy,&
          if(iTrR.le.0.or.iTrR.gt.neigh%nTrans) then
            cycle
          endif
-         sigma=sigma+mcf_ehb*spread(gtors(1:3,ii)*tterm,1,3)* &        ! R
-                   & spread(xyz(1:3,ii)+neigh%transVec(1:3,iTrR),2,3)
+         sigma(:,1)=sigma(:,1)+mcf_ehb*tterm*gtors(1,ii)* &        ! R
+                   & (xyz(1:3,ii)+neigh%transVec(1:3,iTrR))
+         sigma(:,2)=sigma(:,2)+mcf_ehb*tterm*gtors(2,ii)* &        ! R
+                   & (xyz(1:3,ii)+neigh%transVec(1:3,iTrR))
+         sigma(:,3)=sigma(:,3)+mcf_ehb*tterm*gtors(3,ii)* &        ! R
+                   & (xyz(1:3,ii)+neigh%transVec(1:3,iTrR))
       end do
       ! jj, kk and ll same for every i in loop above (only ii or R changes)
-      sigma=sigma+mcf_ehb*spread(gtors(1:3,jj)*tterm,1,3)* &           ! B
-                & spread(xyz(:,jj)+neigh%transVec(:,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gtors(1:3,kk)*tterm,1,3)* &           ! C
-                & spread(xyz(:,kk)+neigh%transVec(:,iTrC),2,3)
-      sigma=sigma+mcf_ehb*spread(gtors(1:3,ll)*tterm,1,3)* &           ! H
-                & spread(xyz(:,ll),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*tterm*gtors(1,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*tterm*gtors(2,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*tterm*gtors(3,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*tterm*gtors(1,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*tterm*gtors(2,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*tterm*gtors(3,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*tterm*gtors(1,ll)* &           ! H
+                & xyz(:,ll)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*tterm*gtors(2,ll)* &           ! H
+                & xyz(:,ll)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*tterm*gtors(3,ll)* &           ! H
+                & xyz(:,ll)
       ! angle part
-      sigma=sigma+mcf_ehb*spread(gangl(1:3,jj)*bterm,1,3)* &           ! B
-                & spread(xyz(:,jj)+neigh%transVec(:,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gangl(1:3,kk)*bterm,1,3)* &           ! C
-                & spread(xyz(:,kk)+neigh%transVec(:,iTrC),2,3)
-      sigma=sigma+mcf_ehb*spread(gangl(1:3,ll)*bterm,1,3)* &           ! H
-                & spread(xyz(:,ll),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*bterm*gangl(1,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*bterm*gangl(2,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*bterm*gangl(3,jj)* &           ! B
+                & (xyz(:,jj)+neigh%transVec(:,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*bterm*gangl(1,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*bterm*gangl(2,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*bterm*gangl(3,kk)* &           ! C
+                & (xyz(:,kk)+neigh%transVec(:,iTrC))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*bterm*gangl(1,ll)* &           ! H
+                & xyz(:,ll)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*bterm*gangl(2,ll)* &           ! H
+                & xyz(:,ll)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*bterm*gangl(3,ll)* &           ! H
+                & xyz(:,ll)
 
 !------------------------------------------------------------------------------
 !     move gradients into place

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -3318,9 +3318,15 @@ subroutine rbxgfnff_eg(n,A,B,X,iTrB,iTrX,at,xyz,q,energy,gdr,param,neigh,sigma)
    gdr(1:3,2) = gb(1:3)
    gdr(1:3,3) = gx(1:3)
    ! sigma
-   sigma=sigma+spread(ga,1,3)*spread(xyz(:,A),2,3)
-   sigma=sigma+spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(:,iTrB),2,3)
-   sigma=sigma+spread(gx,1,3)*spread(xyz(:,X)+neigh%transVec(:,iTrX),2,3)
+   sigma(:,1)=sigma(:,1)+ga(1)*xyz(:,A)
+   sigma(:,2)=sigma(:,2)+ga(2)*xyz(:,A)
+   sigma(:,3)=sigma(:,3)+ga(3)*xyz(:,A)
+   sigma(:,1)=sigma(:,1)+gb(1)*(xyz(:,B)+neigh%transVec(:,iTrB))
+   sigma(:,2)=sigma(:,2)+gb(2)*(xyz(:,B)+neigh%transVec(:,iTrB))
+   sigma(:,3)=sigma(:,3)+gb(3)*(xyz(:,B)+neigh%transVec(:,iTrB))
+   sigma(:,1)=sigma(:,1)+gx(1)*(xyz(:,X)+neigh%transVec(:,iTrX))
+   sigma(:,2)=sigma(:,2)+gx(2)*(xyz(:,X)+neigh%transVec(:,iTrX))
+   sigma(:,3)=sigma(:,3)+gx(3)*(xyz(:,X)+neigh%transVec(:,iTrX))
 
    return
 

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -2777,13 +2777,14 @@ subroutine abhgfnff_eg2_rnr(n,A,B,H,iTrA,iTrB,at,xyz,q,sqrab,srab,energy,gdr,par
       sigma(:,1)=sigma(:,1)+mcf_ehb*gnb_lp(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
       sigma(:,2)=sigma(:,2)+mcf_ehb*gnb_lp(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
       sigma(:,3)=sigma(:,3)+mcf_ehb*gnb_lp(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      gnb_lp = gnb_lp / dble(nbb)
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
          call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          vTrinb=neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
-         sigma(:,1)=sigma(:,1)+mcf_ehb*(gnb(1,i)-gnb_lp(1)/dble(nbb))*(xyz(:,inb)+vTrinb)
-         sigma(:,2)=sigma(:,2)+mcf_ehb*(gnb(2,i)-gnb_lp(2)/dble(nbb))*(xyz(:,inb)+vTrinb)
-         sigma(:,3)=sigma(:,3)+mcf_ehb*(gnb(3,i)-gnb_lp(3)/dble(nbb))*(xyz(:,inb)+vTrinb)
+         sigma(:,1)=sigma(:,1)+mcf_ehb*(gnb(1,i)-gnb_lp(1))*(xyz(:,inb)+vTrinb)
+         sigma(:,2)=sigma(:,2)+mcf_ehb*(gnb(2,i)-gnb_lp(2))*(xyz(:,inb)+vTrinb)
+         sigma(:,3)=sigma(:,3)+mcf_ehb*(gnb(3,i)-gnb_lp(3))*(xyz(:,inb)+vTrinb)
       enddo
 
 end subroutine abhgfnff_eg2_rnr

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -2223,9 +2223,15 @@ subroutine abhgfnff_eg1(n,A,B,H,iTrA,iTrB,at,xyz,q,energy,gdr,param,topo,neigh,s
       dgh(1:3) = -dga(1:3)-dgb(1:3)
       gh(1:3) = gh(1:3) + dgh(1:3)
       ! sigma
-      sigma=sigma+mcf_ehb*spread(ga,1,3)*spread(xyz(:,A)+neigh%transVec(1:3,iTrA),2,3)
-      sigma=sigma+mcf_ehb*spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*ga(1)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*ga(2)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*ga(3)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gb(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gb(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gb(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gh(1)* xyz(:,H)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gh(2)* xyz(:,H)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gh(3)* xyz(:,H)
 !     move gradients into place
       gdr(1:3,1) = ga(1:3)
       gdr(1:3,2) = gb(1:3)

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -2765,16 +2765,25 @@ subroutine abhgfnff_eg2_rnr(n,A,B,H,iTrA,iTrB,at,xyz,q,sqrab,srab,energy,gdr,par
       end do
 
       ! sigma according to gdr above
-      sigma=sigma+mcf_ehb*spread(ga,1,3)*spread(xyz(:,A)+neigh%transVec(1:3,iTrA),2,3)
-      sigma=sigma+mcf_ehb*spread(gb,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
-      sigma=sigma+mcf_ehb*spread(gh,1,3)*spread(xyz(:,H),2,3)
-      sigma=sigma+mcf_ehb*spread(gnb_lp,1,3)*spread(xyz(:,B)+neigh%transVec(1:3,iTrB),2,3)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*ga(1)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*ga(2)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*ga(3)*(xyz(:,A)+neigh%transVec(1:3,iTrA))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gb(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gb(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gb(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gh(1)* xyz(:,H)
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gh(2)* xyz(:,H)
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gh(3)* xyz(:,H)
+      sigma(:,1)=sigma(:,1)+mcf_ehb*gnb_lp(1)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,2)=sigma(:,2)+mcf_ehb*gnb_lp(2)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
+      sigma(:,3)=sigma(:,3)+mcf_ehb*gnb_lp(3)*(xyz(:,B)+neigh%transVec(1:3,iTrB))
       do i=1,nbb
          inb=0; iTr=0 ! jth_nb output
          call neigh%jth_nb(n,xyz,inb,i,B,iTr) ! inb is the i-th nb of B when shifted to iTr
          vTrinb=neigh%transVec(:,iTr)+neigh%transVec(:,iTrB)
-         sigma=sigma+mcf_ehb*spread(gnb(:,i),1,3)*spread(xyz(:,inb)+vTrinb,2,3)
-         sigma=sigma-mcf_ehb*spread(gnb_lp(1:3)/dble(nbb),1,3)*spread(xyz(:,inb)+vTrinb,2,3)
+         sigma(:,1)=sigma(:,1)+mcf_ehb*(gnb(1,i)-gnb_lp(1)/dble(nbb))*(xyz(:,inb)+vTrinb)
+         sigma(:,2)=sigma(:,2)+mcf_ehb*(gnb(2,i)-gnb_lp(2)/dble(nbb))*(xyz(:,inb)+vTrinb)
+         sigma(:,3)=sigma(:,3)+mcf_ehb*(gnb(3,i)-gnb_lp(3)/dble(nbb))*(xyz(:,inb)+vTrinb)
       enddo
 
 end subroutine abhgfnff_eg2_rnr

--- a/src/peeq_module.f90
+++ b/src/peeq_module.f90
@@ -773,11 +773,13 @@ subroutine dsrb_grad(mol,srb,cn,dcndr,dcndL,trans,esrb,gradient,sigma)
          ! save SRB energy
          esrb = esrb + expterm * w
          dtmp = 2.0_wp*pre*dr*expterm * w
-         gradient(:,iat) = gradient(:,iat) - dtmp*rij/rab
-         gradient(:,jat) = gradient(:,jat) + dtmp*rij/rab
+         gradient(:,iat) = gradient(:,iat) - dtmp/rab * rij
+         gradient(:,jat) = gradient(:,jat) + dtmp/rab * rij
          ! three body gradient
          dEdr0(i) = dEdr0(i) + dtmp
-         sigma = sigma - dtmp*spread(rij, 1, 3)*spread(rij, 2, 3)/rab
+         sigma(:, 1) = sigma(:, 1) - dtmp/rab * rij(1) * rij
+         sigma(:, 2) = sigma(:, 2) - dtmp/rab * rij(2) * rij
+         sigma(:, 3) = sigma(:, 3) - dtmp/rab * rij(3) * rij
       enddo ! rep
    enddo ! i
 

--- a/src/solv/gbsa.f90
+++ b/src/solv/gbsa.f90
@@ -694,8 +694,10 @@ subroutine getADet(nAtom, xyz, rad, aDet)
       rad3 = rad2 * rad(iat)
       vec(:) = xyz(:, iat) - center
       r2 = sum(vec**2)
-      inertia(:, :) = inertia + rad3 * ((r2 + tof*rad2) * unity &
-         & - spread(vec, 1, 3) * spread(vec, 2, 3))
+      inertia(:, :) = inertia + rad3 * (r2 + tof*rad2) * unity
+      inertia(:, 1) = inertia(:, 1) - rad3 * vec(1) * vec
+      inertia(:, 2) = inertia(:, 2) - rad3 * vec(2) * vec
+      inertia(:, 3) = inertia(:, 3) - rad3 * vec(3) * vec
    end do
 
    aDet = sqrt(matDet3x3(inertia)**(1.0_wp/3.0_wp)/(tof*totRad3))
@@ -745,8 +747,10 @@ subroutine addADetDeriv(nAtom, xyz, rad, kEps, qvec, gradient)
       rad3 = rad2 * rad(iat)
       vec(:) = xyz(:, iat) - center
       r2 = sum(vec**2)
-      inertia(:, :) = inertia + rad3 * ((r2 + tof*rad2) * unity &
-         & - spread(vec, 1, 3) * spread(vec, 2, 3))
+      inertia(:, :) = inertia + rad3 * (r2 + tof*rad2) * unity
+      inertia(:, 1) = inertia(:, 1) - rad3 * vec(1) * vec
+      inertia(:, 2) = inertia(:, 2) - rad3 * vec(2) * vec
+      inertia(:, 3) = inertia(:, 3) - rad3 * vec(3) * vec
    end do
    aDet = sqrt(matDet3x3(inertia)**(1.0_wp/3.0_wp)/(tof*totRad3))
 

--- a/src/type/coulomb.f90
+++ b/src/type/coulomb.f90
@@ -562,7 +562,9 @@ subroutine getCoulombDerivsCluster(mol, itbl, qvec, djdr, djdtr, djdL)
          vec(:) = mol%xyz(:, jat) - mol%xyz(:, iat)
          r1 = norm2(vec)
          dG(:) = -vec/r1**3
-         dS(:, :) = 0.5_wp * spread(dG, 1, 3) * spread(vec, 2, 3)
+         dS(:, 1) = 0.5_wp * dG(1) * vec
+         dS(:, 2) = 0.5_wp * dG(2) * vec
+         dS(:, 3) = 0.5_wp * dG(3) * vec
          do ish = 1, itbl(2, iat)
             do jsh = 1, itbl(2, jat)
                djdr(:, iat, jj+jsh) = djdr(:, iat, jj+jsh) - dG*qvec(ii+ish)
@@ -689,7 +691,9 @@ pure subroutine getRDeriv(vec, rTrans, alpha, scale, dG, dS)
       arg = alpha**2*r1**2
       dd = - 2*alpha*exp(-arg)/(sqrtpi*r1**2) - erfc(alpha*r1)/(r1**3)
       dG = dG + rij*dd
-      dS = dS + 0.5_wp*dd*spread(rij, 1, 3)*spread(rij, 2, 3)
+      dS(:, 1) = dS(:, 1) + 0.5_wp*dd * rij(1) * rij
+      dS(:, 2) = dS(:, 2) + 0.5_wp*dd * rij(2) * rij
+      dS(:, 3) = dS(:, 3) + 0.5_wp*dd * rij(3) * rij
    enddo
    dG = dG * scale
    dS = dS * scale

--- a/src/xtb/hamiltonian.f90
+++ b/src/xtb/hamiltonian.f90
@@ -541,7 +541,9 @@ subroutine build_dSDQH0(nShell, hData, selfEnergy, dSEdcn, intcut, nat, nao, nbf
                   enddo
                   g(:,iat) = g(:,iat)+g_xyz
                   g(:,jat) = g(:,jat)-g_xyz
-                  sigma(:, :) = sigma + spread(g_xyz, 1, 3) * spread(rij, 2, 3)
+                  sigma(:, 1) = sigma(:, 1) + g_xyz(1) * rij
+                  sigma(:, 2) = sigma(:, 2) + g_xyz(2) * rij
+                  sigma(:, 3) = sigma(:, 3) + g_xyz(3) * rij
                enddo ! lattice translations
             enddo ! jsh : loop over shells on jat
          enddo  ! ish : loop over shells on iat
@@ -732,7 +734,9 @@ subroutine build_dSDQH0_noreset(nShell, hData, selfEnergy, dSEdcn, intcut, &
                dhdcn(jat) = dhdcn(jat) + dCN*dSEdcn(jsh, jat)
                g(:,iat) = g(:,iat)+g_xyz
                g(:,jat) = g(:,jat)-g_xyz
-               sigma(:, :) = sigma + spread(g_xyz, 1, 3) * spread(rij, 2, 3)
+               sigma(:, 1) = sigma(:, 1) + g_xyz(1) * rij
+               sigma(:, 2) = sigma(:, 2) + g_xyz(2) * rij
+               sigma(:, 3) = sigma(:, 3) + g_xyz(3) * rij
             enddo ! jsh : loop over shells on jat
          enddo  ! ish : loop over shells on iat
       enddo ! jat

--- a/src/xtb/repulsion.F90
+++ b/src/xtb/repulsion.F90
@@ -112,7 +112,9 @@ subroutine repulsionEnGrad_latp(mol, repData, trans, cutoff, energy, gradient, &
             t27 = r1**repData%rExp
             dE = zeff * t26/t27
             dG = -(alpha*t16*kExp + repData%rExp) * dE * rij/r2
-            dS = spread(dG, 1, 3) * spread(rij, 2, 3)
+            dS(:, 1) = dG(1) * rij
+            dS(:, 2) = dG(2) * rij
+            dS(:, 3) = dG(3) * rij
             !$acc atomic
             energies(iAt) = energies(iAt) + 0.5_wp * dE
             if (iAt /= jAt) then
@@ -216,7 +218,9 @@ subroutine repulsionEnGrad_neighs(mol, repData, neighs, neighList, energy, &
          t27 = r1**repData%rExp
          dE = zeff * t26/t27
          dG = -(alpha*t16*kExp + repData%rExp) * dE * rij/r2
-         dS = spread(dG, 1, 3) * spread(rij, 2, 3)
+         dS(:, 1) = dG(1) * rij
+         dS(:, 2) = dG(2) * rij
+         dS(:, 3) = dG(3) * rij
          energies(iAt) = energies(iAt) + 0.5_wp * dE
          sigma = sigma + 0.5_wp * dS
          if (iAt /= jAt) then


### PR DESCRIPTION
With gfortran, spread intrinsic is not optimized (more precisely this is libgfortran call) and therefore it significantly affects on performance, especially for 3-body terms. 

This patch speeds up gradient code in 1.5-2x times with gfortran as well other parts which I did not measure. By some reason, it also affects ifx but it gives only 10% speed up for `deriv_atm_triple` subroutine. 

I have used unrolled cycles since they provide an extra optimizations for ifx: time was improved from 680 to 625 ms for my input. Usual cycles does not give this improvement: see the assembler difference here: https://godbolt.org/z/zs6e7vzT4. The first source code is the original, the second is presented in this PR and the third one uses cycles. 

I did not touched initializations/io parts where spread are used.

 