### PR TITLE
Fix rotational mode detection for diatomics

### DIFF
--- a/src/detrotra.f90
+++ b/src/detrotra.f90
@@ -71,7 +71,7 @@ subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)
    integer, allocatable :: ind(:)
    real(wp), allocatable :: mode(:), tmpxyz(:, :), score(:)
    real(wp) :: a0, b0, c0
-   logical :: check_all
+   logical, allocatable :: candidate(:)
 
    n3 = 3*n
    nend = min(merge(5, 6, linear), n3)
@@ -79,14 +79,18 @@ subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)
    if (nend == 0) return
 
    ! Preserve the historic low-mode candidate set when it is large enough.
-   ! If it is not, inspect all modes instead of indexing uninitialized entries.
-   check_all = count(eig <= low_mode_threshold) < nend
+   ! Otherwise, add the remaining modes in ascending eigenvalue order until
+   ! there are enough candidates to identify all rigid-body modes.
+   allocate(candidate(n3), source=eig <= low_mode_threshold)
+   do while (count(candidate) < nend)
+      ii = minloc(eig, dim=1, mask=.not.candidate)
+      candidate(ii) = .true.
+   end do
    allocate(mode(n3), tmpxyz(3, n), score(n3), ind(n3))
 
    nn = 0
    do ii = 1, n3
-      ! Check only low-lying modes unless the full fallback is required.
-      if (.not.check_all .and. eig(ii) > low_mode_threshold) cycle
+      if (.not.candidate(ii)) cycle
 
       select type(h)
       type is(real(sp))

--- a/src/detrotra.f90
+++ b/src/detrotra.f90
@@ -20,12 +20,17 @@ module xtb_detrotra
    implicit none
    private
 
-   public :: detrotra4, detrotra8
+   public :: detrotra
+
+   interface detrotra
+      module procedure detrotra_sp
+      module procedure detrotra_wp
+   end interface detrotra
 
 contains
 
 !> Determine rotational and translational modes using single precision modes
-subroutine detrotra4(linear, n, xyz, h, eig)
+subroutine detrotra_sp(linear, n, xyz, h, eig)
    !> Whether the molecular structure is linear
    logical, intent(in) :: linear
    !> Number of atoms
@@ -41,10 +46,10 @@ subroutine detrotra4(linear, n, xyz, h, eig)
    call detrotra_worker(linear, n, xyz, h, real(eig, wp), rigid)
    ! Identifier for rotational and translational modes
    eig(rigid) = 0.0_sp
-end subroutine detrotra4
+end subroutine detrotra_sp
 
 !> Determine rotational and translational modes using double precision modes
-subroutine detrotra8(linear, n, xyz, h, eig)
+subroutine detrotra_wp(linear, n, xyz, h, eig)
    !> Whether the molecular structure is linear
    logical, intent(in) :: linear
    !> Number of atoms
@@ -60,7 +65,7 @@ subroutine detrotra8(linear, n, xyz, h, eig)
    call detrotra_worker(linear, n, xyz, h, eig, rigid)
    ! Identifier for rotational and translational modes
    eig(rigid) = 0.0_wp
-end subroutine detrotra8
+end subroutine detrotra_wp
 
 !> Identify the modes which best preserve all interatomic distances
 subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)

--- a/src/detrotra.f90
+++ b/src/detrotra.f90
@@ -26,7 +26,9 @@ contains
 
 !> Determine rotational and translational modes using single precision modes
 subroutine detrotra4(linear, n, xyz, h, eig)
+   !> Whether the molecular structure is linear
    logical, intent(in) :: linear
+   !> Number of atoms
    integer, intent(in) :: n
    !> Cartesian coordinates
    real(wp), intent(in) :: xyz(3, n)
@@ -43,7 +45,9 @@ end subroutine detrotra4
 
 !> Determine rotational and translational modes using double precision modes
 subroutine detrotra8(linear, n, xyz, h, eig)
+   !> Whether the molecular structure is linear
    logical, intent(in) :: linear
+   !> Number of atoms
    integer, intent(in) :: n
    !> Cartesian coordinates
    real(wp), intent(in) :: xyz(3, n)
@@ -60,11 +64,17 @@ end subroutine detrotra8
 
 !> Identify the modes which best preserve all interatomic distances
 subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)
+   !> Whether the molecular structure is linear
    logical, intent(in) :: linear
+   !> Number of atoms
    integer, intent(in) :: n
+   !> Cartesian coordinates
    real(wp), intent(in) :: xyz(3, n)
+   !> Eigenvectors from the projected Lindh diagonalization
    class(*), intent(in) :: h(:, :)
+   !> Eigenvalues from the projected Lindh diagonalization
    real(wp), intent(in) :: eig(3*n)
