### PR TITLE
Update the dftd4 version to fix inconsistencies with tblite

### DIFF
--- a/cmake/modules/Finddftd4.cmake
+++ b/cmake/modules/Finddftd4.cmake
@@ -17,7 +17,7 @@
 set(_lib "dftd4")
 set(_pkg "DFTD4")
 set(_url "https://github.com/dftd4/dftd4")
-set(_rev "v4.1.0")
+set(_rev "v4.2.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
    set("${_pkg}_FIND_METHOD" "cmake" "pkgconf" "subproject" "fetch")

--- a/src/ptb/twostepscf.F90
+++ b/src/ptb/twostepscf.F90
@@ -629,7 +629,7 @@ contains
 
       !> Get the WBOs
       allocate (wbo(mol%nat, mol%nat, wfn%nspin))
-      call get_mayer_bond_orders(bas, ints%overlap, wfn%density, wbo)
+      call get_mayer_bond_orders(mol, bas, ints%overlap, wfn%density, wbo)
 
       !> Save some memory by deallocating the second-iteration-specific HO overlap integrals
       deallocate (auxints%overlap_h0_2)

--- a/src/tblite/calculator.F90
+++ b/src/tblite/calculator.F90
@@ -513,7 +513,7 @@ subroutine singlepoint(self, env, mol, chk, printlevel, restart, &
    allocate(post_proc)
    ! Wiberg-Mayer bond orders
    wbo_label = "bond-orders"
-   call add_post_processing(post_proc, wbo_label, error)
+   call add_post_processing(post_proc, struc, wbo_label, error)
    if (allocated(error)) then
       call env%error(error%message, source)
       return
@@ -521,7 +521,7 @@ subroutine singlepoint(self, env, mol, chk, printlevel, restart, &
 
    ! Molecular multipole moments
    molmom_label = "molmom"
-   call add_post_processing(post_proc, molmom_label, error)
+   call add_post_processing(post_proc, struc, molmom_label, error)
    if (allocated(error)) then
       call env%error(error%message, source)
       return

--- a/subprojects/dftd4.wrap
+++ b/subprojects/dftd4.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = dftd4
 url = https://github.com/dftd4/dftd4
-revision = v4.1.0
+revision = v4.2.0


### PR DESCRIPTION
Update to dftd4 4.2.0 with the smooth periodic cutoffs used in the current tblite main branch. Should fix the current build issues of xtb. 