### PR TITLE
Fix monoatomic hessian initialization

### DIFF
--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -495,7 +495,11 @@ subroutine numhess( &
             xsum = xsum + (amass_amu(ii))**2 * (res%hess(ii,i))**2
          enddo
       enddo
-      res%rmass(i)= 1.0_wp / xsum
+      if (xsum > 0.0_wp) then
+         res%rmass(i) = 1.0_wp / xsum
+      else
+         res%rmass(i) = 0.0_wp
+      end if
    enddo
 
    !--- IR intensity ---! (holds in a similar fashion also for Raman)

--- a/src/hessian.F90
+++ b/src/hessian.F90
@@ -437,9 +437,9 @@ subroutine numhess( &
    end if
 
    ! sort such that rot/trans are modes 1:6, H/isqm are scratch
+   h = 0.0_wp
+   isqm = 0.0_wp
    if (mol%n > 1) then
-      h = 0.0_wp
-      isqm = 0.0_wp
       kend=0
       if (freezeset%n == 0) then
          kend=6


### PR DESCRIPTION
This was initially introduced in https://github.com/grimme-lab/xtb/commit/7dd771097701ef4103142bb10179aa52b5786d7a

In hessian.F90, `isqm` is only initialized if `mol%n > 1`. But it is [unconditionally copied into freq](https://github.com/grimme-lab/xtb/compare/main...TyBalduf:xtb:fix/monoatomic-hessian-initialization?expand=1#diff-565fb80b708ce0e4f18fcaee3a834915ceb64970c6e0911b3c0f9b59829862d5R481). The un-initialized value depends on the compiler/heap-layout, but can essentially be any random value. `h` is actually initialized to zero elsewhere, but moving the initialization outside the `mol%n > 1` block feels clearer about the intent.
 
This has manifested as https://github.com/grimme-lab/xtb/issues/1409, where the entropy/free energy winds up being infinite in many cases. The first commit addresses this issue.

Incidentally, I also fixed that the reduced mass for the translational mode would be printed as Infinity, since `xsum==0.0` in this case.

Fixes #1409