### PR TITLE
Update `deriv_atm_triple` subroutine

### DIFF
--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2402,19 +2402,20 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dGr(3) = (-dang(3)*c9*fdmp + dfdmp*c9*ang)/r2jk
 
    dG(:, 1) = -dGr(1) * rij
+   dG(:, 1) = -dGr(2) * rik + dG(:, 1)
    dG(:, 2) = +dGr(1) * rij
+   dG(:, 2) = -dGr(3) * rjk + dG(:, 2)
+   dG(:, 3) = +dGr(2) * rik
+   dG(:, 3) = +dGr(3) * rjk + dG(:, 3)
+
    dS(:, 1) = dGr(1) * rij(1) * rij
    dS(:, 2) = dGr(1) * rij(2) * rij
    dS(:, 3) = dGr(1) * rij(3) * rij
 
-   dG(:, 1) = -dGr(2) * rik + dG(:, 1)
-   dG(:, 3) = +dGr(2) * rik
    dS(:, 1) = dGr(2) * rik(1) * rik + dS(:, 1)
    dS(:, 2) = dGr(2) * rik(2) * rik + dS(:, 2)
    dS(:, 3) = dGr(2) * rik(3) * rik + dS(:, 3)
 
-   dG(:, 2) = -dGr(3) * rjk + dG(:, 2)
-   dG(:, 3) = +dGr(3) * rjk + dG(:, 3)
    dS(:, 1) = dGr(3) * rjk(1) * rjk + dS(:, 1)
    dS(:, 2) = dGr(3) * rjk(2) * rjk + dS(:, 2)
    dS(:, 3) = dGr(3) * rjk(3) * rjk + dS(:, 3)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2364,7 +2364,7 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    integer, intent(in) :: alp
    real(wp), intent(out) :: dE, dG(3, 3), dS(3, 3), dCN(3)
 
-   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang, dang, fdmp, dfdmp, dGr, cralp
+   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang_fact, ang, dang, fdmp, dfdmp, dGr, cralp
 
    c9 = -sqrt(c6ij*c6ik*c6jk)
 
@@ -2374,8 +2374,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    rrr1 = sqrt(rrr2)
    rrr3 = rrr1*rrr2
 
-   ang = 0.375_wp * (r2ij+r2jk-r2ik)*(r2ij-r2jk+r2ik)*(-r2ij+r2jk+r2ik) &
-      & / (rrr3*rrr2) + 1.0_wp/(rrr3)
+   ang_fact = 0.375_wp / (rrr2*rrr3)
+   ang = ang_fact * (r2ij+r2jk-r2ik)*(r2ij-r2jk+r2ik)*(-r2ij+r2jk+r2ik) &
+      & + 1.0_wp/(rrr3)
 
    cralp = (ccc1/rrr1)**(real(alp, kind=wp)/3.0_wp)
    fdmp = 1.0_wp/(1.0_wp + 6.0_wp*cralp)
@@ -2385,9 +2386,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dE = -fdmp*ang*c9
 
    ! Derivative w.r.t. i-j distance
-   dang = -0.375_wp*(r2ij**3+r2ij**2*(r2jk+r2ik) &
+   dang = -ang_fact*(r2ij**3+r2ij**2*(r2jk+r2ik) &
       & +r2ij*(3.0_wp*r2jk**2+2.0_wp*r2jk*r2ik+3.0_wp*r2ik**2) &
-      & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik)) / (rrr3*rrr2)
+      & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik))
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
    dG(:, 1) = -dGr * rij
    dG(:, 2) = +dGr * rij
@@ -2396,9 +2397,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dS(:, 3) = 0.5_wp * dGr * rij(3) * rij
 
    ! Derivative w.r.t. i-k distance
-   dang = -0.375_wp*(r2ik**3+r2ik**2*(r2jk+r2ij) &
+   dang = -ang_fact*(r2ik**3+r2ik**2*(r2jk+r2ij) &
       & +r2ik*(3.0_wp*r2jk**2+2.0*r2jk*r2ij+3.0_wp*r2ij**2) &
-      & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij)) / (rrr3*rrr2)
+      & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij))
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    dG(:, 1) = -dGr * rik + dG(:, 1)
    dG(:, 3) = +dGr * rik
@@ -2407,9 +2408,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dS(:, 3) = 0.5_wp * dGr * rik(3) * rik + dS(:, 3)
 
    ! Derivative w.r.t. j-k distance
-   dang=-0.375_wp*(r2jk**3+r2jk**2*(r2ik+r2ij) &
+   dang= -ang_fact*(r2jk**3+r2jk**2*(r2ik+r2ij) &
       & +r2jk*(3.0_wp*r2ik**2+2.0_wp*r2ik*r2ij+3.0_wp*r2ij**2) &
-      & -5.0_wp*(r2ik-r2ij)**2*(r2ik+r2ij)) / (rrr3*rrr2)
+      & -5.0_wp*(r2ik-r2ij)**2*(r2ik+r2ij))
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
    dG(:, 2) = -dGr * rjk + dG(:, 2)
    dG(:, 3) = +dGr * rjk + dG(:, 3)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2364,7 +2364,7 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    integer, intent(in) :: alp
    real(wp), intent(out) :: dE, dG(3, 3), dS(3, 3), dCN(3)
 
