### PR TITLE
Ensure a restart file is written after convergence failure

### DIFF
--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -1245,6 +1245,18 @@ contains
       end if
 
       ! ------------------------------------------------------------------------
+      !  to further speed up xtb calculations we dump our most important
+      !  quantities in a restart file, so we can save some precious seconds
+      select type (calc)
+      type is (TxTBCalculator)
+         if (restart) then
+            call writeRestart(env, chk%wfn, 'xtbrestart', set%gfn_method)
+         end if
+      type is (TTBLiteCalculator)
+         if (restart) call dumpRestart(env, chk, 'xtbrestart')
+      end select
+
+      ! ------------------------------------------------------------------------
       !  we may have generated some non-fatal errors, which have been saved,
       !  so we should tell the user, (s)he may want to know what went wrong
       call env%show("Runtime exception occurred")

--- a/src/prog/main.F90
+++ b/src/prog/main.F90
@@ -671,6 +671,7 @@ contains
 
       call env%checkpoint("Setup for calculation failed")
 
+      exist = .false.
       select type (calc)
       type is (TxTBCalculator)
          if (restart .and. calc%xtbData%level /= 0) then ! only in first run
@@ -723,6 +724,10 @@ contains
       select type (calc)
       type is (TGFFCalculator)
          gff_print = .false.
+      type is (TxTBCalculator)
+         if (restart) call writeRestart(env, chk%wfn, 'xtbrestart', set%gfn_method)
+      type is (TTBLiteCalculator)
+         if (restart) call dumpRestart(env, chk, 'xtbrestart')
       end select
       call env%checkpoint("Single point calculation terminated")
 
@@ -1238,18 +1243,6 @@ contains
          call mdopt(env, mol, chk, calc, egap, set%etemp, set%maxscciter, etot, g, sigma)
          call stop_timing(10)
       end if
-
-      ! ------------------------------------------------------------------------
-      !  to further speed up xtb calculations we dump our most important
-      !  quantities in a restart file, so we can save some precious seconds
-      select type (calc)
-      type is (TxTBCalculator)
-         if (restart) then
-            call writeRestart(env, chk%wfn, 'xtbrestart', set%gfn_method)
-         end if
-      type is (TTBLiteCalculator)
-         if (restart) call dumpRestart(env, chk, 'xtbrestart')
-      end select
 
       ! ------------------------------------------------------------------------
       !  we may have generated some non-fatal errors, which have been saved,

--- a/src/restart.f90
+++ b/src/restart.f90
@@ -44,7 +44,6 @@ subroutine readRestart(env,wfx,fname,n,at,gfn_method,success,verbose)
    integer(i8) :: iver8,idum8,n8,nshell8,nel8,nopen8
    integer :: ich ! file handle
    integer :: err
-   logical :: exist
 
    success = .false.
    call open_binary(ich,fname,'r')
@@ -59,21 +58,23 @@ subroutine readRestart(env,wfx,fname,n,at,gfn_method,success,verbose)
          if (nopen8.ne.int(wfx%nopen,i8).and.verbose) &
             &  call env%warning('Multiplicity missmatch in restart file.', source)
          if ((n8.eq.int(wfx%n,i8)).and.(nshell8.eq.int(wfx%nshell,i8))) then
-            success = .true.
-            read(ich) wfx%qsh
-            if (verbose) &
-            write(stdout,'("q/qsh data taken from xtbrestart")')
-            if ((gfn_method.gt.1).and.(iver8.gt.1)) then
+            read(ich,iostat=err) wfx%qsh
+            if (err.eq.0 .and. gfn_method.gt.1 .and. iver8.gt.1) then
 !              read dipole and qpole CAMM
-               read(ich) wfx%dipm
-               read(ich) wfx%qp
+               read(ich,iostat=err) wfx%dipm
+               if (err.eq.0) read(ich,iostat=err) wfx%qp
+            end if
+            if (err.eq.0) then
+               success = .true.
                if (verbose) &
+               write(stdout,'("q/qsh data taken from xtbrestart")')
+               if (gfn_method.gt.1 .and. verbose) &
                write(stdout,'("CAMM data taken from xtbrestart")')
+            else if (verbose) then
+               call env%warning('Could not read restart data.', source)
             endif
-         else
-            if (verbose) &
+         else if (verbose) then
             call env%warning('Dimension missmatch in restart file.', source)
-            success = .false.
          endif
       else
          if (verbose) &

--- a/test/unit/test_gfn1.f90
+++ b/test/unit/test_gfn1.f90
@@ -38,7 +38,8 @@ subroutine collect_gfn1(testsuite)
       new_unittest("mindless-basic", test_gfn1_mindless_basic), &
       new_unittest("mindless-solvation", test_gfn1_mindless_solvation), &
       new_unittest("ipea-indole", test_ipea_indole), &
-      new_unittest("mindless-cosmo", test_gfn1_mindless_cosmo) &
+      new_unittest("mindless-cosmo", test_gfn1_mindless_cosmo), &
+      new_unittest("restart", test_gfn1_restart) &
       ]
 
 end subroutine collect_gfn1
@@ -920,5 +921,54 @@ subroutine test_gfn1_mindless_cosmo(error)
    end do
 
 end subroutine test_gfn1_mindless_cosmo
+
+
+subroutine test_gfn1_restart(error)
+   use xtb_mctc_accuracy, only : wp
+   use xtb_type_environment, only : TEnvironment, init
+   use xtb_type_wavefunction, only : TWavefunction
+   use xtb_restart, only : readRestart, writeRestart
+
+   type(error_type), allocatable, intent(out) :: error
+   character(len=*), parameter :: fname = '.xtb_issue_1146_restart'
+
+   type(TEnvironment) :: env
+   type(TWavefunction) :: wfn, wfn_bad
+   logical :: success
+
+   call init(env)
+   call wfn%allocate(2, 2, 2)
+   wfn%nel = 2
+   wfn%nopen = 0
+   wfn%qsh = [0.1_wp, 0.2_wp]
+
+   call writeRestart(env, wfn, fname, 1)
+
+   call readRestart(env, wfn, fname, 2, [1, 1], 1, success, .false.)
+   call check_(error, success)
+
+   call readRestart(env, wfn, fname, 2, [1, 1], 2, success, .false.)
+   call check_(error, success)
+
+   wfn%nel = 3
+   call readRestart(env, wfn, fname, 2, [1, 1], 1, success, .false.)
+   call check_(error, success)
+
+   wfn%nel = 2
+   wfn%nopen = 1
+   call readRestart(env, wfn, fname, 2, [1, 1], 1, success, .false.)
+   call check_(error, success)
+
+   call wfn_bad%allocate(3, 3, 3)
+   wfn_bad%nel = 2
+   wfn_bad%nopen = 0
+   call readRestart(env, wfn_bad, fname, 3, [1, 1, 1], 1, success, .false.)
+   call check_(error, .not.success)
+
+   call delete_file(fname)
+   call wfn_bad%deallocate
+   call wfn%deallocate
+
+end subroutine test_gfn1_restart
 
 end module test_gfn1


### PR DESCRIPTION
Fixes #1146 

Just adds writing/dumping of restart files to before the calculation termination that would occur if the initial SCC failed to converged.