### PR TITLE
Thermo submodule: make mass weighting a seperate keyword

### DIFF
--- a/src/prog/thermo.f90
+++ b/src/prog/thermo.f90
@@ -270,6 +270,8 @@ contains
 
          case ('--turbomole')
             htype = hessType%tmol
+
+         case ('--mass-weighted', '--massweighted')
             massWeighted = .true.
 
          case ('--orca')
@@ -354,7 +356,7 @@ contains
          "", &
          "<geometry> may be provided as any valid input to xtb", &
          "the [hessian] file is read and processed depending on the selected options,", &
-         "the default format is a non-massweighted Turbomole hessian file", &
+         "the default format is a Cartesian, non-mass-weighted Turbomole Hessian file", &
          "", &
          "Options", &
          "", &
@@ -373,7 +375,8 @@ contains
          "   --dftbplus             Read a DFTB+ hessian.out file, implies projection", &
          "", &
          "   --turbomole         Read a Turbomole Hessian file", &
-         "                       use this only when $nomw is not present in control", &
+         "", &
+         "   --mass-weighted     Input Hessian is already mass weighted", &
          "", &
          "   --orca         Read an Orca Hessian file", &
          "", &

--- a/src/prog/thermo.f90
+++ b/src/prog/thermo.f90
@@ -374,9 +374,9 @@ contains
          "", &
          "   --dftbplus             Read a DFTB+ hessian.out file, implies projection", &
          "", &
-         "   --turbomole         Read a Turbomole Hessian file", &
+         "   --turbomole         Read a non-mass-weighted Turbomole Hessian file", &
          "", &
-         "   --mass-weighted     Input Hessian is already mass weighted", &
+         "   --mass-weighted     Assume mass-weighted input Hessian", &
          "", &
          "   --orca         Read an Orca Hessian file", &
          "", &


### PR DESCRIPTION
This change separates now the input hessian format from the mass-weighting boolean in the thermo submodule. This lead in the past to confusion with issue #1333 which should be closed by this PR