### PR TITLE
Add solvation and electric fields to the manpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ features reality:
 - S. Ehlert ([@awvwgk](https://github.com/awvwgk))
 - S. Ehrlich
 - M. Friede ([@marvinfriede](https://github.com/marvinfriede))
-- T. Froitzheim([@thfroitzheim](https://github.com/thfroitzheim))
+- T. Froitzheim ([@thfroitzheim](https://github.com/thfroitzheim))
 - I. Gerasimov ([@foxtran](https://github.com/foxtran))
 - [S. Grimme](https://www.chemie.uni-bonn.de/pctc/mulliken-center/grimme/) ([@stefangrimme](https://github.com/stefangrimme))
 - C. Hölzer ([@hoelzerC](https://github.com/hoelzerc))

--- a/man/xtb.1.adoc
+++ b/man/xtb.1.adoc
@@ -101,6 +101,10 @@ OPTIONS
     The inner region is given as comma-separated indices directly in the commandline
     or in a file with each index on a separate line.
 
+*--efield* 'REAL,REAL,REAL'::
+    static electric field in Cartesian coordinates, overrides `.EFIELD` file,
+    works only via tblite for the xTB Hamiltonians, or with GFN-FF and PTB.
+
 *--etemp, --temp* 'REAL'::
     electronic temperature for SCC (default = 300K)
 
@@ -135,6 +139,18 @@ OPTIONS
     'methanol', 'n-hexane' (only GFN2-xTB), 'THF' and 'toluene'.
     The solvent input is not case-sensitive.
     The Gsolv reference state can be chosen as 'reference', 'bar1M', or 'gsolv' (default).
+
+*--gbe* 'SOLVENT/EPSILON'::
+    generalized Born for finite epsilon (GBe) solvation model (tblite required),
+    includes only the electrostatic solvation contribution (no SASA model),
+    available solvents are all solvents that are available for alpb.
+    Additionally, the dielectric constant can be set manually.
+
+*--gb* 'SOLVENT/EPSILON'::
+    generalized Born (GB) solvation model (tblite required),
+    includes only the electrostatic solvation contribution (no SASA model),
+    available solvents are all solvents that are available for alpb.
+    Additionally, the dielectric constant can be set manually.
 
 *--cosmo* 'SOLVENT/EPSILON'::
     domain decomposition conductor-like screening model (ddCOSMO)

--- a/src/xhelp.f90
+++ b/src/xhelp.f90
@@ -143,8 +143,8 @@ subroutine help(iunit)
    "    or in a file with each index on a separate line.", &
    "",&
    "--efield REAL,REAL,REAL",&
-   "    static electric field in cartesian coordinates, overrides .EFIELD file.",&
-   "    works only via tblite or with GFN-FF and PTB.",&
+   "    static electric field in Cartesian coordinates, overrides '.EFIELD' file,",&
+   "    works only via tblite for the xTB Hamiltonians, or with GFN-FF and PTB.",&
    "",&
    "--etemp REAL",&
    "    electronic temperature (default = 300K)",&
@@ -182,12 +182,16 @@ subroutine help(iunit)
    "    The Gsolv reference state can be chosen as reference, bar1M, or gsolv (default).",&
    "",&
    "--gbe SOLVENT/EPSILON",&
-   "    Use generalized Born for finite epsilon (GBE) solvation model (tblite required).", &
-   "    Solvent is specified by dielectric constant or the solvent name.",&
+   "    generalized Born for finite epsilon (GBe) solvation model (tblite required),", &
+   "    includes only the electrostatic solvation contribution (no SASA model),", &
+   "    available solvents are all solvents that are available for alpb.", &
+   "    Additionally, the dielectric constant can be set manually.", &
    "",&
    "--gb SOLVENT/EPSILON",&
-   "    Use generalized Born solvation model (GB) (tblite required).", &
-   "    Solvent is specified by dielectric constant or the solvent name.",&
+   "    generalized Born (GB) solvation model (tblite required),", &
+   "    includes only the electrostatic solvation contribution (no SASA model),", &
+   "    available solvents are all solvents that are available for alpb.", &
+   "    Additionally, the dielectric constant can be set manually.", &
    "",&
    "--cosmo SOLVENT/EPSILON",&
    "    domain decomposition conductor-like screening model (ddCOSMO),",&


### PR DESCRIPTION
Adds the GB/GBe and electric field entries to the manpage (was missing in #1397)