### PR TITLE
Fix OpenMP thread memory leaks in aespot, coulomb, disp, and hamiltonian

### DIFF
--- a/src/aespot.F90
+++ b/src/aespot.F90
@@ -410,6 +410,8 @@ subroutine mmompop_cpu(nat,nao,aoat2,xyz,p,s,dpint,qpint,dipm,qp)
 !$ qp(:,:) = qp + qp_omp
    !$omp end critical (qp_crt)
 
+!$ deallocate(dipm_omp, qp_omp)
+
    !$omp end parallel
 
    ! remove trace

--- a/src/coulomb/klopmanohno.F90
+++ b/src/coulomb/klopmanohno.F90
@@ -566,6 +566,8 @@ subroutine getCoulombDerivsCluster(mol, itbl, gamAverage, gExp, hardness, &
 !$ djdtr(:,:) = djdtr + djdtr_omp
    !$omp end critical (djdtr_crt)
 
+!$ deallocate(djdr_omp, djdtr_omp, djdL_omp)
+
    !$omp end parallel
 
 end subroutine getCoulombDerivsCluster

--- a/src/disp/coordinationnumber.F90
+++ b/src/disp/coordinationnumber.F90
@@ -472,6 +472,8 @@ subroutine ncoordLatP(mol, trans, cutoff, kcn, cfunc, dfunc, enscale, &
 !$ cn(:) = cn + cn_omp
    !$omp end critical (cn_crt)
 
+!$ deallocate(cn_omp, dcndr_omp, dcndL_omp)
+
    !$omp end parallel
 
 end subroutine ncoordLatP

--- a/src/xtb/hamiltonian.F90
+++ b/src/xtb/hamiltonian.F90
@@ -785,6 +785,8 @@ subroutine build_dSDQH0_noreset(nShell, hData, selfEnergy, dSEdcn, intcut, &
 !$ dhdcn(:) = dhdcn + dhdcn_omp
    !$omp end critical (dhdcn_crt)
 
+!$ deallocate(g_omp, sigma_omp, dhdcn_omp)
+
    !$omp end parallel
 
 end subroutine build_dSDQH0_noreset


### PR DESCRIPTION
This pull request addresses a memory leak introduced after commit #1350. When running with Intel MKL, each GFN2 call increases memory usage by roughly 300–400 MB. After about 100 iterations, XTB reaches ~50 GB of RAM usage, whereas the same system required only ~1 GB before #1350.

After this commit it seems it comes back to normal, without any performance penalty. 

The issue appears to stem from several variables that are no longer being deallocated. 