### PR TITLE
Allow GFN-FF selection from xcontrol

### DIFF
--- a/man/xcontrol.7.adoc
+++ b/man/xcontrol.7.adoc
@@ -237,8 +237,8 @@ $gbsa
 
 $gfn
 ~~~~
-*method*='int'::
-    version of the GFN Hamiltonian
+*method*='int'|'ff'::
+    version of the GFN Hamiltonian; use 'ff' for GFN-FF
 
 *dispscale*='real'::
     Scale dispersion energy of GFN-FF

--- a/src/set_module.f90
+++ b/src/set_module.f90
@@ -1527,7 +1527,8 @@ subroutine set_gfn(env,key,val)
    case('version','method')
       if (key.eq.'version') &
          call env%warning("Don't use the 'version' key, since it is confusing",source)
-      if(val.eq.'ff') then
+      if (lowercase(trim(val)) == 'ff') then
+         if (set1) call set_exttyp('ff')
          set1=.false.
          return
       endif

--- a/test/inputs/gfnff.inp
+++ b/test/inputs/gfnff.inp
@@ -1,0 +1,3 @@
+$gfn
+   method=ff
+$end

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -123,6 +123,8 @@ add_test("xtb/GFN0-xTB" ${XTB-EXE} --coffee --gfn 0 --strict --norestart --names
 add_test("xtb/GFN1-xTB" ${XTB-EXE} --coffee --gfn 1 --strict --norestart --namespace test4)
 add_test("xtb/GFN2-xTB/GBSA" ${XTB-EXE} --coffee --gfn 2 --strict --gbsa h2o --norestart --namespace test5)
 add_test("xtb/GFN2-FF" ${XTB-EXE} --coffee --gfnff --strict --norestart --namespace test6)
+add_test("xtb/GFN2-FF/xcontrol" ${XTB-EXE} --coffee --strict --norestart --namespace test7
+  --input "${PROJECT_SOURCE_DIR}/test/inputs/gfnff.inp")
 
 set_tests_properties(
   "xtb/Singlepoint"
@@ -131,6 +133,7 @@ set_tests_properties(
   "xtb/GFN1-xTB"
   "xtb/GFN2-xTB/GBSA"
   "xtb/GFN2-FF"
+  "xtb/GFN2-FF/xcontrol"
   PROPERTIES
   ENVIRONMENT XTBPATH=${PROJECT_SOURCE_DIR}
 )

--- a/test/unit/meson.build
+++ b/test/unit/meson.build
@@ -93,6 +93,10 @@ test('Argparser print version', xtb_exe, args: '--version', env: xtbenv)
 test('Argparser print help', xtb_exe, args: '--help', env: xtbenv)
 test('Argparser print license', xtb_exe, args: '--license', env: xtbenv)
 test('Argparser no arguments', xtb_exe, should_fail: true, env: xtbenv)
+test('GFN2-FF xcontrol', xtb_exe, env: xtbenv, args: [
+  '--coffee', '--strict', '--norestart', '--namespace', 'test7',
+  '--input', files('../inputs/gfnff.inp'),
+])
 if host_machine.system() != 'windows'
   test('Info', xtb_exe, env: xtbenv, args: [
     'info',


### PR DESCRIPTION
While `$gfn method='ff'` has technically been accepted by the xcontrol parser since #188, it wouldn't actually set GFN-FF as the method to use, still requiring `--gfnff` or `--gff` to be specified on the commandline. 