### PR TITLE
Stabilize periodic GFN-FF optimization

### DIFF
--- a/src/geoopt_driver.f90
+++ b/src/geoopt_driver.f90
@@ -162,10 +162,12 @@ subroutine geometry_optimization &
      ! create new anc filter
      optcell = mol%npbc > 0 .and. set%optcell
      call new_cartesian_filter(filter, mol, optcell)
+     opt_input%max_displacement = set%optset%maxdispl_opt
      ! create new Limited-memory BFGS optimizer 
      call new_lbfgs_optimizer(lbfgs_opt, env, opt_input, filter)
      ! run optimization
-     call relax_pbc(lbfgs_opt, env, mol, wfn, calc, filter, printlevel, fail, iter_needed)
+     call relax_pbc(lbfgs_opt, env, mol, wfn, calc, filter, tight, &
+        & maxcycle_in, printlevel, fail, iter_needed)
    case(p_engine_inertial)
       call fire & ! FIRE !
          &(env,ilog,mol,wfn,calc, &

--- a/src/lbfgs_anc/driver.f90
+++ b/src/lbfgs_anc/driver.f90
@@ -36,8 +36,10 @@ module xtb_pbc_optimizer_driver
 
 !> Driver for performing geometry optimization
 !subroutine    relax(self, ctx, mol, calc, filter, accuracy, verbosity)
-subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, iter_needed)
+subroutine relax_pbc(self, env, mol, chk, calc, filter, optlevel, maxcycle_in, &
+      & printlevel, optfail, iter_needed)
   use xtb_pbc, only: cross_product
+  use xtb_optimizer, only : get_optthr
   use xtb_gfnff_calculator, only : TGFFCalculator, newGFFCalculator
   !> Instance of the optimization driver
   class(optimizer_type), intent(inout) :: self
@@ -53,6 +55,10 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
   class(TCalculator), intent(inout) :: calc
   !> Transformation filter for coordinates
   class(cartesian_filter), intent(in) :: filter
+  !> Optimization level controlling convergence thresholds
+  integer, intent(in) :: optlevel
+  !> User-provided maximum number of optimization cycles
+  integer, intent(in) :: maxcycle_in
   !> Output verbosity
   integer, intent(in) :: printlevel
   ! Variables for/from singlepoint 
@@ -76,7 +82,7 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
 
   !> Convergence accuracy
   real(wp) :: accuracy
-  integer :: nvar, step, this_step, i, stat
+  integer :: nvar, step, this_step, steps_taken, i, stat
   real(wp) :: elast, ediff, gnorm, dnorm, ethr, gthr, dthr, gamax, damax, cvol
   real(wp), allocatable :: val, gcurr(:), glast(:), displ(:)
   logical :: econv, gconv, dconv, converged, f_exists
@@ -100,9 +106,9 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
   glast(:) = 0.0_wp
   displ(:) = 0.0_wp
 
-  accuracy = 1.0_wp
-  call get_thr(accuracy, ethr, gthr, dthr)
-  this_step = 20*nvar
+  call get_optthr(mol%n, optlevel, ethr, gthr, this_step, accuracy)
+  if (maxcycle_in > 0) this_step = maxcycle_in
+  dthr = 1.0e-3_wp
 
   inquire( file="xtboptlog.cif", exist=f_exists )
   if(f_exists)then
@@ -122,8 +128,8 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
     call filter%transform_structure(mol, displ) ! original
 
     dnorm = norm2(displ)
-    damax = maxval(abs(gcurr))
-    dconv = dnorm/nvar < dthr
+    damax = maxval(abs(displ))
+    dconv = dnorm < dthr
 
     glast(:) = gcurr
     elast = val
@@ -155,7 +161,7 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
     econv = ediff <= epsilon(0.0_wp) .and. abs(ediff) < ethr
     gnorm = norm2(gcurr)
     gamax = maxval(abs(gcurr))
-    gconv = gnorm/nvar < gthr
+    gconv = gnorm < gthr
     converged = econv .and. gconv .and. dconv
     cvol=dot_product(mol%lattice(:,1), cross_product( &
                    & mol%lattice(:,2), mol%lattice(:,3)))/6.748334606_wp !in a0 now