-   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang, dang, fdmp, dfdmp, dGr, cr
+   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang, dang, fdmp, dfdmp, dGr, cralp
 
    c9 = -sqrt(c6ij*c6ik*c6jk)
 
@@ -2377,9 +2377,9 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    ang = 0.375_wp * (r2ij+r2jk-r2ik)*(r2ij-r2jk+r2ik)*(-r2ij+r2jk+r2ik) &
       & / (rrr3*rrr2) + 1.0_wp/(rrr3)
 
-   cr = (ccc1/rrr1)**(1.0_wp/3.0_wp)
-   fdmp = 1.0_wp/(1.0_wp + 6.0_wp*cr**alp)
-   dfdmp = -(2.0_wp*alp*cr**alp) * fdmp**2
+   cralp = (ccc1/rrr1)**(real(alp, kind=wp)/3.0_wp)
+   fdmp = 1.0_wp/(1.0_wp + 6.0_wp*cralp)
+   dfdmp = -(2.0_wp*alp*cralp) * fdmp**2
 
    ! Energy contribution
    dE = -fdmp*ang*c9

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2364,7 +2364,7 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    integer, intent(in) :: alp
    real(wp), intent(out) :: dE, dG(3, 3), dS(3, 3), dCN(3)
 
-   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang_fact, ang, dang, fdmp, dfdmp, dGr, cralp
+   real(wp) :: c9, dc9, ccc1, rrr1, rrr2, rrr3, ang_fact, ang, dang(3), fdmp, dfdmp, dGr(3), cralp
 
    c9 = -sqrt(c6ij*c6ik*c6jk)
 
@@ -2386,37 +2386,38 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
    dE = -fdmp*ang*c9
 
    ! Derivative w.r.t. i-j distance
