### PR TITLE
Fix gfnff topology restoration

### DIFF
--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -59,7 +59,7 @@ module xtb_docking_search_nci
    implicit none
 
    private
-   public :: docking_search
+   public :: docking_search, restore_gff
 
 contains
 
@@ -544,14 +544,7 @@ contains
             !> Select which kind of optimization is done
             select type (calc)
             type is (TGFFCalculator)
-               call restart_gff(env, comb, calc)
-               !Keeping Fragments and charges
-               calc%neigh%nbond = neigh_backup%nbond
-               calc%neigh%nb = neigh_backup%nb
-               calc%topo%qfrag = topo_backup%qfrag
-               calc%topo%qa = topo_backup%qa
-               calc%topo%fraglist = topo_backup%fraglist
-               calc%topo%nfrag = topo_backup%nfrag
+               call restore_gff(env, comb, calc, topo_backup, neigh_backup)
             type is (TxTBCalculator)
                call restart_xTB(env, comb, chk, calc)
             end select
@@ -916,13 +909,7 @@ contains
 
          select type (calc)
          type is (TGFFCalculator)
-            call restart_gff(env, comb, calc)
-            calc%neigh%nbond = neigh_backup%nbond
-            calc%neigh%nb = neigh_backup%nb
-            calc%topo%qfrag = topo_backup%qfrag
-            calc%topo%qa = topo_backup%qa
-            calc%topo%fraglist = topo_backup%fraglist
-            calc%topo%nfrag = topo_backup%nfrag
+            call restore_gff(env, comb, calc, topo_backup, neigh_backup)
          type is (TxTBCalculator)
             call restart_xTB(env, comb, chk, calc)
          end select
@@ -1073,12 +1060,7 @@ contains
 
       integer :: itopo = 32
 
-      !> Read the constrain again with new xyz only if necessary
-      if (constraint_xyz) then
-         nconstr=0 !Reset number of constraints for distance, angle, and dihedral
-         call read_userdata(xcontrol, env, mol)
-         call constrain_xTB_gff(env, mol)
-      end if
+      call update_gff_constraints(env, mol)
 
       !if(auto_walls) call number_walls=0; read_userdata(xcontrol,env,mol) !everytime new wall pot
 
@@ -1108,6 +1090,64 @@ contains
            &         calc%param, calc%topo, calc%neigh, set%efield, calc%accuracy)
 
    end subroutine restart_gff
+
+   !> @brief Restore the stable GFN-FF state before optimizing a docking pose.
+   !>
+   !> GFN-FF derives its covalent topology from the input geometry.  A docking
+   !> pose can bring otherwise separate fragments close enough that rebuilding
+   !> the calculator would create spurious intermolecular bonds, angles, and
+   !> torsions.  Restore the topology and neighbor data saved while the
+   !> fragments were separated so all connectivity-dependent arrays remain
+   !> consistent.
+   !>
+   !> Mark the calculator for an update so geometry-dependent interaction lists
+   !> are refreshed by the next energy evaluation.  The external-field reference
+   !> geometry is also reset to the current pose rather than retained from the
+   !> separated backup structure.
+   subroutine restore_gff(env, mol, calc, topo, neigh)
+
+      !> Calculation environment
+      type(TEnvironment), intent(inout) :: env
+      !> Molecule containing the current docking pose
+      type(TMolecule), intent(inout) :: mol
+      !> GFN-FF calculator to restore
+      type(TGFFCalculator), intent(inout) :: calc
+      !> Topology generated with the docking fragments separated
+      type(TGFFTopology), intent(in) :: topo
+      !> Neighbor data generated with the docking fragments separated
+      type(TNeigh), intent(in) :: neigh
+
+      call update_gff_constraints(env, mol)
+
+      calc%topo = topo
+      calc%neigh = neigh
+      calc%update = .true.
+      if (allocated(calc%topo%xyze0)) calc%topo%xyze0 = mol%xyz
+
+   end subroutine restore_gff
+
+   !> @brief Rebuild coordinate-dependent GFN-FF constraints for a new geometry.
+   !>
+   !> User constraints whose values are taken from the input coordinates must be
+   !> reread whenever docking changes the molecule or pose.  Reset the global
+   !> distance, angle, and dihedral constraint count before parsing to avoid
+   !> accumulating entries from the previous geometry.  If no coordinate-based
+   !> constraints were requested, this routine is a no-op.
+   subroutine update_gff_constraints(env, mol)
+
+      !> Calculation environment
+      type(TEnvironment), intent(inout) :: env
+      !> Molecule supplying the current coordinates
+      type(TMolecule), intent(inout) :: mol
+
+      !> Read the constraints again with new xyz only if necessary
+      if (constraint_xyz) then
+         nconstr = 0 ! Reset number of constraints for distance, angle, and dihedral
+         call read_userdata(xcontrol, env, mol)
+         call constrain_xTB_gff(env, mol)
+      end if
+
+   end subroutine update_gff_constraints
 
    subroutine restart_xTB(env, mol, chk, calc, basisset)
 

