### PR TITLE
Improve CMake reuse of vendored subprojects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,14 +30,13 @@ project(
   LANGUAGES "C" "Fortran"
 )
 
-enable_testing()
-
 # Follow GNU conventions for installing directories
 include(GNUInstallDirs)
 
 
 # Include CMake specific configurations
 add_subdirectory("cmake")
+include("${PROJECT_SOURCE_DIR}/cmake/modules/xtb-utils.cmake")
 
 # Check a specific CMake targets for xtb build & execute corresponding Find scripts
 if(NOT TARGET "mctc-lib::mctc-lib")
@@ -49,12 +48,22 @@ if(NOT TARGET "tblite::tblite" AND WITH_TBLITE)
    add_compile_definitions(WITH_TBLITE)
 endif()
 
+foreach(_xtb_dep IN ITEMS toml-f test-drive mstore multicharge dftd4 s-dftd3 tblite)
+   xtb_promote_target("${_xtb_dep}")
+endforeach()
+unset(_xtb_dep)
+
 if(NOT TARGET "cpcmx::cpcmx" AND WITH_CPCMX)
    find_package("cpcmx" REQUIRED)
    add_compile_definitions(WITH_CPCMX)
 endif()
 
-if(NOT TARGET "test-drive::test-drive")
+foreach(_xtb_dep IN ITEMS cpcmx numsa toml-f test-drive mctc-lib)
+   xtb_promote_target("${_xtb_dep}")
+endforeach()
+unset(_xtb_dep)
+
+if(WITH_TESTS AND NOT TARGET "test-drive::test-drive")
   find_package("test-drive" REQUIRED)
 endif()
 
@@ -339,4 +348,7 @@ install(
 )
    
 # Tests
-add_subdirectory("test")
+if(WITH_TESTS)
+   enable_testing()
+   add_subdirectory("test")
+endif()

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -18,6 +18,7 @@
 option(WITH_OpenMP "Enable support for shared memory parallelisation with OpenMP" TRUE)
 option(WITH_TBLITE "Use tblite library as backend for xTB" TRUE)
 option(WITH_CPCMX "Use CPCM-X solvation library for xTB" TRUE)
+option(WITH_TESTS "Enable compilation of unit tests" TRUE)
 
 
 # Set build type as CMake does not provide defaults

--- a/cmake/modules/Findtblite.cmake
+++ b/cmake/modules/Findtblite.cmake
@@ -17,7 +17,7 @@
 set(_lib "tblite")
 set(_pkg "TBLITE")
 set(_url "https://github.com/tblite/tblite")
-set(_rev "HEAD")
+set(_rev "v0.6.0")
 
 if(NOT DEFINED "${_pkg}_FIND_METHOD")
    set("${_pkg}_FIND_METHOD" "cmake" "pkgconf" "subproject" "fetch")

--- a/cmake/modules/xtb-utils.cmake
+++ b/cmake/modules/xtb-utils.cmake
@@ -15,6 +15,14 @@
 # along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 # Handling of subproject dependencies
+# Reuse targets already created by nested FetchContent/subprojects.
+macro("xtb_promote_target" package)
+   if(NOT TARGET "${package}::${package}" AND TARGET "${package}")
+      add_library("${package}::${package}" INTERFACE IMPORTED GLOBAL)
+      target_link_libraries("${package}::${package}" INTERFACE "${package}")
+   endif()
+endmacro()
+
 macro(
    "xtb_find_package"
    package
@@ -24,6 +32,8 @@ macro(
 )
 string(TOLOWER "${package}" _pkg_lc)
 string(TOUPPER "${package}" _pkg_uc)
+
+xtb_promote_target("${package}")
 
 # iterate through all methods
 foreach(method ${methods})
@@ -50,7 +60,7 @@ foreach(method ${methods})
       pkg_check_modules("${_pkg_uc}" QUIET "${package}") # check if it is a pkg-config module
       if("${_pkg_uc}_FOUND")
          message(STATUS "Found ${package} via pkg-config")
-         add_library("${package}::${package}" INTERFACE IMPORTED) # interface library
+         add_library("${package}::${package}" INTERFACE IMPORTED GLOBAL) # interface library
          target_link_libraries(
             "${package}::${package}"
             INTERFACE
@@ -82,8 +92,10 @@ foreach(method ${methods})
          )
 
          # create interface directory and manage it's dependencies
-         add_library("${package}::${package}" INTERFACE IMPORTED)
-         target_link_libraries("${package}::${package}" INTERFACE "${package}")
+         if(NOT TARGET "${package}::${package}")
+            add_library("${package}::${package}" INTERFACE IMPORTED GLOBAL)
+            target_link_libraries("${package}::${package}" INTERFACE "${package}")
+         endif()
 
          # We need the module directory in the subproject before we finish the configure stage
          if(NOT EXISTS "${${_pkg_uc}_BINARY_DIR}/include")
@@ -107,8 +119,10 @@ foreach(method ${methods})
       )
       FetchContent_MakeAvailable("${_pkg_lc}")
 
