### PR TITLE
electronic temperature now also set for tblite correctly via command line flag --etemp

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -1614,6 +1614,8 @@ contains
             call args%nextArg(sec)
             if (allocated(sec)) then
                call set_scc(env, 'temp', sec)
+               !set etemp for tblite
+               idum = getValue(env, sec, tblite%etemp)
             else
                call env%error("Temperature in --etemp option is missing", source)
             end if


### PR DESCRIPTION
If the electronic temperature was specified via the --etemp command line flagcommand, its value did not change when using --tblite.