--- a/src/docking/search_nci.f90
+++ b/src/docking/search_nci.f90
@@ -59,7 +59,7 @@ module xtb_docking_search_nci
    implicit none
 
    private
-   public :: docking_search, restore_gff
+   public :: docking_search
 
 contains
 
@@ -1060,7 +1060,11 @@ contains
 
       integer :: itopo = 32
 
-      call update_gff_constraints(env, mol)
+      if (constraint_xyz) then
+         nconstr = 0
+         call read_userdata(xcontrol, env, mol)
+         call constrain_xTB_gff(env, mol)
+      end if
 
       !if(auto_walls) call number_walls=0; read_userdata(xcontrol,env,mol) !everytime new wall pot
 
@@ -1091,19 +1095,10 @@ contains
 
    end subroutine restart_gff
 
-   !> @brief Restore the stable GFN-FF state before optimizing a docking pose.
+   !> Restore GFN-FF state determined from separated docking fragments
    !>
-   !> GFN-FF derives its covalent topology from the input geometry.  A docking
-   !> pose can bring otherwise separate fragments close enough that rebuilding
-   !> the calculator would create spurious intermolecular bonds, angles, and
-   !> torsions.  Restore the topology and neighbor data saved while the
-   !> fragments were separated so all connectivity-dependent arrays remain
-   !> consistent.
-   !>
-   !> Mark the calculator for an update so geometry-dependent interaction lists
-   !> are refreshed by the next energy evaluation.  The external-field reference
-   !> geometry is also reset to the current pose rather than retained from the
-   !> separated backup structure.
+   !> Reuse the saved covalent topology while refreshing data that depend on the
+   !> current pose.
    subroutine restore_gff(env, mol, calc, topo, neigh)
 
       !> Calculation environment
@@ -1117,7 +1112,11 @@ contains
       !> Neighbor data generated with the docking fragments separated
       type(TNeigh), intent(in) :: neigh
 
-      call update_gff_constraints(env, mol)
+      if (constraint_xyz) then
+         nconstr = 0
+         call read_userdata(xcontrol, env, mol)
+         call constrain_xTB_gff(env, mol)
+      end if
 
       calc%topo = topo
       calc%neigh = neigh
@@ -1125,29 +1124,6 @@ contains
       if (allocated(calc%topo%xyze0)) calc%topo%xyze0 = mol%xyz
 
    end subroutine restore_gff