-   dang = -ang_fact*(r2ij**3+r2ij**2*(r2jk+r2ik) &
+   dang(1) = -ang_fact*(r2ij**3+r2ij**2*(r2jk+r2ik) &
       & +r2ij*(3.0_wp*r2jk**2+2.0_wp*r2jk*r2ik+3.0_wp*r2ik**2) &
       & -5.0_wp*(r2jk-r2ik)**2*(r2jk+r2ik))
-   dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ij
-   dG(:, 1) = -dGr * rij
-   dG(:, 2) = +dGr * rij
-   dS(:, 1) = 0.5_wp * dGr * rij(1) * rij
-   dS(:, 2) = 0.5_wp * dGr * rij(2) * rij
-   dS(:, 3) = 0.5_wp * dGr * rij(3) * rij
-
+   dGr(1) = (-dang(1)*c9*fdmp + dfdmp*c9*ang)/r2ij
    ! Derivative w.r.t. i-k distance
-   dang = -ang_fact*(r2ik**3+r2ik**2*(r2jk+r2ij) &
+   dang(2) = -ang_fact*(r2ik**3+r2ik**2*(r2jk+r2ij) &
       & +r2ik*(3.0_wp*r2jk**2+2.0_wp*r2jk*r2ij+3.0_wp*r2ij**2) &
       & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij))
-   dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
-   dG(:, 1) = -dGr * rik + dG(:, 1)
-   dG(:, 3) = +dGr * rik
-   dS(:, 1) = 0.5_wp * dGr * rik(1) * rik + dS(:, 1)
-   dS(:, 2) = 0.5_wp * dGr * rik(2) * rik + dS(:, 2)
-   dS(:, 3) = 0.5_wp * dGr * rik(3) * rik + dS(:, 3)
-
+   dGr(2) = (-dang(2)*c9*fdmp + dfdmp*c9*ang)/r2ik
    ! Derivative w.r.t. j-k distance
-   dang= -ang_fact*(r2jk**3+r2jk**2*(r2ik+r2ij) &
+   dang(3)= -ang_fact*(r2jk**3+r2jk**2*(r2ik+r2ij) &
       & +r2jk*(3.0_wp*r2ik**2+2.0_wp*r2ik*r2ij+3.0_wp*r2ij**2) &
       & -5.0_wp*(r2ik-r2ij)**2*(r2ik+r2ij))
-   dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2jk
-   dG(:, 2) = -dGr * rjk + dG(:, 2)
-   dG(:, 3) = +dGr * rjk + dG(:, 3)
-   dS(:, 1) = 0.5_wp * dGr * rjk(1) * rjk + dS(:, 1)
-   dS(:, 2) = 0.5_wp * dGr * rjk(2) * rjk + dS(:, 2)
-   dS(:, 3) = 0.5_wp * dGr * rjk(3) * rjk + dS(:, 3)
+   dGr(3) = (-dang(3)*c9*fdmp + dfdmp*c9*ang)/r2jk
+
+   dG(:, 1) = -dGr(1) * rij
+   dG(:, 2) = +dGr(1) * rij
+   dS(:, 1) = 0.5_wp * dGr(1) * rij(1) * rij
+   dS(:, 2) = 0.5_wp * dGr(1) * rij(2) * rij
+   dS(:, 3) = 0.5_wp * dGr(1) * rij(3) * rij
+
+   dG(:, 1) = -dGr(2) * rik + dG(:, 1)
+   dG(:, 3) = +dGr(2) * rik
+   dS(:, 1) = 0.5_wp * dGr(2) * rik(1) * rik + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr(2) * rik(2) * rik + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr(2) * rik(3) * rik + dS(:, 3)
+
+   dG(:, 2) = -dGr(3) * rjk + dG(:, 2)
+   dG(:, 3) = +dGr(3) * rjk + dG(:, 3)
+   dS(:, 1) = 0.5_wp * dGr(3) * rjk(1) * rjk + dS(:, 1)
+   dS(:, 2) = 0.5_wp * dGr(3) * rjk(2) * rjk + dS(:, 2)
+   dS(:, 3) = 0.5_wp * dGr(3) * rjk(3) * rjk + dS(:, 3)
 
    ! CN derivative
    dc9 = 0.5_wp*c9*(dc6ij/c6ij+dc6ik/c6ik)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2403,21 +2403,23 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
 
    dG(:, 1) = -dGr(1) * rij
    dG(:, 2) = +dGr(1) * rij
-   dS(:, 1) = 0.5_wp * dGr(1) * rij(1) * rij
-   dS(:, 2) = 0.5_wp * dGr(1) * rij(2) * rij
-   dS(:, 3) = 0.5_wp * dGr(1) * rij(3) * rij
+   dS(:, 1) = dGr(1) * rij(1) * rij
+   dS(:, 2) = dGr(1) * rij(2) * rij
+   dS(:, 3) = dGr(1) * rij(3) * rij
 
    dG(:, 1) = -dGr(2) * rik + dG(:, 1)
    dG(:, 3) = +dGr(2) * rik
-   dS(:, 1) = 0.5_wp * dGr(2) * rik(1) * rik + dS(:, 1)
-   dS(:, 2) = 0.5_wp * dGr(2) * rik(2) * rik + dS(:, 2)
-   dS(:, 3) = 0.5_wp * dGr(2) * rik(3) * rik + dS(:, 3)
+   dS(:, 1) = dGr(2) * rik(1) * rik + dS(:, 1)
+   dS(:, 2) = dGr(2) * rik(2) * rik + dS(:, 2)
+   dS(:, 3) = dGr(2) * rik(3) * rik + dS(:, 3)
 
    dG(:, 2) = -dGr(3) * rjk + dG(:, 2)
    dG(:, 3) = +dGr(3) * rjk + dG(:, 3)
-   dS(:, 1) = 0.5_wp * dGr(3) * rjk(1) * rjk + dS(:, 1)
-   dS(:, 2) = 0.5_wp * dGr(3) * rjk(2) * rjk + dS(:, 2)
-   dS(:, 3) = 0.5_wp * dGr(3) * rjk(3) * rjk + dS(:, 3)
+   dS(:, 1) = dGr(3) * rjk(1) * rjk + dS(:, 1)
+   dS(:, 2) = dGr(3) * rjk(2) * rjk + dS(:, 2)
+   dS(:, 3) = dGr(3) * rjk(3) * rjk + dS(:, 3)
+
+   dS = 0.5_wp * dS
 
    ! CN derivative
    dc9 = 0.5_wp*c9*(dc6ij/c6ij+dc6ik/c6ik)

--- a/src/disp/dftd4.F90
+++ b/src/disp/dftd4.F90
@@ -2398,7 +2398,7 @@ pure subroutine deriv_atm_triple(c6ij, c6ik, c6jk, cij, cjk, cik, &
 
    ! Derivative w.r.t. i-k distance
    dang = -ang_fact*(r2ik**3+r2ik**2*(r2jk+r2ij) &
-      & +r2ik*(3.0_wp*r2jk**2+2.0*r2jk*r2ij+3.0_wp*r2ij**2) &
+      & +r2ik*(3.0_wp*r2jk**2+2.0_wp*r2jk*r2ij+3.0_wp*r2ij**2) &
       & -5.0_wp*(r2jk-r2ij)**2*(r2jk+r2ij))
    dGr = (-dang*c9*fdmp + dfdmp*c9*ang)/r2ik
    dG(:, 1) = -dGr * rik + dG(:, 1)


### PR DESCRIPTION
This patch speeds up `deriv_atm_triple` from 360 CPU cycles to 160 CPU cycles on x86-64-v3 Arch with GCC 14.2. This routine takes about half of time for gradient evaluation for medium size molecules. Intel compiler is also affected with close impact.