+   !> Indices of the rotational and translational modes
    integer, allocatable, intent(out) :: rigid(:)
    real(wp), parameter :: low_mode_threshold = 0.05_wp
    integer :: i, j, ii, nn, n3, nend
@@ -109,8 +119,8 @@ subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)
       c0 = 0.0_wp
       do i = 2, n
          do j = 1, i - 1
-            a0 = sqrt(sum((xyz(:, i) - xyz(:, j))**2))
-            b0 = sqrt(sum((tmpxyz(:, i) - tmpxyz(:, j))**2))
+            a0 = norm2(xyz(:, i) - xyz(:, j))
+            b0 = norm2(tmpxyz(:, i) - tmpxyz(:, j))
             ! Sum the squared distance differences.
             c0 = c0 + (a0 - b0)**2
          end do

--- a/src/detrotra.f90
+++ b/src/detrotra.f90
@@ -16,132 +16,111 @@
 ! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
 
 module xtb_detrotra
-  implicit none
-  private
-  public :: detrotra4, detrotra8
-
-  contains
-
-  subroutine detrotra4(linear,mol,h,eig)
-    use xtb_mctc_accuracy, only : sp, wp
-    use xtb_type_molecule
-    implicit none
-    type(TMolecule), intent(in) :: mol
-    real(sp), intent(in)    :: h(3*mol%n,3*mol%n)    ! values from projected Lindh diag
-    real(sp), intent(inout) :: eig(3*mol%n)          ! eigenvectors from projected Lindh diag
-    logical, intent(in)     :: linear
-  
-    integer               :: i,j,k,kk,ii,nn,n3,nend
-    integer,allocatable   :: ind(:)
-    real(wp), allocatable :: tmp(:,:)
-    real(wp), allocatable :: e(:)
-    real(wp)              :: a0,b0,c0
-  
-    n3 = 3*mol%n
-  
-    allocate(tmp(3,mol%n),e(n3),ind(n3))
-  
-    nn = 0
-    do ii=1, n3
-       if(eig(ii).gt.0.05) cycle  ! only lowest checked
-  
-       kk=0
-       do j=1,mol%n
-          do k=1,3
-             kk=kk+1
-             tmp(k,j)=mol%xyz(k,j)+h(kk,ii) ! distort along mode ii
-          enddo
-       enddo
-  
-       c0=0            ! compared all interatomic distances of original and distortet geom.
-       do i=2,mol%n
-          do j=1,i-1
-             a0 = sqrt((mol%xyz(1,i)-mol%xyz(1,j))**2+(mol%xyz(2,i)-mol%xyz(2,j))**2+(mol%xyz(3,i)-mol%xyz(3,j))**2)
-             b0 = sqrt((tmp(1,i)-tmp(1,j))**2+(tmp(2,i)-tmp(2,j))**2+(tmp(3,i)-tmp(3,j))**2)
-             c0 = c0+(a0-b0)**2   
-          enddo
-       enddo
-       nn = nn + 1
-       e(nn)=sqrt(c0/mol%n)*abs(eig(ii))  ! weight by Lindh eigenvalue
-       ind(nn)=nn
-  
-    enddo
-  
-    call qsort(e, 1, nn, ind)   ! sort
-  
-    nend = 6
-    if (linear) nend = 5
-  
-    do i=1,nend
-       eig(ind(i)) = 0.0  ! identifier for rot/tra
-    enddo
-  
-  end subroutine detrotra4
-
-!> determine rotational and translational modes 
-subroutine detrotra8(linear,n,xyz,h,eig)
-   
-   use xtb_mctc_accuracy, only : wp
-   use xtb_type_molecule
+   use xtb_mctc_accuracy, only : sp, wp
    implicit none