-
-   !> @brief Rebuild coordinate-dependent GFN-FF constraints for a new geometry.
-   !>
-   !> User constraints whose values are taken from the input coordinates must be
-   !> reread whenever docking changes the molecule or pose.  Reset the global
-   !> distance, angle, and dihedral constraint count before parsing to avoid
-   !> accumulating entries from the previous geometry.  If no coordinate-based
-   !> constraints were requested, this routine is a no-op.
-   subroutine update_gff_constraints(env, mol)
-
-      !> Calculation environment
-      type(TEnvironment), intent(inout) :: env
-      !> Molecule supplying the current coordinates
-      type(TMolecule), intent(inout) :: mol
-
-      !> Read the constraints again with new xyz only if necessary
-      if (constraint_xyz) then
-         nconstr = 0 ! Reset number of constraints for distance, angle, and dihedral
-         call read_userdata(xcontrol, env, mol)
-         call constrain_xTB_gff(env, mol)
-      end if
-
-   end subroutine update_gff_constraints
 
    subroutine restart_xTB(env, mol, chk, calc, basisset)
 

--- a/src/gfnff/gfnff_eg.f90
+++ b/src/gfnff/gfnff_eg.f90
@@ -399,10 +399,10 @@ subroutine gfnff_eg(env,mol,pr,n,ichrg,at,xyz,sigma,g,etot,res_gff, &
    if (version == gffVersion%harmonic2020) then
       ebond=0
       !$omp parallel do default(none) reduction(+:ebond, g) &
-      !$omp shared(topo, param, xyz, at) private(i, iat, jat, rab, r2, r3, rn, dum)
-      do i=1,topo%nbond
-         iat=topo%blist(1,i)
-         jat=topo%blist(2,i)
+      !$omp shared(neigh, param, xyz, at) private(i, iat, jat, rab, r2, r3, rn, dum)
+      do i=1,neigh%nbond
+         iat=neigh%blist(1,i)
+         jat=neigh%blist(2,i)
          r3 =xyz(:,iat)-xyz(:,jat)
          rab=sqrt(sum(r3*r3))
          rn=0.7*(param%rcov(at(iat))+param%rcov(at(jat)))

--- a/test/unit/test_docking.f90
+++ b/test/unit/test_docking.f90
@@ -32,8 +32,7 @@ subroutine collect_docking(testsuite)
       new_unittest("dock_gfn2_eth_wat", test_dock_eth_wat_gfn2), &
       new_unittest("dock_gfn2_wat_wat_wall", test_dock_wat_wat_gfn2_wall), &
       new_unittest("dock_gfn2_wat_wat_attpot", test_dock_wat_wat_gfn2_attpot), &
-      new_unittest("dock_gfnff_wat_wat", test_dock_wat_wat_gfnff), &
-      new_unittest("restore_gfnff_topology", test_restore_gfnff_topology) &
+      new_unittest("dock_gfnff_wat_wat", test_dock_wat_wat_gfnff) &
       ]
 
 end subroutine collect_docking
@@ -641,89 +640,5 @@ subroutine test_dock_wat_wat_gfnff(error)
    call molB%deallocate
 
 end subroutine test_dock_wat_wat_gfnff
