### PR TITLE
Avoid some heavy instructions in xtb/hamiltonian

### DIFF
--- a/src/grad_core.f90
+++ b/src/grad_core.f90
@@ -44,10 +44,9 @@ pure subroutine dshellPoly(iPoly,jPoly,iRad,jRad,rab2,xyz1,xyz2,rf,dxyz)
    real(wp), intent(in)  :: rab2
    real(wp), intent(out) :: dxyz(3),rf
    real(wp), intent(in)  :: xyz1(3),xyz2(3)
-   real(wp) :: rab,k1,k2,rr,r,a,dum,rf1,rf2,dx,dy,dz
-   real(wp) :: t14,t15,t17,t22,t20,t23,t10,t11,t35,t13
-
-   a=0.5            ! R^a dependence 0.5 in GFN1
+   real(wp) :: rab,k1,k2,rr,r,dum,rf1,rf2,dx,dy,dz
+   real(wp) :: t14,t15,t17,t20,t23,t10,t11,t35,t13
+   real(wp), parameter :: a = 0.5_wp
 
    dx=xyz1(1)-xyz2(1)
    dy=xyz1(2)-xyz2(2)
@@ -63,13 +62,12 @@ pure subroutine dshellPoly(iPoly,jPoly,iRad,jRad,rab2,xyz1,xyz2,rf,dxyz)
    k1=iPoly*0.01_wp
    k2=jPoly*0.01_wp
 
-   t14 = rr**a
+   t14 = sqrt(rr) ! rr**a: R^a dependence 0.5 in GFN1
    t15 = k1*t14
    t17 = 1.0_wp/rab2
-   t22 = rr**a
-   t23 = k2*t22
-   rf=(1.0_wp+t15)*(1.0_wp+k2*t22)
-   dxyz(:)=(t15*(1.0_wp+t23)+(1.0_wp+t15)*k2*t22)*a*t17*[dx,dy,dz]
+   t23 = k2*t14
+   rf=(1.0_wp+t15)*(1.0_wp+k2*t14)
+   dxyz(:)=(t15*(1.0_wp+t23)+(1.0_wp+t15)*k2*t14)*a*t17*[dx,dy,dz]
 
 end subroutine dshellPoly
 

--- a/src/intgrad.f90
+++ b/src/intgrad.f90
@@ -771,9 +771,10 @@ pure subroutine get_overlap(icao,jcao,naoi,naoj,ishtyp,jshtyp,ri,rj,point,intcut
          jprim=jp+primcount(jcao+1)
          ! exponent the same for each l component
          alpj=alp(jprim)
+         est=rij2*alpi*alpj
+         if(est.gt.intcut*(alpi+alpj)) cycle
          ab=1.0_wp/(alpi+alpj)
-         est=rij2*alpi*alpj*ab
-         if(est.gt.intcut) cycle
+         est = est*ab
          kab = exp(-est)*(sqrtpi*sqrt(ab))**3
          rp = (alpi*ri + alpj*rj)*ab
          do k = 0, ishtyp + jshtyp
@@ -844,9 +845,10 @@ pure subroutine get_grad_overlap(icao,jcao,naoi,naoj,ishtyp,jshtyp,ri,rj,point,i
          jprim=jp+primcount(jcao+1)
          ! exponent the same for each l component
          alpj=alp(jprim)
+         est=alpi*alpj*rij2
+         if(est.gt.intcut*(alpi+alpj)) cycle
          ab = 1.0_wp/(alpi+alpj)
-         est=alpi*alpj*rij2*ab
-         if(est.gt.intcut) cycle
+         est = est*ab
          kab = exp(-est)*(sqrtpi*sqrt(ab))**3
          rp = (alpi*ri + alpj*rj)*ab
          do k = 0, ishtyp + jshtyp + 1
@@ -921,9 +923,10 @@ pure subroutine get_multiints(icao,jcao,naoi,naoj,ishtyp,jshtyp,ri,rj,point, &
          jprim = jp+primcount(jcao+1)
          ! exponent the same for each l component
          alpj = alp(jprim)
+         est = alpi*alpj*rij2
+         if(est.gt.intcut*(alpi+alpj)) cycle
          ab = 1.0_wp/(alpi+alpj)
-         est = alpi*alpj*rij2*ab
-         if(est.gt.intcut) cycle
+         est = est*ab
          kab = exp(-est)*(sqrtpi*sqrt(ab))**3
          rp = (alpi*ri + alpj*rj)*ab
          do k = 0, ishtyp + jshtyp + 2
@@ -996,9 +999,10 @@ pure subroutine get_grad_multiint(icao,jcao,naoi,naoj,ishtyp,jshtyp,ri,rj, &
          jprim = jp+primcount(jcao+1)
          ! exponent the same for each l component
          alpj = alp(jprim)
+         est = alpi*alpj*rij2
+         if(est.gt.intcut*(alpi+alpj)) cycle
          ab = 1.0_wp/(alpi+alpj)
-         est = alpi*alpj*rij2*ab
-         if(est.gt.intcut) cycle
+         est = est*ab
          kab = exp(-est)*(sqrtpi*sqrt(ab))**3
          rp = (alpi*ri + alpj*rj)*ab
          do k = 0, ishtyp + jshtyp + 3

--- a/src/scc_core.f90
+++ b/src/scc_core.f90
@@ -732,9 +732,8 @@ pure function shellPoly(iPoly,jPoly,iRad,jRad,xyz1,xyz2)
    real(wp), intent(in) :: iRad,jRad
    real(wp), intent(in) :: xyz1(3),xyz2(3)
    real(wp) :: shellPoly
-   real(wp) :: rab,k1,rr,r,rf1,rf2,dx,dy,dz,a
-
-   a=0.5_wp           ! R^a dependence 0.5 in GFN1
+   real(wp) :: rab,k1,rr,r,rf1,rf2,dx,dy,dz
+   real(wp), parameter :: a = 0.5_wp ! R^a dependence 0.5 in GFN1
 
    dx=xyz1(1)-xyz2(1)
    dy=xyz1(2)-xyz2(2)
@@ -747,8 +746,8 @@ pure function shellPoly(iPoly,jPoly,iRad,jRad,xyz1,xyz2)
 
    r=rab/rr
 
-   rf1=1.0_wp+0.01_wp*iPoly*r**a
-   rf2=1.0_wp+0.01_wp*jPoly*r**a
+   rf1=1.0_wp+0.01_wp*iPoly*sqrt(r)
+   rf2=1.0_wp+0.01_wp*jPoly*sqrt(r)
 
    shellPoly= rf1*rf2
 


### PR DESCRIPTION
This patch slightly speeds up evaluation of `build_SDQH0`, `build_dSDQH0`, `build_dSDQH0_noreset` routines by avoiding pow calls in `shellPoly` and `dshellPoly` routines with GCC (Intel compilers use constant propagation here) and sometimes useless divisions in `intgrad.f90`.