### PR TITLE
Preserve atoms in fragmented GFN-FF Hessians

### DIFF
--- a/src/gfnff/frag_hess.f90
+++ b/src/gfnff/frag_hess.f90
@@ -210,6 +210,8 @@ module xtb_gfnff_fraghess
         nspinsyst(nsystem+1:maxsystem) = 0
         ispinsyst(:,nsystem+1:maxsystem) = 0
 
+        ! Atom pairs in different Hessian fragments are disconnected.
+        rmaxab = huge(1.0_sp)
         do i = 1, nsystem !loop über separierte systeme
            do j = 1, nspinsyst(i) !loop über atom1 im system
               do k = j, nspinsyst(i)

--- a/src/gfnff/frag_hess.f90
+++ b/src/gfnff/frag_hess.f90
@@ -89,11 +89,12 @@ module xtb_gfnff_fraghess
         real(wp) :: maxdist
         real(wp) :: cur_dist
         real(wp) :: max_link
-        real(wp) :: box_xyz(3), vec(3)
+        real(wp) :: box_min(3), box_xyz(3), vec(3)
         real(wp) :: frag_cma(3,maxsystem)
         logical  :: equal(maxsystem)
         logical  :: visited(nspin)
         logical, allocatable :: assigned(:, :)
+        logical  :: valid_partition
 
         integer, allocatable  :: ifrag_ini(:)
 
@@ -117,6 +118,8 @@ module xtb_gfnff_fraghess
         eq_frag = 0
         frag_cma = 0
         grid = 0
+        box_min = 0
+        box_xyz = 0
         equal = .false.
 
         call mrecgffPBC(nspin,numctr, numnb, neigh, fragcount, fragvec)
@@ -140,10 +143,17 @@ module xtb_gfnff_fraghess
            end if
         end do
 
-        !Determine box size
-        do i = 1, 3
-           box_xyz(i) = maxval(frag_cma(i,:)) - minval(frag_cma(i,:))
-        end do
+        nci_ini = nsystem
+
+        ! Determine the bounds from the small fragments placed on the grid.
+        if (any(nspinsyst(1:nci_ini) < nci_frag_size)) then
+           do i = 1, 3
+              box_min(i) = minval(frag_cma(i,1:nci_ini), &
+                 & mask=nspinsyst(1:nci_ini) < nci_frag_size)
+              box_xyz(i) = maxval(frag_cma(i,1:nci_ini), &
+                 & mask=nspinsyst(1:nci_ini) < nci_frag_size) - box_min(i)
+           end do
+        end if
 
         !Determine number of sub boxes
         nbox =  ceiling((real(nspin)/real(maxmagnat))**(1.0d0/3.0d0))
@@ -153,22 +163,27 @@ module xtb_gfnff_fraghess
            nfrag_ini = nspinsyst(i)
            if (nfrag_ini.lt.nci_frag_size) then
              do j = 1, 3
-                grid(j,i) =   nbox * ( frag_cma(j,i) - minval(frag_cma(j,:)) ) / box_xyz(j)
-                if (grid(j,i).eq.0) grid(j,i) = grid(j,i) + 1.0d0
-                grid(j,i) = ceiling( grid(j,i) )
+                if (box_xyz(j).gt.epsilon(1.0_wp)) then
+                   grid(j,i) = nbox * (frag_cma(j,i) - box_min(j)) / box_xyz(j)
+                   if (grid(j,i).eq.0) grid(j,i) = grid(j,i) + 1.0_wp
+                   grid(j,i) = ceiling(grid(j,i))
+                else
+                   grid(j,i) = 1.0_wp
+                end if
              end do
            end if
         end do
 
         !Sum over all nci fragments on same grid position
-        nci_ini=nsystem
         do i = 1, nci_ini !nsystem
+           if (equal(i)) cycle
            eq_frag=0
            !nfrag_ini=nspinsyst(i)
            do j = i+1, nci_ini
               nfrag_ini=nspinsyst(j)
               vec(:) = grid(:,i)-grid(:,j)
-              if (norm2(grid(:,i)).ne.0.and.norm2(vec).eq.0.and..not.equal(j)) then
+              if (norm2(grid(:,i)) /= 0 .and. norm2(vec) == 0 .and. &
+                 & .not. equal(j) .and. nspinsyst(i) + nfrag_ini <= maxmagnat) then
                 eq_frag = eq_frag + 1
                 do k = 1, nfrag_ini
                    ispinsyst(nspinsyst(i)+k,i) = ispinsyst(k,j)
@@ -298,6 +313,25 @@ module xtb_gfnff_fraghess
                return
             end if
         end do ! End loop: while nspinsyst(ass) > maxmagnat
+
+        ! Every atom must occur in exactly one Hessian fragment. Fall back to
+        ! full diagonalization rather than using an incomplete partition.
+        assigned_to_frag = 0
+        valid_partition = .true.
+        do i = 1, nsystem
+           do j = 1, nspinsyst(i)
+              ati = ispinsyst(j,i)
+              if (ati < 1 .or. ati > nspin) then
+                 valid_partition = .false.
+              else
+                 assigned_to_frag(ati) = assigned_to_frag(ati) + 1
+              end if
+           end do
+        end do
+        if (.not. valid_partition .or. any(assigned_to_frag /= 1)) then
+           call env%warning("Invalid Hessian fragmentation. Turning off fragmentation.")
+           nsystem = 1
+        end if
 
 
      end subroutine fragmentize

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -39,6 +39,7 @@ subroutine collect_gfnff(testsuite)
       new_unittest("pdb", test_gfnff_pdb), &
       new_unittest("sdf", test_gfnff_sdf), &
       new_unittest("pbc", test_gfnff_pbc), &
