### PR TITLE
Increase width of coordinates in Cosmo files

### DIFF
--- a/src/solv/cosmo.f90
+++ b/src/solv/cosmo.f90
@@ -909,7 +909,7 @@ subroutine writeCosmoFile(self, unit, num, sym, xyz, qat, energy)
       & "$coord_rad", &
       & "#atom   x                  y                  z             element  radius [A]"
    do iat = 1, size(xyz, 2)
-      write(unit, '(i4, 3(1x, f18.14), 2x, a4, 1x, f9.5)') &
+      write(unit, '(i4, 3(1x, f19.14), 2x, a4, 1x, f9.5)') &
          & iat, xyz(:, iat), sym(iat), self%rvdw(iat)*autoaa
    end do
 


### PR DESCRIPTION
* Previously any coordinate -100 bohr or smaller, 1000 bohr or larger would fail to be written. This increases these limits to -1000 and 10000 respectively.

Misprinted coordinates would break the parsing in downstream code like CPCM-X if the coordinates dipped below -100 bohr.