### PR TITLE
Fix L-ANC with fragmented Hessians and fixed atoms

### DIFF
--- a/src/gfnff/frag_hess.f90
+++ b/src/gfnff/frag_hess.f90
@@ -298,7 +298,7 @@ module xtb_gfnff_fraghess
 
      end subroutine fragmentize
 
-     subroutine frag_hess_diag( nat,hess,eig_calc,ispinsyst,nspinsyst,nsystem )
+     subroutine frag_hess_diag( nat,hess,eig_calc,ispinsyst,nspinsyst,nsystem,subtract_mean )
      !---------------------------------------------------------------------------------------------
      ! Purpose:
      ! Subroutine performs diagonalization of fragmented hessian.
@@ -315,6 +315,7 @@ module xtb_gfnff_fraghess
      ! Input:
      ! nat      - Number of atoms of the entire system
      ! hess     - (Lindh) Hessian of the entire system
+     ! subtract_mean - Remove the uniform component from each fragmented eigenvector
      !
      ! Output:
      ! hess     - diagonalized hessian (eigenvectors), overwritten
@@ -329,6 +330,7 @@ module xtb_gfnff_fraghess
         integer,  intent(in) :: ispinsyst(:,:)         ! array with list of atoms of each fragment
         integer,  intent(in) :: nspinsyst(:)           ! array with # of atoms for each fragment
         integer,  intent(in) :: nsystem                            ! # of fragments
+        logical,  intent(in) :: subtract_mean
         !Stack
         integer                  :: isystem
         integer                  :: i,j,ii,jj,k
@@ -400,9 +402,13 @@ module xtb_gfnff_fraghess
 !$omp end do
 !$omp end parallel
 
-        do i = 1,nat3
-           ev_calc(:,i) = ev_calc(:,i) - ( sum( ev_calc(:,i) ) / nat3 )
-        end do
+        ! Exact fixing already anchors the system. Applying this adjustment in
+        ! that case would reintroduce components in the fixed-coordinate rows.
+        if (subtract_mean) then
+           do i = 1,nat3
+              ev_calc(:,i) = ev_calc(:,i) - ( sum( ev_calc(:,i) ) / nat3 )
+           end do
+        end if
 
         hess = ev_calc
 

--- a/src/relaxation_engine.f90
+++ b/src/relaxation_engine.f90
@@ -572,18 +572,16 @@ subroutine l_ancopt &
          & gnorm=norm2(gradient), number=iter)
    endif
 
-   ! different DOF in case of frag hess
+   ! determine degrees of freedom
    nat3 = 3 * mol%n
-   if (fragmented_hessian) then
+   if (fixset%n > 0) then ! exact fixing
+      nvar = nat3 - 3*fixset%n - 3
+      if (nvar <= 0) nvar = 1
+   else if (fragmented_hessian) then
       nvar = nat3
    else
       nvar = nat3 - 6
-      if(linear) nvar = nat3 - 5
-
-      if(fixset%n.gt.0) then ! exact fixing
-         nvar=nat3-3*fixset%n-3
-         if(nvar.le.0) nvar=1
-      endif
+      if (linear) nvar = nat3 - 5
    end if
 
    allocate( hdiag(nvar), source = 0.0_wp )
@@ -650,7 +648,7 @@ subroutine l_ancopt &
       if (calc%topo%nsystem.gt.1) then
          write(env%unit,'(" * fragmented diagonalization...",1x,i0,1x,"fragments")') calc%topo%nsystem
          call frag_hess_diag(mol%n,hess,eig,calc%topo%ispinsyst, &
-            & calc%topo%nspinsyst,calc%topo%nsystem)
+            & calc%topo%nspinsyst,calc%topo%nsystem,fixset%n == 0)
        else if (calc%topo%nsystem.eq.1) then
           lwork  = 1 + 6*nat3 + 2*nat3**2
           allocate(aux(lwork))


### PR DESCRIPTION
Exact atom fixing determines the reduced optimizer dimension independently of fragmented Hessian selection. Give it precedence so large GFN-FF optimizations request the number of modes left by the fixed-coordinate projection.

Since we have the exact fixing take precedence, we also skip the fragmented eigenvector mean adjustment when exact fixing is active, since it causes nominally fixed atoms to drift.

Fixes #800