### PR TITLE
Open-shell doublet as default for uneven number of electrons

### DIFF
--- a/man/xtb.1.adoc
+++ b/man/xtb.1.adoc
@@ -71,6 +71,7 @@ OPTIONS
 
 *-u, --uhf* 'INT'::
     specify number of unpaired electrons as 'INT', overrides `.UHF` file and `xcontrol` option
+    (default: 0 (singlet) for even electron number, 1 (doublet) for odd electron number)
 
 *--gfn* 'INT'::
     specify parametrisation of GFN-xTB (default = 2)

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -609,12 +609,19 @@ contains
          call chk%wfn%allocate(mol%n, calc%basis%nshell, calc%basis%nao)
 
          ! Make sure number of electrons is initialized and multiplicity is consistent
+         ! Default is restricted closed-shell singlet for even number of electrons
+         ! and restricted open-shell doublet for odd number of electrons
          chk%wfn%nel = nint(sum(mol%z) - mol%chrg)
-         if (mod(mol%uhf, 2) /= mod(chk%wfn%nel, 2)) then
-            call env%terminate("Assigned number of unpaired electrons (flag '--uhf <int>' or <int> in file '.UHF') is not consistent with the total number of electrons")
-         else
+         if (mod(mol%uhf, 2) == mod(chk%wfn%nel, 2)) then
+            ! Restricted closed-shell case
             chk%wfn%nopen = mol%uhf
-         end if
+         else
+            ! Restricted open-shell case
+            if (mol%uhf /= 0) then
+               call env%terminate("Assigned number of unpaired electrons (flag '--uhf <int>' or <int> in file '.UHF') is not consistent with the total number of electrons")
+            end if
+            chk%wfn%nopen = mod(int(chk%wfn%nel), 2)
+         end if 
 
          ! EN charges and CN
          if (set%gfn_method < 2) then

--- a/src/scf_module.F90
+++ b/src/scf_module.F90
@@ -481,7 +481,7 @@ subroutine scf(env, mol, wfn, basis, pcem, xtbData, solvation, &
       write(env%unit,scifmt) "-> wf. convergence ",qconv,   "e   "
       write(env%unit,dblfmt) "Broyden damping    ",set%broydamp,"    "
       write(env%unit,intfmt) "net charge         ",nint(mol%chrg)
-      write(env%unit,intfmt) "unpaired electrons ",mol%uhf
+      write(env%unit,intfmt) "unpaired electrons ",wfn%nopen
       write(env%unit,'(10x,51("."))')
    endif
 

--- a/src/xhelp.f90
+++ b/src/xhelp.f90
@@ -117,6 +117,7 @@ subroutine help(iunit)
    "",&
    "-u, --uhf INT",&
    "    specify number of unpaired electrons as INT, overrides .UHF file and xcontrol option",&
+   "    (default: 0 (singlet) for even electron number, 1 (doublet) for odd electron number)",&
    "",&
    "--gfn INT",&
    "    specify parametrisation of GFN-xTB (default = 2)",&


### PR DESCRIPTION
This PR reverts part of the #1235 following discussions with @stefangrimme. 
An error occurs only if the number of unpaired electrons specified via the `.UHF` file or the `--uhf` flag is inconsistent with the total number of electrons (i.e., it is even and the number of electrons is odd or the other way around). 
In all other cases, we specify a default: 
- closed-shell singlet (unpaired=0) if the number of electrons is even
- open-shell doublet (unpaired=1) if the number of electrons is odd

Given that we use the first default all of the time, the low-spin open-shell default is the logical extension. 