+      new_unittest("fragmentation", test_gfnff_fragmentation), &
       new_unittest("Ln_An", test_gfnff_LnAn_H) &
       ]
 
@@ -927,6 +928,74 @@ subroutine test_gfnff_pbc(error)
     call check_(error, energy2, energy, thr=thr2)
 
 end subroutine test_gfnff_pbc
+
+subroutine test_gfnff_fragmentation(error)
+   use xtb_mctc_accuracy, only : wp
+   use xtb_type_environment, only : TEnvironment, init
+   use xtb_gfnff_fraghess, only : fragmentize
+
+   type(error_type), allocatable, intent(out) :: error
+
+   integer, parameter :: nat = 501
+   integer, parameter :: maxsystem = 600
+   integer, parameter :: maxmagnat = 500
+   integer, parameter :: numnb = 2
+   integer, parameter :: numctr = 1
+
+   type(TEnvironment) :: env
+   integer :: at(nat), neigh(numnb,nat,numctr), counts(nat)
+   integer :: i, j, nsystem, shifted_nsystem
+   integer, allocatable :: fragments(:,:), fragment_sizes(:)
+   integer, allocatable :: shifted_fragments(:,:), shifted_sizes(:)
+   real(wp) :: xyz(3,nat), shifted_xyz(3,nat)
+   real(wp), allocatable :: jab(:)
+
+   call init(env)
+   at = 1
+   neigh = 0
+   allocate(jab(nat*(nat+1)/2), source=1.0_wp)
+   do i = 1, nat
+      jab(i*(i+1)/2) = 0.0_wp
+      j = i - 1
+      xyz(:,i) = [real(mod(j,11),wp), real(mod(j/11,11),wp), &
+         & real(j/121,wp)]
+   end do
+
+   call fragmentize(nat, at, xyz, maxsystem, maxmagnat, jab, numnb, numctr, neigh, &
+      & fragments, fragment_sizes, nsystem, env)
+   shifted_xyz = xyz + 300.0_wp
+   call fragmentize(nat, at, shifted_xyz, maxsystem, maxmagnat, jab, numnb, numctr, neigh, &
+      & shifted_fragments, shifted_sizes, shifted_nsystem, env)
+
+   call check_(error, shifted_nsystem, nsystem)
+   if (allocated(error)) return
+   call check_(error, all(shifted_sizes(1:nsystem) == fragment_sizes(1:nsystem)))
+   if (allocated(error)) return
+   call check_(error, all(shifted_fragments(:,1:nsystem) == fragments(:,1:nsystem)))
+   if (allocated(error)) return
+
+   counts = 0
+   do i = 1, nsystem
+      do j = 1, fragment_sizes(i)
+         counts(fragments(j,i)) = counts(fragments(j,i)) + 1
+      end do
+   end do
+   call check_(error, all(counts == 1))
+   if (allocated(error)) return
+   call check_(error, maxval(fragment_sizes(1:nsystem)) <= maxmagnat)
+   if (allocated(error)) return
+
+   ! A crowded grid cell must be divided without losing disconnected atoms.
+   xyz = 300.0_wp
+   call fragmentize(nat, at, xyz, maxsystem, maxmagnat, jab, numnb, numctr, neigh, &
+      & fragments, fragment_sizes, nsystem, env)
+   call check_(error, nsystem, 2)
+   if (allocated(error)) return
+   call check_(error, sum(fragment_sizes(1:nsystem)), nat)
+   if (allocated(error)) return
+   call check_(error, maxval(fragment_sizes(1:nsystem)) <= maxmagnat)
+
+end subroutine test_gfnff_fragmentation
 
 subroutine test_gfnff_LnAn_H(error)
    use xtb_mctc_accuracy, only : wp

--- a/test/unit/test_gfnff.f90
+++ b/test/unit/test_gfnff.f90
@@ -977,6 +977,10 @@ subroutine test_gfnff_fragmentation(error)
    counts = 0
    do i = 1, nsystem
       do j = 1, fragment_sizes(i)
+         if (fragments(j,i) < 1 .or. fragments(j,i) > nat) then
+            call check_(error, .false.)
+            return
+         end if
          counts(fragments(j,i)) = counts(fragments(j,i)) + 1
       end do
    end do


### PR DESCRIPTION
Fixes #1286

Fragment grid bounds included unused zero-initialized center entries, making the partition depend on the coordinate origin. For translated clusters (like in #1286 where many of the waters were displace 300 Angstroms away from the origin) this could place many disconnected molecules in one oversized block; the splitter for overly large groups assumes they are fully connected, which leads to it only retain the two endpoint components (disconnected waters), leaving the atoms from all the other waters without Hessian modes.

This change computes bounds based on active small fragments, caps merged blocks at the fragment size limit, and ensures already group fragments are skipped.  We now check that every atom belongs to exactly one fragment and fall back to full diagonalization if that check fails.