-    
-   integer, intent(in)     :: n
-   real(wp), intent(in)    :: xyz(3,n)    ! values from projected Lindh diag
-   real(wp), intent(in)    :: h(3*n,3*n)    ! values from projected Lindh diag
-   real(wp), intent(inout) :: eig(3*n)          ! eigenvalues from projected Lindh diag
-   logical, intent(in)     :: linear
-  
-   integer               :: i,j,k,kk,ii,nn,n3,nend
-   integer,allocatable   :: ind(:)
-   real(wp), allocatable :: tmpxyz(:,:)
-   real(wp), allocatable :: e(:)
-   real(wp)              :: a0,b0,c0
+   private
+
+   public :: detrotra4, detrotra8
+
+contains
+
+!> Determine rotational and translational modes using single precision modes
+subroutine detrotra4(linear, n, xyz, h, eig)
+   logical, intent(in) :: linear
+   integer, intent(in) :: n
+   !> Cartesian coordinates
+   real(wp), intent(in) :: xyz(3, n)
+   !> Eigenvectors from the projected Lindh diagonalization
+   real(sp), intent(in) :: h(3*n, 3*n)
+   !> Eigenvalues from the projected Lindh diagonalization
+   real(sp), intent(inout) :: eig(3*n)
+   integer, allocatable :: rigid(:)
+
+   call detrotra_worker(linear, n, xyz, h, real(eig, wp), rigid)
+   ! Identifier for rotational and translational modes
+   eig(rigid) = 0.0_sp
+end subroutine detrotra4
+
+!> Determine rotational and translational modes using double precision modes
+subroutine detrotra8(linear, n, xyz, h, eig)
+   logical, intent(in) :: linear
+   integer, intent(in) :: n
+   !> Cartesian coordinates
+   real(wp), intent(in) :: xyz(3, n)
+   !> Eigenvectors from the projected Lindh diagonalization
+   real(wp), intent(in) :: h(3*n, 3*n)
+   !> Eigenvalues from the projected Lindh diagonalization
+   real(wp), intent(inout) :: eig(3*n)
+   integer, allocatable :: rigid(:)
+
+   call detrotra_worker(linear, n, xyz, h, eig, rigid)
+   ! Identifier for rotational and translational modes
+   eig(rigid) = 0.0_wp
+end subroutine detrotra8
+
+!> Identify the modes which best preserve all interatomic distances
+subroutine detrotra_worker(linear, n, xyz, h, eig, rigid)
+   logical, intent(in) :: linear
+   integer, intent(in) :: n
+   real(wp), intent(in) :: xyz(3, n)
+   class(*), intent(in) :: h(:, :)
+   real(wp), intent(in) :: eig(3*n)
+   integer, allocatable, intent(out) :: rigid(:)
+   real(wp), parameter :: low_mode_threshold = 0.05_wp
+   integer :: i, j, ii, nn, n3, nend
+   integer, allocatable :: ind(:)
+   real(wp), allocatable :: mode(:), tmpxyz(:, :), score(:)
+   real(wp) :: a0, b0, c0
+   logical :: check_all
 
    n3 = 3*n
+   nend = min(merge(5, 6, linear), n3)
+   allocate(rigid(nend))
+   if (nend == 0) return
 
-   allocate(tmpxyz(3,n),e(n3),ind(n3))
+   ! Preserve the historic low-mode candidate set when it is large enough.
+   ! If it is not, inspect all modes instead of indexing uninitialized entries.
+   check_all = count(eig <= low_mode_threshold) < nend
+   allocate(mode(n3), tmpxyz(3, n), score(n3), ind(n3))
 
    nn = 0
-   do ii=1, n3
+   do ii = 1, n3
+      ! Check only low-lying modes unless the full fallback is required.
+      if (.not.check_all .and. eig(ii) > low_mode_threshold) cycle
 
-      if(eig(ii).gt.0.05) cycle  ! check only low-lying modes 
-      
-      ! distort initial geometry along ii-th mode !
-      kk=0
-      do j=1,n
-         do k=1,3
-            kk=kk+1
-            tmpxyz(k,j)=xyz(k,j)+h(kk,ii)
-         enddo
-      enddo
+      select type(h)
+      type is(real(sp))
+         mode = real(h(:, ii), wp)
+      type is(real(wp))
+         mode = h(:, ii)
+      class default
+         error stop "Unsupported mode precision in detrotra"
+      end select
 
-      ! compare all interatomic distances of original and distortet geom. !
-      c0=0           
-      do i=2,n
-         do j=1,i-1
-            a0 = sqrt((xyz(1,i)-xyz(1,j))**2+(xyz(2,i)-xyz(2,j))**2+(xyz(3,i)-xyz(3,j))**2)
-            b0 = sqrt((tmpxyz(1,i)-tmpxyz(1,j))**2+(tmpxyz(2,i)-tmpxyz(2,j))**2+(tmpxyz(3,i)-tmpxyz(3,j))**2)
-            c0 = c0+(a0-b0)**2 ! sum of squared differences  
-         enddo
-      enddo
+      ! Distort the initial geometry along the ii-th mode.
+      tmpxyz = xyz + reshape(mode, shape(tmpxyz))
 
-      nn = nn + 1 
-      e(nn)=sqrt(c0/n)*abs(eig(ii))  ! weight by Lindh eigenvalue
-      ind(nn)=nn
+      ! Compare all interatomic distances of the original and distorted
+      ! geometries.
+      c0 = 0.0_wp
+      do i = 2, n
+         do j = 1, i - 1
+            a0 = sqrt(sum((xyz(:, i) - xyz(:, j))**2))
+            b0 = sqrt(sum((tmpxyz(:, i) - tmpxyz(:, j))**2))
+            ! Sum the squared distance differences.
+            c0 = c0 + (a0 - b0)**2
+         end do
+      end do
 
