### PR TITLE
Update `batmgfnff_eg` subroutine

### DIFF
--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -3346,7 +3346,6 @@ end subroutine rbxgfnff_eg
 
 !> taken from D3 ATM code
   subroutine batmgfnff_eg(n, iat, jat, kat, iTrj, iTrk, at, xyz, q, energy, g, ds, param, neigh)
-    use xtb_mctc_accuracy, only: wp
     implicit none
     type(TGFFData), intent(in) :: param
     type(TNeigh), intent(in) :: neigh


### PR DESCRIPTION
To avoid any further bugs like described in #1246 because of uninitialized out variables (I do not know how it happened), I've updated `batmgfnff_eg` routine.

List of changes:
- initialized out variables with zero
- removed unused variables
- reduced computational cost of whole subroutine. I left only few divisions and 3 sqrt's. Before, it is used more frequently in ASM.