### PR TITLE
Avoid meson 1.8.1

### DIFF
--- a/.github/workflows/fortran-build.yml
+++ b/.github/workflows/fortran-build.yml
@@ -36,7 +36,7 @@ jobs:
            run: |
             sudo apt-get install libopenblas-dev
          - name: Install meson
-           run: pip install meson!=1.8.0 ninja
+           run: pip install meson==1.7.0 ninja
          - name: Configure build
            run: >-
             meson setup ${{ env.BUILD_DIR }} --buildtype=debug --warnlevel=0 -Db_coverage=true ${{ env.MESON_ARGS }}
@@ -206,7 +206,7 @@ jobs:
            uses: actions/setup-python@v5
            with:
             python-version: 3.x
-         - run: pip3 install meson!=1.8.0 ninja --user
+         - run: pip3 install meson==1.7.0 ninja --user
          - name: Add Intel repository
            if: contains(matrix.os, 'ubuntu')
            run: |
@@ -311,7 +311,7 @@ jobs:
            uses: actions/setup-python@v5
            with:
             python-version: 3.x
-         - run: pip3 install meson!=1.8.0 ninja --user
+         - run: pip3 install meson==1.7.0 ninja --user
          - name: Install Intel MKL
            if: contains(matrix.os, 'ubuntu')
            run: |

--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,8 @@ project(
 )
 
 # Check for specific unsupported meson versions
- if meson.version().version_compare('==1.8.0')
-   error('Meson version 1.8.0 has a known issue — please use any other version ≥ 0.62.0')
+ if meson.version().version_compare('==1.8.0') or meson.version().version_compare('==1.8.1')
+   error('Meson versions 1.8.0 and 1.8.1 have known issues — please use any other version ≥ 0.62.0')
  endif
 
 install = not meson.is_subproject()


### PR DESCRIPTION
Meson 1.8.1 is still not stable for configuring xtb builds. See errors here:
https://github.com/grimme-lab/xtb/actions/runs/15366340755?pr=1298 