-   enddo
+      nn = nn + 1
+      ! Weight the distance change by the Lindh eigenvalue.
+      score(nn) = sqrt(c0/n)*abs(eig(ii))
+      ind(nn) = ii
+   end do
 
-   ! sort in ascending order !
-   call qsort(e,1,nn,ind)   
+   ! Sort in ascending order.
+   call qsort(score, 1, nn, ind)
+   rigid = ind(:nend)
+end subroutine detrotra_worker
 
-   nend = 6
-   if (linear) nend = 5
-
-   ! set lowest eigenvalues to zero !
-   do i=1,nend
-      eig(ind(i)) = 0.0  
-   enddo
-
-end subroutine detrotra8
-  
 end module xtb_detrotra

--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -671,7 +671,7 @@ subroutine l_ancopt &
    end select
 
    if (.not. fragmented_hessian) then
-      call detrotra4(linear,mol,hess,eig)
+      call detrotra4(linear, mol%n, mol%xyz, hess, eig)
    end if
 
    select type(calc)

--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -421,7 +421,7 @@ subroutine l_ancopt &
    use xtb_axis
    use xtb_hessian
    use xtb_lsrmsd
-   use xtb_detrotra, only : detrotra4
+   use xtb_detrotra, only : detrotra
 
    use xtb_gfnff_fraghess
 
@@ -671,7 +671,7 @@ subroutine l_ancopt &
    end select
 
    if (.not. fragmented_hessian) then
-      call detrotra4(linear, mol%n, mol%xyz, hess, eig)
+      call detrotra(linear, mol%n, mol%xyz, hess, eig)
    end if
 
    select type(calc)

--- a/src/type/anc.f90
+++ b/src/type/anc.f90
@@ -184,7 +184,7 @@ subroutine generate_anc_blowup(self,iunit,xyz,hess,pr,linear)
 
    use xtb_mctc_accuracy, only : wp
    use xtb_mctc_la
-   use xtb_detrotra, only : detrotra8
+   use xtb_detrotra, only : detrotra
    implicit none
 
    !> ANC object
@@ -241,7 +241,7 @@ subroutine generate_anc_blowup(self,iunit,xyz,hess,pr,linear)
       &        aux,lwork,iwork,liwork,info)
 
    ! determine, sort, and nullify rot/trans modes !  
-   call detrotra8(linear,self%n,self%xyz,hess,self%eigv) 
+   call detrotra(linear,self%n,self%xyz,hess,self%eigv)
 
    ! find lowest eigenvalue (ignore nullified ones) !
    elow = minval(self%eigv,mask=(abs(self%eigv) > thr1)) 

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
   "coulomb"
   "dftd3"
   "dftd4"
+  "detrotra"
   "docking"
   "eeq"
   "gfn0"

--- a/test/unit/main.f90
+++ b/test/unit/main.f90
@@ -24,6 +24,7 @@ program tester
    use test_coulomb, only : collect_coulomb
    use test_dftd3, only : collect_dftd3
    use test_dftd4, only : collect_dftd4
+   use test_detrotra, only : collect_detrotra
    use test_docking, only : collect_docking
    use test_eeq, only : collect_eeq
    use test_gfn0, only : collect_gfn0
@@ -62,6 +63,7 @@ program tester
       new_testsuite("coulomb", collect_coulomb), &
       new_testsuite("dftd3", collect_dftd3), &
       new_testsuite("dftd4", collect_dftd4), &