-      add_library("${package}::${package}" INTERFACE IMPORTED)
-      target_link_libraries("${package}::${package}" INTERFACE "${package}")
+      if(NOT TARGET "${package}::${package}")
+         add_library("${package}::${package}" INTERFACE IMPORTED GLOBAL)
+         target_link_libraries("${package}::${package}" INTERFACE "${package}")
+      endif()
 
       if(NOT EXISTS "${${_pkg_lc}_BINARY_DIR}/include")
          file(MAKE_DIRECTORY "${${_pkg_lc}_BINARY_DIR}/include")

--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,8 @@ project(
 install = not meson.is_subproject()
 install_modules = install and get_option('install_modules')
 
+meson.add_dist_script('meson/dist_symlinks.sh')
+
 commit = get_option('build_name')
 git = find_program('git', required: false)
 if git.found()

--- a/meson/dist_symlinks.sh
+++ b/meson/dist_symlinks.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# This file is part of xtb.
+# SPDX-Identifier: LGPL-3.0-or-later
+#
+# xtb is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# xtb is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+if [ -z "$MESON_DIST_ROOT" ]; then
+    echo "Error: This script must be run via meson dist."
+    exit 1
+fi
+
+echo "Setting up symlinks for nested subprojects in distribution tarball..."
+
+cd "$MESON_DIST_ROOT/subprojects" || exit 1
+
+link_subproject() {
+    local parent="$1"
+    local dependency="$2"
+
+    if [ -d "$parent" ] && [ -d "$dependency" ]; then
+        echo "  -> Symlinking $dependency into $parent/subprojects"
+        mkdir -p "$parent/subprojects"
+        ln -sfn "../../$dependency" "$parent/subprojects/$dependency"
+    fi
+}
+
+link_project_alias() {
+    local source="$1"
+    local alias="$2"
+
+    if [ -d "$source" ] && [ ! -e "$alias" ]; then
+        echo "  -> Symlinking $source as top-level $alias subproject"
+        ln -sfn "$source" "$alias"
+    fi
+}
+
+# Meson uses the wrap/subproject name cpx, while CMake searches for cpcmx.
+link_project_alias cpx cpcmx
+
+# tblite is a direct xTB dependency, but in the xTB distribution tarball its
+# CMake subprojects live one directory above tblite/subprojects.
+link_subproject tblite toml-f
+link_subproject tblite multicharge
+link_subproject tblite dftd4
+link_subproject tblite s-dftd3
+link_subproject tblite mstore
+
+# Same pattern as tblite: dftd4 and toml-f need these nested sources for
+# CMake/offline builds.
+link_subproject dftd4 mstore
+link_subproject toml-f test-drive
+
+# CPCM-X is vendored as cpx in Meson, but its CMake build has its own nested
+# dependency lookup.
+link_subproject cpx numsa
+link_subproject cpx toml-f
+link_subproject cpx test-drive
+link_subproject numsa test-drive
+
+# Optional JSON support in mctc-lib/jonquil needs these sources offline.
+link_subproject mctc-lib toml-f
+link_subproject mctc-lib jonquil
+link_subproject jonquil test-drive
+
+echo "Symlink setup complete."

--- a/meson/dist_symlinks.sh
+++ b/meson/dist_symlinks.sh
@@ -39,7 +39,7 @@ link_project_alias() {
     local source="$1"
     local alias="$2"
 
-    if [ -d "$source" ] && [ ! -e "$alias" ]; then
+    if [ -d "$source" ] && { [ ! -e "$alias" ] || [ -L "$alias" ]; }; then
         echo "  -> Symlinking $source as top-level $alias subproject"
         ln -sfn "$source" "$alias"
     fi


### PR DESCRIPTION
- Fix CMake target reuse so that subprojects already introduced by nested FetchContent/subproject builds are not added again, avoiding duplicate targets such as `test-drive`, `test-drive-lib`, and related test executables.
- Add Meson dist symlinks, so the CMake build can reuse the dependency sources already included in the dist tarball instead of downloading another copy online.