@@ -181,6 +187,8 @@ subroutine relax_pbc(self, env, mol, chk, calc, filter, printlevel, optfail, ite
 
   end do optLoop
   ! end of optimization loop
+
+  steps_taken = min(step, this_step)
 
 close(133) ! close xtboptlog.cif unit
 
@@ -211,7 +219,7 @@ endif
   if (.not.converged) then
     optfail = .true.
     write(*,*) ''
-    write(*,*) 'Could not converge in',step,' steps.'
+    write(*,*) 'Could not converge in',steps_taken,' steps.'
     call env%error("Could not converge geometry.",source)
   end if
   ! Output message if converged in time
@@ -222,7 +230,7 @@ endif
   end if
 
   if (present(iter_needed)) then
-    iter_needed = step
+    iter_needed = steps_taken
   end if
 
 end subroutine relax_pbc
@@ -258,17 +266,6 @@ subroutine step_summary(env, energy, ediff, gnorm, gamax, dnorm, damax, cvol, &
    end if
 end subroutine step_summary
 
-
-subroutine get_thr(accuracy, ethr, gthr, dthr)
-   real(wp), intent(in) :: accuracy
-   real(wp), intent(out) :: ethr
-   real(wp), intent(out) :: gthr
-   real(wp), intent(out) :: dthr
-
-   ethr = accuracy * 5.0e-7_wp
-   gthr = accuracy * 1.0e-3_wp
-   dthr = 5.0e-2_wp
-end subroutine get_thr
 
 !>
 subroutine write_optlog(step, n, xyz, lattice, symbol, energy)

--- a/src/lbfgs_anc/lbfgs.f90
+++ b/src/lbfgs_anc/lbfgs.f90
@@ -28,6 +28,7 @@ module xtb_pbc_optimizer_lbfgs
 
    type :: lbfgs_input
       integer :: memory = 20
+      real(wp) :: max_displacement = 1.0_wp
    end type lbfgs_input
                                                    
   type, abstract :: optimizer_type                  
@@ -43,7 +44,7 @@ module xtb_pbc_optimizer_lbfgs
         real(wp), intent(in) :: gcurr(:)            
         real(wp), intent(in) :: glast(:)            
         integer, intent(in) :: tot_step
-        real(wp), intent(out) :: displ(:)     
+        real(wp), intent(inout) :: displ(:)
      end subroutine step_i                           
   end interface                                     
 
@@ -52,10 +53,12 @@ module xtb_pbc_optimizer_lbfgs
       integer :: iter
       integer :: nvar
       integer :: memory
+      real(wp) :: max_displacement
       real(wp), allocatable :: hdiag(:)
       real(wp), allocatable :: s(:, :)
       real(wp), allocatable :: y(:, :)
       real(wp), allocatable :: rho(:)
+      logical, allocatable :: valid(:)
    contains
       procedure :: step
    end type lbfgs_optimizer
@@ -77,9 +80,11 @@ subroutine new_lbfgs_optimizer(self, env, input, filter)
    self%iter = 0
    self%nvar = filter%get_dimension()
    self%memory = input%memory
+   self%max_displacement = input%max_displacement
    allocate(self%s(self%nvar, input%memory), source=0.0_wp)
    allocate(self%y(self%nvar, input%memory), source=0.0_wp)
    allocate(self%rho(input%memory), source=0.0_wp)
+   allocate(self%valid(input%memory), source=.false.)
    allocate(self%hdiag(self%nvar), source=1.0_wp)
 
 end subroutine new_lbfgs_optimizer
@@ -87,7 +92,8 @@ end subroutine new_lbfgs_optimizer
 
 !> updates displacement using the formula given by Nocedal, generally known
 !> as limited memory BFGS algorithm
-subroutine lbfgs_step(iter, memory, nvar, gradient, glast, displacement, hdiag, s, y, rho, tot_step)
+subroutine lbfgs_step(iter, memory, nvar, gradient, glast, displacement, &
+      & hdiag, s, y, rho, valid, max_displacement, tot_step)
    !> Current iteration step
    integer, intent(in) :: iter
    !> Memory limit for the LBFGS update
@@ -110,11 +116,15 @@ subroutine lbfgs_step(iter, memory, nvar, gradient, glast, displacement, hdiag, 
    real(wp), intent(inout) :: y(:, :)
    !> LBFGS scratch array of dot products between s and y
    real(wp), intent(inout) :: rho(:)
+   !> Whether a history slot contains a positive-curvature update
+   logical, intent(inout) :: valid(:)
+   !> Maximum norm of the proposed displacement
+   real(wp), intent(in) :: max_displacement
 
    real(wp), allocatable :: d(:), q(:), a(:)
-   real(wp) :: b
+   real(wp) :: b, curvature_tol, displacement_norm
 
-   integer :: thisiter, lastiter, mem
+   integer :: thisiter, mem
    integer :: i
    real(wp) :: f_damp
 
@@ -125,36 +135,39 @@ subroutine lbfgs_step(iter, memory, nvar, gradient, glast, displacement, hdiag, 
    y(:, thisiter) = gradient - glast
 
    b = mctc_dot(s(:, thisiter), y(:, thisiter))
-
-   rho(thisiter) = 1.0_wp / max(abs(b), epsilon(1.0_wp))
+   curvature_tol = sqrt(epsilon(1.0_wp)) * norm2(s(:, thisiter)) * &
+      & norm2(y(:, thisiter))
+   valid(thisiter) = b > curvature_tol
+   if (valid(thisiter)) then
+      rho(thisiter) = 1.0_wp / b
+   else
+      rho(thisiter) = 0.0_wp
+   end if
 
    q = gradient
    do mem = iter, max(1, iter-memory+1), -1
       i = mod(mem-1, memory)+1
+      if (.not.valid(i)) cycle
       a(i) = rho(i) * mctc_dot(s(:, i), q)
       q = q - a(i) * y(:, i)
    enddo
 
    d = hdiag * q
-if(iter.le.memory) then
-   do mem = max(1, iter-memory), iter
+   do mem = max(1, iter-memory+1), iter
       i = mod(mem-1, memory)+1
+      if (.not.valid(i)) cycle
       b = rho(i) * mctc_dot(y(:, i), d)
       d = d + s(:, i) * (a(i) - b)
    enddo
-else
-   do mem = max(1, iter-memory), iter-1
-      i = mod(mem-1, memory)+1
-      b = rho(i) * mctc_dot(y(:, i), d)
-      d = d + s(:, i) * (a(i) - b)
-   enddo
-endif
+
    f_damp = 1.0_wp/(1.0_wp + 3000.0_wp*real(tot_step)**(-3))
-   if (maxval(abs(d)).lt.0.1_wp.or.tot_step.gt.50) then
-     displacement = -d
-   else
-     displacement = -d*f_damp
-   endif
+   if (maxval(abs(d)) >= 0.1_wp) d = d*f_damp
+
+   displacement_norm = norm2(d)
+   if (max_displacement > 0.0_wp .and. displacement_norm > max_displacement) then
+      d = d * max_displacement/displacement_norm
+   end if
+   displacement = -d
 end subroutine lbfgs_step
 
 
@@ -164,12 +177,13 @@ subroutine step(self, val, gcurr, glast, displ, tot_step)
    real(wp), intent(in) :: gcurr(:)
    real(wp), intent(in) :: glast(:)
    integer, intent(in) :: tot_step
-   real(wp), intent(out) :: displ(:)
+   real(wp), intent(inout) :: displ(:)
 
    self%iter = self%iter + 1
 
-   call lbfgs_step(self%iter, self%memory, self%nvar, gcurr, glast, displ, self%hdiag, &
-      & self%s, self%y, self%rho, tot_step)
+   call lbfgs_step(self%iter, self%memory, self%nvar, gcurr, glast, displ, &
+      & self%hdiag, self%s, self%y, self%rho, self%valid, &
+      & self%max_displacement, tot_step)
 end subroutine step
 
 end module xtb_pbc_optimizer_lbfgs

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -38,10 +38,86 @@ subroutine collect_gfnff(testsuite)
       new_unittest("pdb", test_gfnff_pdb), &
       new_unittest("sdf", test_gfnff_sdf), &
       new_unittest("pbc", test_gfnff_pbc), &
+      new_unittest("lbfgs-history", test_lbfgs_history), &
+      new_unittest("lbfgs-curvature", test_lbfgs_curvature), &
       new_unittest("Ln_An", test_gfnff_LnAn_H) &
       ]
 
 end subroutine collect_gfnff
+
+
+subroutine test_lbfgs_history(error)
+   use xtb_mctc_accuracy, only : wp
+   use xtb_pbc_optimizer_lbfgs, only : lbfgs_optimizer
+   type(error_type), allocatable, intent(out) :: error
+   type(lbfgs_optimizer) :: opt
+   real(wp), parameter :: thr = 1.0e-12_wp
+   real(wp) :: energy
+   real(wp) :: gradient(2), previous_gradient(2), displacement(2)
+   real(wp) :: reference(2)
+
+   opt%iter = 3
+   opt%nvar = 2
+   opt%memory = 2
+   opt%max_displacement = 1.0_wp
+   allocate(opt%s(2, 2), source=0.0_wp)
+   allocate(opt%y(2, 2), source=0.0_wp)
+   allocate(opt%rho(2), source=0.0_wp)
+   allocate(opt%valid(2), source=.false.)
+   allocate(opt%hdiag(2), source=1.0_wp)
+
+   ! The first slot holds iteration 3; iteration 4 wraps into the second slot.
+   opt%s(:, 1) = [0.03_wp, 0.00_wp]
+   opt%y(:, 1) = [0.03_wp, 0.01_wp]
+   opt%rho(1) = 1.0_wp/dot_product(opt%s(:, 1), opt%y(:, 1))
+   opt%valid(1) = .true.
+   displacement = [0.01_wp, 0.02_wp]
+   gradient = [0.05_wp, 0.04_wp]
+   previous_gradient = [0.03_wp, 0.03_wp]
+   energy = 0.0_wp
+
+   call opt%step(energy, gradient, previous_gradient, displacement, 4)
+
+   reference = [-0.0197916666666667_wp, -0.0904166666666667_wp]
+   call check_(error, displacement(1), reference(1), thr=thr)
+   if (allocated(error)) return
+   call check_(error, displacement(2), reference(2), thr=thr)
+end subroutine test_lbfgs_history
+
+
+subroutine test_lbfgs_curvature(error)
+   use xtb_mctc_accuracy, only : wp
+   use xtb_pbc_optimizer_lbfgs, only : lbfgs_optimizer
+   type(error_type), allocatable, intent(out) :: error
+   type(lbfgs_optimizer) :: opt
+   real(wp), parameter :: max_displacement = 0.25_wp
+   real(wp) :: energy
+   real(wp) :: gradient(2), previous_gradient(2), displacement(2)
+
+   opt%iter = 1
+   opt%nvar = 2
+   opt%memory = 2
+   opt%max_displacement = max_displacement
+   allocate(opt%s(2, 2), source=0.0_wp)
+   allocate(opt%y(2, 2), source=0.0_wp)
+   allocate(opt%rho(2), source=0.0_wp)
+   allocate(opt%valid(2), source=.false.)
+   allocate(opt%hdiag(2), source=1.0_wp)
+
+   ! This update has s.y < 0 and must not enter the L-BFGS history.
+   displacement = [-0.25_wp, 0.00_wp]
+   previous_gradient = [1.00_wp, 0.00_wp]
+   gradient = [1.50_wp, 0.00_wp]
+   energy = 0.0_wp
+
+   call opt%step(energy, gradient, previous_gradient, displacement, 100)
+
+   call check_(error, opt%valid(2), .false.)
+   if (allocated(error)) return
+   call check_(error, norm2(displacement), max_displacement, thr=epsilon(1.0_wp))
+   if (allocated(error)) return
+   call check_(error, dot_product(displacement, gradient) < 0.0_wp)
+end subroutine test_lbfgs_curvature
 
 
 subroutine test_gfnff_sp(error)


### PR DESCRIPTION
Potential fix for #1382. LLM generated and haven't gotten a chance to carefully look over it, but figured it might at least serve as the base for fixing this issue.

LLM short summary:
> The periodic L-BFGS implementation is also corrected to apply wrapped
> history in the required order, reject nonpositive-curvature updates, retain
> the previous displacement correctly, enforce the configured maximum step,
> and honor optimization level, maximum-cycle, and maximum-displacement input.
> Focused regression tests cover history wrapping and curvature rejection.