+      new_testsuite("detrotra", collect_detrotra), &
       new_testsuite("docking", collect_docking), &
       new_testsuite("eeq", collect_eeq), &
       new_testsuite("gfn0", collect_gfn0), &

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -37,6 +37,7 @@ tests = [
   'coulomb',
   'dftd3',
   'dftd4',
+  'detrotra',
   'docking',
   'eeq',
   'gfn0',

--- a/test/unit/test_detrotra.f90
+++ b/test/unit/test_detrotra.f90
@@ -19,7 +19,7 @@
 module test_detrotra
    use testdrive, only : new_unittest, unittest_type, error_type, check
    use xtb_mctc_accuracy, only : sp, wp
-   use xtb_detrotra, only : detrotra4, detrotra8
+   use xtb_detrotra, only : detrotra
    implicit none
    private
 
@@ -33,15 +33,15 @@ subroutine collect_detrotra(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
    testsuite = [ &
-      new_unittest("detrotra4_diatomic", test_detrotra4_diatomic), &
-      new_unittest("detrotra8_diatomic", test_detrotra8_diatomic), &
+      new_unittest("detrotra_sp_diatomic", test_detrotra_sp_diatomic), &
+      new_unittest("detrotra_wp_diatomic", test_detrotra_wp_diatomic), &
       new_unittest("low_mode_candidates", test_low_mode_candidates), &
       new_unittest("adaptive_mode_candidates", test_adaptive_mode_candidates) &
       ]
 
 end subroutine collect_detrotra
 
-subroutine test_detrotra4_diatomic(error)
+subroutine test_detrotra_sp_diatomic(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 2
    real(wp), parameter :: xyz(3, nat) = reshape([ &
@@ -58,13 +58,13 @@ subroutine test_detrotra4_diatomic(error)
 
    eig = [1.0e-14_sp, 2.0e-14_sp, 3.0e-14_sp, 3.4_sp, 3.4_sp, 40.6_sp]
 
-   call detrotra4(.true., nat, xyz, hess, eig)
+   call detrotra(.true., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_sp), 5)
    call check(error, eig(6), 40.6_sp, thr=epsilon(0.0_sp))
-end subroutine test_detrotra4_diatomic
+end subroutine test_detrotra_sp_diatomic
 
-subroutine test_detrotra8_diatomic(error)
+subroutine test_detrotra_wp_diatomic(error)
    type(error_type), allocatable, intent(out) :: error
    integer, parameter :: nat = 2
    real(wp), parameter :: xyz(3, nat) = reshape([ &
@@ -81,11 +81,11 @@ subroutine test_detrotra8_diatomic(error)
 
    eig = [1.0e-14_wp, 2.0e-14_wp, 3.0e-14_wp, 3.4_wp, 3.4_wp, 40.6_wp]
 
-   call detrotra8(.true., nat, xyz, hess, eig)
+   call detrotra(.true., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_wp), 5)
    call check(error, eig(6), 40.6_wp, thr=epsilon(0.0_wp))
-end subroutine test_detrotra8_diatomic
+end subroutine test_detrotra_wp_diatomic
 
 subroutine test_low_mode_candidates(error)
    type(error_type), allocatable, intent(out) :: error
@@ -107,7 +107,7 @@ subroutine test_low_mode_candidates(error)
    eig = [0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, &
       3.0_wp, 4.0_wp, 5.0_wp]
 
-   call detrotra8(.false., nat, xyz, hess, eig)
+   call detrotra(.false., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_wp), 6)
    call check(error, eig(7), 3.0_wp, thr=epsilon(0.0_wp))
@@ -130,7 +130,7 @@ subroutine test_adaptive_mode_candidates(error)
    eig = [0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.10_wp, &
       0.20_wp, 0.30_wp, 0.40_wp]
 
-   call detrotra8(.false., nat, xyz, hess, eig)
+   call detrotra(.false., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_wp), 6)
    call check(error, eig(6), 0.0_wp)

--- a/test/unit/test_detrotra.f90
+++ b/test/unit/test_detrotra.f90
@@ -1,6 +1,8 @@
 ! This file is part of xtb.
 ! SPDX-Identifier: LGPL-3.0-or-later
 !
+! Copyright (C) 2026 Ty Balduf
+!
 ! xtb is free software: you can redistribute it and/or modify it under
 ! the terms of the GNU Lesser General Public License as published by
 ! the Free Software Foundation, either version 3 of the License, or
@@ -23,11 +25,6 @@ module test_detrotra
 
    public :: collect_detrotra
 
-   interface build_diatomic_modes
-      module procedure build_diatomic_modes_sp
-      module procedure build_diatomic_modes_wp
-   end interface build_diatomic_modes
-
 contains
 
 !> Collect all exported unit tests
@@ -36,10 +33,10 @@ subroutine collect_detrotra(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
    testsuite = [ &
-      new_unittest("single precision linear diatomic", test_detrotra4_diatomic), &
-      new_unittest("double precision linear diatomic", test_detrotra8_diatomic), &
-      new_unittest("preserve sufficient low-mode candidates", test_low_mode_candidates), &
-      new_unittest("adaptively expand mode candidates", test_adaptive_mode_candidates) &
+      new_unittest("detrotra4_diatomic", test_detrotra4_diatomic), &
+      new_unittest("detrotra8_diatomic", test_detrotra8_diatomic), &
+      new_unittest("low_mode_candidates", test_low_mode_candidates), &
+      new_unittest("adaptive_mode_candidates", test_adaptive_mode_candidates) &
       ]
 
 end subroutine collect_detrotra
@@ -50,15 +47,21 @@ subroutine test_detrotra4_diatomic(error)
    real(wp), parameter :: xyz(3, nat) = reshape([ &
       0.0_wp, 0.0_wp, 0.0_wp, &
       1.0_wp, 0.0_wp, 0.0_wp], shape(xyz))
-   real(sp) :: hess(3*nat, 3*nat), eig(3*nat)
+   real(sp), parameter :: hess(3*nat, 3*nat) = reshape([ &
+      1.0_sp, 0.0_sp, 0.0_sp, 1.0_sp, 0.0_sp, 0.0_sp, &
+      0.0_sp, 1.0_sp, 0.0_sp, 0.0_sp, 1.0_sp, 0.0_sp, &
+      0.0_sp, 0.0_sp, 1.0_sp, 0.0_sp, 0.0_sp, 1.0_sp, &
+      0.0_sp, 0.0_sp, 0.0_sp, -1.0_sp, 1.0_sp, 0.0_sp, &
+      0.0_sp, 0.0_sp, 0.0_sp, -1.0_sp, 0.0_sp, 1.0_sp, &
+      0.0_sp, 0.0_sp, 0.0_sp, 1.0_sp, 0.0_sp, 0.0_sp], shape(hess))
+   real(sp) :: eig(3*nat)
 
-   call build_diatomic_modes(hess)
    eig = [1.0e-14_sp, 2.0e-14_sp, 3.0e-14_sp, 3.4_sp, 3.4_sp, 40.6_sp]
 
    call detrotra4(.true., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_sp), 5)
-   call check(error, eig(6), 40.6_sp, thr=1.0e-5_sp)
+   call check(error, eig(6), 40.6_sp, thr=epsilon(0.0_sp))
 end subroutine test_detrotra4_diatomic
 
 subroutine test_detrotra8_diatomic(error)
@@ -67,15 +70,21 @@ subroutine test_detrotra8_diatomic(error)
    real(wp), parameter :: xyz(3, nat) = reshape([ &
       0.0_wp, 0.0_wp, 0.0_wp, &
       1.0_wp, 0.0_wp, 0.0_wp], shape(xyz))
-   real(wp) :: hess(3*nat, 3*nat), eig(3*nat)
+   real(wp), parameter :: hess(3*nat, 3*nat) = reshape([ &
+      1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, &
+      0.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 0.0_wp, &
+      0.0_wp, 0.0_wp, 1.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, &
+      0.0_wp, 0.0_wp, 0.0_wp, -1.0_wp, 1.0_wp, 0.0_wp, &
+      0.0_wp, 0.0_wp, 0.0_wp, -1.0_wp, 0.0_wp, 1.0_wp, &
+      0.0_wp, 0.0_wp, 0.0_wp, 1.0_wp, 0.0_wp, 0.0_wp], shape(hess))
+   real(wp) :: eig(3*nat)
 
-   call build_diatomic_modes(hess)
    eig = [1.0e-14_wp, 2.0e-14_wp, 3.0e-14_wp, 3.4_wp, 3.4_wp, 40.6_wp]
 
    call detrotra8(.true., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_wp), 5)
-   call check(error, eig(6), 40.6_wp, thr=1.0e-12_wp)
+   call check(error, eig(6), 40.6_wp, thr=epsilon(0.0_wp))
 end subroutine test_detrotra8_diatomic
 
 subroutine test_low_mode_candidates(error)
@@ -101,7 +110,7 @@ subroutine test_low_mode_candidates(error)
    call detrotra8(.false., nat, xyz, hess, eig)
 
    call check(error, count(eig == 0.0_wp), 6)
-   call check(error, eig(7), 3.0_wp, thr=1.0e-12_wp)
+   call check(error, eig(7), 3.0_wp, thr=epsilon(0.0_wp))
 end subroutine test_low_mode_candidates
 
 subroutine test_adaptive_mode_candidates(error)
@@ -125,31 +134,7 @@ subroutine test_adaptive_mode_candidates(error)
 
    call check(error, count(eig == 0.0_wp), 6)
    call check(error, eig(6), 0.0_wp)
-   call check(error, eig(7), 0.20_wp, thr=1.0e-12_wp)
+   call check(error, eig(7), 0.20_wp, thr=epsilon(0.0_wp))
 end subroutine test_adaptive_mode_candidates
-
-subroutine build_diatomic_modes_sp(hess)
-   real(sp), intent(out) :: hess(6, 6)
-
-   hess = 0.0_sp
-   hess([1, 4], 1) = 1.0_sp
-   hess([2, 5], 2) = 1.0_sp
-   hess([3, 6], 3) = 1.0_sp
-   hess([4, 5], 4) = [-1.0_sp, 1.0_sp]
-   hess([4, 6], 5) = [-1.0_sp, 1.0_sp]
-   hess(4, 6) = 1.0_sp
-end subroutine build_diatomic_modes_sp
-
-subroutine build_diatomic_modes_wp(hess)
-   real(wp), intent(out) :: hess(6, 6)
-
-   hess = 0.0_wp
-   hess([1, 4], 1) = 1.0_wp
-   hess([2, 5], 2) = 1.0_wp
-   hess([3, 6], 3) = 1.0_wp
-   hess([4, 5], 4) = [-1.0_wp, 1.0_wp]
-   hess([4, 6], 5) = [-1.0_wp, 1.0_wp]
-   hess(4, 6) = 1.0_wp
-end subroutine build_diatomic_modes_wp
 
 end module test_detrotra

--- a/test/unit/test_detrotra.f90
+++ b/test/unit/test_detrotra.f90
@@ -38,7 +38,8 @@ subroutine collect_detrotra(testsuite)
    testsuite = [ &
       new_unittest("single precision linear diatomic", test_detrotra4_diatomic), &
       new_unittest("double precision linear diatomic", test_detrotra8_diatomic), &
-      new_unittest("preserve sufficient low-mode candidates", test_low_mode_candidates) &
+      new_unittest("preserve sufficient low-mode candidates", test_low_mode_candidates), &
+      new_unittest("adaptively expand mode candidates", test_adaptive_mode_candidates) &
       ]
 
 end subroutine collect_detrotra
@@ -102,6 +103,30 @@ subroutine test_low_mode_candidates(error)
    call check(error, count(eig == 0.0_wp), 6)
    call check(error, eig(7), 3.0_wp, thr=1.0e-12_wp)
 end subroutine test_low_mode_candidates
+
+subroutine test_adaptive_mode_candidates(error)
+   type(error_type), allocatable, intent(out) :: error
+   integer, parameter :: nat = 3
+   real(wp), parameter :: xyz(3, nat) = reshape([ &
+      0.0_wp, 0.0_wp, 0.0_wp, &
+      1.0_wp, 0.0_wp, 0.0_wp, &
+      0.0_wp, 1.0_wp, 0.0_wp], shape(xyz))
+   real(wp) :: hess(3*nat, 3*nat), eig(3*nat)
+   integer :: i
+
+   hess = 0.0_wp
+   do i = 1, 6
+      hess(i, i) = 1.0_wp
+   end do
+   eig = [0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.10_wp, &
+      0.20_wp, 0.30_wp, 0.40_wp]
+
+   call detrotra8(.false., nat, xyz, hess, eig)
+
+   call check(error, count(eig == 0.0_wp), 6)
+   call check(error, eig(6), 0.0_wp)
+   call check(error, eig(7), 0.20_wp, thr=1.0e-12_wp)
+end subroutine test_adaptive_mode_candidates
 
 subroutine build_diatomic_modes_sp(hess)
    real(sp), intent(out) :: hess(6, 6)

--- a/test/unit/test_detrotra.f90
+++ b/test/unit/test_detrotra.f90
@@ -1,0 +1,130 @@
+! This file is part of xtb.
+! SPDX-Identifier: LGPL-3.0-or-later
+!
+! xtb is free software: you can redistribute it and/or modify it under
+! the terms of the GNU Lesser General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! xtb is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU Lesser General Public License for more details.
+!
+! You should have received a copy of the GNU Lesser General Public License
+! along with xtb.  If not, see <https://www.gnu.org/licenses/>.
+
+module test_detrotra
+   use testdrive, only : new_unittest, unittest_type, error_type, check
+   use xtb_mctc_accuracy, only : sp, wp
+   use xtb_detrotra, only : detrotra4, detrotra8
+   implicit none
+   private
+
+   public :: collect_detrotra
+
+   interface build_diatomic_modes
+      module procedure build_diatomic_modes_sp
+      module procedure build_diatomic_modes_wp
+   end interface build_diatomic_modes
+
+contains
+
+!> Collect all exported unit tests
+subroutine collect_detrotra(testsuite)
+   !> Collection of tests
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+   testsuite = [ &
+      new_unittest("single precision linear diatomic", test_detrotra4_diatomic), &
+      new_unittest("double precision linear diatomic", test_detrotra8_diatomic), &
+      new_unittest("preserve sufficient low-mode candidates", test_low_mode_candidates) &
+      ]
+
+end subroutine collect_detrotra
+
+subroutine test_detrotra4_diatomic(error)
+   type(error_type), allocatable, intent(out) :: error
+   integer, parameter :: nat = 2
+   real(wp), parameter :: xyz(3, nat) = reshape([ &
+      0.0_wp, 0.0_wp, 0.0_wp, &
+      1.0_wp, 0.0_wp, 0.0_wp], shape(xyz))
+   real(sp) :: hess(3*nat, 3*nat), eig(3*nat)
+
+   call build_diatomic_modes(hess)
+   eig = [1.0e-14_sp, 2.0e-14_sp, 3.0e-14_sp, 3.4_sp, 3.4_sp, 40.6_sp]
+
+   call detrotra4(.true., nat, xyz, hess, eig)
+
+   call check(error, count(eig == 0.0_sp), 5)
+   call check(error, eig(6), 40.6_sp, thr=1.0e-5_sp)
+end subroutine test_detrotra4_diatomic
+
+subroutine test_detrotra8_diatomic(error)
+   type(error_type), allocatable, intent(out) :: error
+   integer, parameter :: nat = 2
+   real(wp), parameter :: xyz(3, nat) = reshape([ &
+      0.0_wp, 0.0_wp, 0.0_wp, &
+      1.0_wp, 0.0_wp, 0.0_wp], shape(xyz))
+   real(wp) :: hess(3*nat, 3*nat), eig(3*nat)
+
+   call build_diatomic_modes(hess)
+   eig = [1.0e-14_wp, 2.0e-14_wp, 3.0e-14_wp, 3.4_wp, 3.4_wp, 40.6_wp]
+
+   call detrotra8(.true., nat, xyz, hess, eig)
+
+   call check(error, count(eig == 0.0_wp), 5)
+   call check(error, eig(6), 40.6_wp, thr=1.0e-12_wp)
+end subroutine test_detrotra8_diatomic
+
+subroutine test_low_mode_candidates(error)
+   type(error_type), allocatable, intent(out) :: error
+   integer, parameter :: nat = 3
+   real(wp), parameter :: xyz(3, nat) = reshape([ &
+      0.0_wp, 0.0_wp, 0.0_wp, &
+      1.0_wp, 0.0_wp, 0.0_wp, &
+      0.0_wp, 1.0_wp, 0.0_wp], shape(xyz))
+   real(wp) :: hess(3*nat, 3*nat), eig(3*nat)
+   integer :: i
+
+   hess = 0.0_wp
+   do i = 1, 6
+      hess(i, i) = 1.0_wp
+   end do
+   hess([1, 4, 7], 7) = 1.0_wp
+   hess(8, 8) = 1.0_wp
+   hess(9, 9) = 1.0_wp
+   eig = [0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, 0.01_wp, &
+      3.0_wp, 4.0_wp, 5.0_wp]
+
+   call detrotra8(.false., nat, xyz, hess, eig)
+
+   call check(error, count(eig == 0.0_wp), 6)
+   call check(error, eig(7), 3.0_wp, thr=1.0e-12_wp)
+end subroutine test_low_mode_candidates
+
+subroutine build_diatomic_modes_sp(hess)
+   real(sp), intent(out) :: hess(6, 6)
+
+   hess = 0.0_sp
+   hess([1, 4], 1) = 1.0_sp
+   hess([2, 5], 2) = 1.0_sp
+   hess([3, 6], 3) = 1.0_sp
+   hess([4, 5], 4) = [-1.0_sp, 1.0_sp]
+   hess([4, 6], 5) = [-1.0_sp, 1.0_sp]
+   hess(4, 6) = 1.0_sp
+end subroutine build_diatomic_modes_sp
+
+subroutine build_diatomic_modes_wp(hess)
+   real(wp), intent(out) :: hess(6, 6)
+
+   hess = 0.0_wp
+   hess([1, 4], 1) = 1.0_wp
+   hess([2, 5], 2) = 1.0_wp
+   hess([3, 6], 3) = 1.0_wp
+   hess([4, 5], 4) = [-1.0_wp, 1.0_wp]
+   hess([4, 6], 5) = [-1.0_wp, 1.0_wp]
+   hess(4, 6) = 1.0_wp
+end subroutine build_diatomic_modes_wp
+
+end module test_detrotra


### PR DESCRIPTION
Fixes #1203

The `detrotra4/8` routines would score any mode with an eigenvalue below 0.05 to determine how well they preserved atomic distances, in order to classify low modes as translations/rotations vs vibrations. It would then sort these modes by score using the `ind` array and zero out the Hessian eigenvalues for the 6 (5 if linear) lowest scoring modes. 

This generally works fine, but if there aren't enough modes with an eigenvalue below 0.05, it would still try to zero out 5/6 modes even though some of the entries in `ind` would be undefined, leading to potential out of bounds access.

To avoid this, we check the number of low eigenvalue modes up front. If it isn't at least 5/6, we then check all the modes which should ensure we find 5/6 to remove. Checking all the modes shouldn't hurt performance, as we should only have this few small eigenvalues for small molecules, namely the diatomic case where a single value over the arbitrary 0.05 threshold was enough to cause a segfault.

-----

Beyond the bug fix, I also consolidated the interfaces for `detrota4/8` and have them use a common worker routine, since they perform the same algorithm just with single/double precision arrays.