-
-
-subroutine test_restore_gfnff_topology(error)
-   use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
-   use xtb_mctc_accuracy, only : wp
-   use xtb_type_data, only : scc_results
-   use xtb_type_environment, only : TEnvironment, init
-   use xtb_type_molecule, only : TMolecule, init
-   use xtb_type_restart, only : TRestart
-   use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
-   use xtb_gfnff_neighbor, only : TNeigh
-   use xtb_gfnff_topology, only : TGFFTopology
-   use xtb_docking_search_nci, only : restore_gff
-
-   type(error_type), allocatable, intent(out) :: error
-
-   integer, parameter :: nat = 6
-   integer, parameter :: at(nat) = [8, 1, 1, 8, 1, 1]
-   real(wp), parameter :: water(3, 3) = reshape([&
-      &  0.00000000000000_wp, 0.00000000000000_wp, 0.74114171466667_wp, &
-      & -1.42882182100000_wp, 0.00000000000000_wp, -0.37057085733333_wp, &
-      &  1.42882182100000_wp, 0.00000000000000_wp, -0.37057085733333_wp], &
-      & shape(water))
-
-   type(TEnvironment) :: env
-   type(TMolecule) :: mol
-   type(TRestart) :: chk
-   type(TGFFCalculator) :: calc
-   type(TGFFTopology) :: topo
-   type(TNeigh) :: neigh
-   type(scc_results) :: res
-   real(wp) :: xyz(3, nat), energy, hl_gap, sigma(3, 3), gradient(3, nat)
-   logical :: exitRun
-
-   call init(env)
-
-   xyz(:, 1:3) = water
-   xyz(:, 4:6) = water
-   xyz(1, 4:6) = xyz(1, 4:6) + 20.0_wp
-   call init(mol, at, xyz)
-   call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false.)
-
-   call env%check(exitRun)
-   call check_(error, .not.exitRun)
-   if (exitRun) return
-
-   topo = calc%topo
-   neigh = calc%neigh
-   call check_(error, neigh%nbond, 4)
-
-   call mol%deallocate
-   xyz(:, 4:6) = water
-   xyz(1, 4:6) = xyz(1, 4:6) + 4.0_wp
-   call init(mol, at, xyz)
-   call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false.)
-
-   call env%check(exitRun)
-   call check_(error, .not.exitRun)
-   if (exitRun) return
-   call check_(error, calc%neigh%nbond > neigh%nbond)
-
-   call restore_gff(env, mol, calc, topo, neigh)
-
-   call check_(error, calc%neigh%nbond, neigh%nbond)
-   call check_(error, all(calc%neigh%blist == neigh%blist))
-   call check_(error, all(calc%neigh%vbond == neigh%vbond))
-   call check_(error, all(calc%neigh%bpair == neigh%bpair))
-   call check_(error, calc%topo%nangl, topo%nangl)
-   call check_(error, all(calc%topo%alist == topo%alist))
-   call check_(error, all(calc%topo%vangl == topo%vangl))
-   call check_(error, calc%topo%ntors, topo%ntors)
-   call check_(error, all(calc%topo%tlist == topo%tlist))
-   call check_(error, all(calc%topo%vtors == topo%vtors))
-   call check_(error, all(calc%topo%xyze0 == mol%xyz))
-
-   call calc%singlepoint(env, mol, chk, 0, .false., energy, gradient, sigma, &
-      & hl_gap, res)
-
-   call env%check(exitRun)
-   call check_(error, .not.exitRun)
-   call check_(error, ieee_is_finite(energy))
-   call check_(error, all(ieee_is_finite(gradient)))
-
-end subroutine test_restore_gfnff_topology
 
 end module test_docking

--- a/test/unit/test_docking.f90
+++ b/test/unit/test_docking.f90
@@ -32,7 +32,8 @@ subroutine collect_docking(testsuite)
       new_unittest("dock_gfn2_eth_wat", test_dock_eth_wat_gfn2), &
       new_unittest("dock_gfn2_wat_wat_wall", test_dock_wat_wat_gfn2_wall), &
       new_unittest("dock_gfn2_wat_wat_attpot", test_dock_wat_wat_gfn2_attpot), &
-      new_unittest("dock_gfnff_wat_wat", test_dock_wat_wat_gfnff) &
+      new_unittest("dock_gfnff_wat_wat", test_dock_wat_wat_gfnff), &
+      new_unittest("restore_gfnff_topology", test_restore_gfnff_topology) &
       ]
 
 end subroutine collect_docking
@@ -640,5 +641,89 @@ subroutine test_dock_wat_wat_gfnff(error)
    call molB%deallocate
 
 end subroutine test_dock_wat_wat_gfnff
+
+
+subroutine test_restore_gfnff_topology(error)
+   use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
+   use xtb_mctc_accuracy, only : wp
+   use xtb_type_data, only : scc_results
+   use xtb_type_environment, only : TEnvironment, init
+   use xtb_type_molecule, only : TMolecule, init
+   use xtb_type_restart, only : TRestart
+   use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
+   use xtb_gfnff_neighbor, only : TNeigh
+   use xtb_gfnff_topology, only : TGFFTopology
+   use xtb_docking_search_nci, only : restore_gff
+
+   type(error_type), allocatable, intent(out) :: error
+
+   integer, parameter :: nat = 6
+   integer, parameter :: at(nat) = [8, 1, 1, 8, 1, 1]
+   real(wp), parameter :: water(3, 3) = reshape([&
+      &  0.00000000000000_wp, 0.00000000000000_wp, 0.74114171466667_wp, &
+      & -1.42882182100000_wp, 0.00000000000000_wp, -0.37057085733333_wp, &
+      &  1.42882182100000_wp, 0.00000000000000_wp, -0.37057085733333_wp], &
+      & shape(water))
+
+   type(TEnvironment) :: env
+   type(TMolecule) :: mol
+   type(TRestart) :: chk
+   type(TGFFCalculator) :: calc
+   type(TGFFTopology) :: topo
+   type(TNeigh) :: neigh
+   type(scc_results) :: res
+   real(wp) :: xyz(3, nat), energy, hl_gap, sigma(3, 3), gradient(3, nat)
+   logical :: exitRun
+
+   call init(env)
+
+   xyz(:, 1:3) = water
+   xyz(:, 4:6) = water
+   xyz(1, 4:6) = xyz(1, 4:6) + 20.0_wp
+   call init(mol, at, xyz)
+   call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false.)
+
+   call env%check(exitRun)
+   call check_(error, .not.exitRun)
+   if (exitRun) return
+
+   topo = calc%topo
+   neigh = calc%neigh
+   call check_(error, neigh%nbond, 4)
+
+   call mol%deallocate
+   xyz(:, 4:6) = water
+   xyz(1, 4:6) = xyz(1, 4:6) + 4.0_wp
+   call init(mol, at, xyz)
+   call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false.)
+
+   call env%check(exitRun)
+   call check_(error, .not.exitRun)
+   if (exitRun) return
+   call check_(error, calc%neigh%nbond > neigh%nbond)
+
+   call restore_gff(env, mol, calc, topo, neigh)
+
+   call check_(error, calc%neigh%nbond, neigh%nbond)
+   call check_(error, all(calc%neigh%blist == neigh%blist))
+   call check_(error, all(calc%neigh%vbond == neigh%vbond))
+   call check_(error, all(calc%neigh%bpair == neigh%bpair))
+   call check_(error, calc%topo%nangl, topo%nangl)
+   call check_(error, all(calc%topo%alist == topo%alist))
+   call check_(error, all(calc%topo%vangl == topo%vangl))
+   call check_(error, calc%topo%ntors, topo%ntors)
+   call check_(error, all(calc%topo%tlist == topo%tlist))
+   call check_(error, all(calc%topo%vtors == topo%vtors))
+   call check_(error, all(calc%topo%xyze0 == mol%xyz))
+
+   call calc%singlepoint(env, mol, chk, 0, .false., energy, gradient, sigma, &
+      & hl_gap, res)
+
+   call env%check(exitRun)
+   call check_(error, .not.exitRun)
+   call check_(error, ieee_is_finite(energy))
+   call check_(error, all(ieee_is_finite(gradient)))
+
+end subroutine test_restore_gfnff_topology
 
 end module test_docking

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -30,6 +30,7 @@ subroutine collect_gfnff(testsuite)
 
    testsuite = [ &
       new_unittest("sp", test_gfnff_sp), &
+      new_unittest("harmonic", test_gfnff_harmonic), &
       new_unittest("hb", test_gfnff_hb), &
       new_unittest("gbsa", test_gfnff_gbsa), &
       new_unittest("mindless", test_gfnff_mindless_basic), &
@@ -130,6 +131,53 @@ subroutine test_gfnff_sp(error)
    call mol%deallocate
 
 end subroutine test_gfnff_sp
+
+
+subroutine test_gfnff_harmonic(error)
+   use, intrinsic :: ieee_arithmetic, only : ieee_is_finite
+   use xtb_mctc_accuracy, only : wp
+   use xtb_test_molstock, only : getMolecule
+   use xtb_type_data, only : scc_results
+   use xtb_type_environment, only : TEnvironment, init
+   use xtb_type_molecule, only : TMolecule
+   use xtb_type_restart, only : TRestart
+   use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
+   use xtb_gfnff_param, only : gffVersion
+
+   type(error_type), allocatable, intent(out) :: error
+
+   type(TEnvironment) :: env
+   type(TMolecule) :: mol
+   type(TRestart) :: chk
+   type(TGFFCalculator) :: calc
+   type(scc_results) :: res
+   real(wp) :: energy, hl_gap, sigma(3, 3), gradient(3, 3)
+   logical :: exitRun
+
+   call init(env)
+   call getMolecule(mol, "h2o")
+   call newGFFCalculator(env, mol, calc, '.param_gfnff.xtb', .false., &
+      & gffVersion%harmonic2020)
+
+   call env%check(exitRun)
+   call check_(error, .not.exitRun)
+   if (exitRun) return
+
+   call check_(error, calc%neigh%nbond, 2)
+   call check_(error, allocated(calc%neigh%blist))
+   call check_(error, .not.allocated(calc%topo%blist))
+
+   call calc%singlepoint(env, mol, chk, 0, .false., energy, gradient, sigma, &
+      & hl_gap, res)
+
+   call env%check(exitRun)
+   call check_(error, .not.exitRun)
+   call check_(error, ieee_is_finite(energy))
+   call check_(error, all(ieee_is_finite(gradient)))
+   call check_(error, energy, 0.00476278587765942_wp, thr=1.0e-12_wp)
+   call check_(error, norm2(gradient), 0.0478776130669465_wp, thr=1.0e-12_wp)
+
+end subroutine test_gfnff_harmonic
 
 subroutine test_gfnff_hb(error)
    use xtb_mctc_accuracy, only : wp

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -151,6 +151,7 @@ subroutine test_gfnff_harmonic(error)
    type(TRestart) :: chk
    type(TGFFCalculator) :: calc
    type(scc_results) :: res
+   real(wp), parameter :: thr = 1000*epsilon(1.0_wp)
    real(wp) :: energy, hl_gap, sigma(3, 3), gradient(3, 3)
    logical :: exitRun
 
@@ -163,6 +164,7 @@ subroutine test_gfnff_harmonic(error)
    call check_(error, .not.exitRun)
    if (exitRun) return
 
+   ! Harmonic GFN-FF stores its bond list in the neighbor data.
    call check_(error, calc%neigh%nbond, 2)
    call check_(error, allocated(calc%neigh%blist))
    call check_(error, .not.allocated(calc%topo%blist))
@@ -174,8 +176,8 @@ subroutine test_gfnff_harmonic(error)
    call check_(error, .not.exitRun)
    call check_(error, ieee_is_finite(energy))
    call check_(error, all(ieee_is_finite(gradient)))
-   call check_(error, energy, 0.00476278587765942_wp, thr=1.0e-12_wp)
-   call check_(error, norm2(gradient), 0.0478776130669465_wp, thr=1.0e-12_wp)
+   call check_(error, energy, 0.00476278587765942_wp, thr=thr)
+   call check_(error, norm2(gradient), 0.0478776130669465_wp, thr=thr)
 
 end subroutine test_gfnff_harmonic
 


### PR DESCRIPTION
Fixes #987, Fixes #1132 

#987 was introduced by https://github.com/grimme-lab/xtb/pull/929, where (among other changes) `TGFFTopology` `blist` and `nbond` attributes were no longer set, with most usages replaced by the corresponding attributes of `TNeigh`. The 2D->3D conversion code missed this remapping, so the harmonic restraints were using faulty `topo%nbond` and `topo%blist` rather than the up to date `neigh%nbond` and `neigh%blist` as intended. Updating those resolves the issue.

#1132 stems from artificial bonds between the ligand and receptor being formed during close contacts. Some of these "bonds" would be nonsensical like an H-H bond. The proposed fix is to restore the separated bonding for ligand and receptor, just allowing them to interact non-covalently.